### PR TITLE
Fix invalid character in unsafe-code.md

### DIFF
--- a/spec/unsafe-code.md
+++ b/spec/unsafe-code.md
@@ -1,4 +1,4 @@
-﻿# Unsafe code
+# Unsafe code
 
 The core C# language, as defined in the preceding chapters, differs notably from C and C++ in its omission of pointers as a data type. Instead, C# provides references and the ability to create objects that are managed by a garbage collector. This design, coupled with other features, makes C# a much safer language than C or C++. In the core C# language it is simply not possible to have an uninitialized variable, a "dangling" pointer, or an expression that indexes an array beyond its bounds. Whole categories of bugs that routinely plague C and C++ programs are thus eliminated.
 


### PR DESCRIPTION
A invisible control character prevented the title from being displayed correctly.