### PR TITLE
Fix typo in property_initializer syntax

### DIFF
--- a/spec/classes.md
+++ b/spec/classes.md
@@ -2579,7 +2579,7 @@ property_body
     ;
 
 property_initializer
-    : '=' variable_initializer
+    : '=' variable_initializer ';'
     ;
 ```
 


### PR DESCRIPTION
I noticed a typo in the property_initializer syntax for classes