### PR TITLE
Change reachability

### DIFF
--- a/proposals/csharp-7.0/local-functions.md
+++ b/proposals/csharp-7.0/local-functions.md
@@ -67,4 +67,5 @@ using local functions with capturing.
 
 We add to the spec
 
-> The body of a statement-bodied lambda expression or local function is considered reachable.
+> The body of a local function is considered reachable if and only if it is
+> the target of an invocation or delegate conversion in a reachable expression.


### PR DESCRIPTION
I think local functions bodies should only be considered reachable if they are used by a reachable expression.