### PR TITLE
Fixes #160.

### DIFF
--- a/spec/expressions.md
+++ b/spec/expressions.md
@@ -3505,8 +3505,7 @@ bool? operator |(bool? x, bool? y);
 
 The following table lists the results produced by these operators for all combinations of the values `true`, `false`, and `null`.
 
-
-| `x`     | `y`     | `x & y` | `x | y` |
+| `x`     | `y`     | `x & y` | <code>x &#124; y</code> |
 |:-------:|:-------:|:-------:|:-------:|
 | `true`  | `true`  | `true`  | `true`  | 
 | `true`  | `false` | `false` | `true`  | 


### PR DESCRIPTION
The issue was the pipe character in `x | y`, which isn't allowed in a table since the table uses that character to represent column/cell breaks. To keep the code formatting, the expression needed to be written as 

```
<code>x &#124; y</code>
````