### PR TITLE
Typo in markup

### DIFF
--- a/spec/namespaces.md
+++ b/spec/namespaces.md
@@ -465,7 +465,7 @@ namespace N2
 
 Above, within member declarations in the `N2` namespace, the static members and nested types of `N1.A` are directly available, and thus the method `N` is able to reference both the `B` and `M` members of `N1.A`.
 
-A *using_static_directive` specifically does not import extension methods directly as static methods, but makes them available for extension method invocation ([Extension method invocations](expressions.md#extension-method-invocations)). In the example
+A *using_static_directive* specifically does not import extension methods directly as static methods, but makes them available for extension method invocation ([Extension method invocations](expressions.md#extension-method-invocations)). In the example
 
 ```csharp
 namespace N1 


### PR DESCRIPTION
There was a backtick where it should have been an asterisk.