### PR TITLE
Require an asterisk to close a delimited_doc_comment

### DIFF
--- a/spec/documentation-comments.md
+++ b/spec/documentation-comments.md
@@ -16,7 +16,7 @@ single_line_doc_comment
     ;
 
 delimited_doc_comment
-    : '/**' delimited_comment_section* asterisk* '/'
+    : '/**' delimited_comment_section* asterisk+ '/'
     ;
 ```
 


### PR DESCRIPTION
Prior to this change, the grammar showed that the asterisk in the '*/' pair
that closes a block comment was optional. This change updates the grammar
rule to require at least one asterisk to appear.