### PR TITLE
Remove abbreviations from the text

### DIFF
--- a/proposals/proposal-template.md
+++ b/proposals/proposal-template.md
@@ -8,7 +8,7 @@
 ## Summary
 [summary]: #summary
 
-One para explanation of the feature.
+One paragraph explanation of the feature.
 
 ## Motivation
 [motivation]: #motivation
@@ -33,7 +33,7 @@ What other designs have been considered? What is the impact of not doing this?
 ## Unresolved questions
 [unresolved]: #unresolved-questions
 
-What parts of the design are still TBD?
+What parts of the design are still to be discussed?
 
 ## Design meetings
 

--- a/proposals/proposal-template.md
+++ b/proposals/proposal-template.md
@@ -33,7 +33,7 @@ What other designs have been considered? What is the impact of not doing this?
 ## Unresolved questions
 [unresolved]: #unresolved-questions
 
-What parts of the design are still to be discussed?
+What parts of the design are still undecided?
 
 ## Design meetings
 


### PR DESCRIPTION
Some people aren't native English speakers and they might have problems understanding the text when abbreviations are used.