### PR TITLE
Proposal for tuple equality/inequality comparisons

### DIFF
--- a/proposals/tuple-equality.md
+++ b/proposals/tuple-equality.md
@@ -8,7 +8,7 @@ In the nullable case, additional checks for `temp1.HasValue` and `temp2.HasValue
 
 When an element-wise comparison returns a non-bool result (for instance, when a non-bool user-defined `operator ==` or `operator !=` is used, or in a dynamic comparison), then that result will be either converted to `bool` or run through `operator true` or `operator false` to get a `bool`. The tuple comparison always ends up returning a `bool`.
 
-As of C# 7.2, such code produces an error (`error CS0019: Operator '==' cannot be applied to operands of type '(...)' and '(...)'`).
+As of C# 7.2, such code produces an error (`error CS0019: Operator '==' cannot be applied to operands of type '(...)' and '(...)'`), unless there is a user-defined `operator==`.
 
 ## Details
 
@@ -23,14 +23,29 @@ When a tuple literal is used as operand (on either side), it receives a converte
 
 For instance, in `(1L, 2, "hello") == (1, 2L, null)`, the converted type for both tuple literals is `(long, long, string)` and the second literal has no natural type.
 
-__TODO__ add more details on conversion back to `bool` when a non-bool user-defined `operator ==` or a `dynamic` operand is involed in one of the element-wise comparisons.
 
 ### Deconstruction and conversions to tuple
 In `(a, b) == x`, the fact that `x` can deconstruct into two elements does not play a role. That could conceivably be in a future proposal, although it would raise questions about `x == y` (is this a simple comparison or an element-wise comparison, and if so using what cardinality?).
 Similarly, conversions to tuple play no role.
 
+### Tuple element names
 
-## Evaluation order
+When converting a tuple literal, we warn when an explicit tuple element name was provided in the literal, but it doesn't match the target tuple element name.
+We use the same rule in tuple comparison, so that assuming `(int a, int b) t` we warn on `d` in `t == (c, d: 0)`.
+
+### Non-bool element-wise comparison results
+
+If an element-wise comparison is dynamic in a tuple equality, we use a dynamic invocation of the operator `false` and negate that to get a `bool` and continue with further element-wise comparisons. 
+
+If an element-wise comparison returns some other non-bool type in a tuple equality, there are two cases:
+- if the non-bool type converts to `bool`, we apply that conversion,
+- if there is no such conversion, but the type has an operator `false`, we'll use that and negate the result.
+
+In a tuple inequality, the same rules apply except that we'll use the operator `true` (without negation) instead of the operator `true`.
+
+Those rules are similar the rules involved for using a non-bool type in an `if` statement and some other existing contexts.
+
+## Evaluation order and special cases
 The left-hand-side value is evaluated first, then the right-hand-side value, then the element-wise comparisons from left to right (including conversions, and with early exit based on existing rules for conditional AND/OR operators).
 
 For instance, if there is a conversion from type `A` to type `B` and a method `(A, A) GetTuple()`, evaluating `(new A(1), (new B(2), new B(3))) == (new B(4), GetTuple())` means:
@@ -40,6 +55,17 @@ For instance, if there is a conversion from type `A` to type `B` and a method `(
 - `new B(4)`
 - `GetTuple()`
 - then the element-wise conversions and comparisons and conditional logic is evaluated (convert `new A(1)` to type `B`, then compare it with `new B(4)`, and so on).
+
+### Comparing `null` to `null`
+
+This is a special case from regular comparisons, that carries over to tuple comparisons. The `null == null` comparison is allowed, and the `null` literals do not get any type.
+In tuple equality, this means, `(0, null) == (0, null)` is also allowed and the `null` and tuple literals don't get a type either.
+
+### Comparing a nullable struct to `null` without `operator==`
+
+This is another special case from regular comparisons, that carries over to tuple comparisons.
+If you have a `struct S` without `operator==`, the `(S?)x == null` comparison is allowed, and it is interpreted as `((S?).x).HasValue`.
+In tuple equality, the same rule is applied, so `(0, (S?)x) == (0, null)` is allowed.
 
 ## Compatibility
 

--- a/proposals/tuple-equality.md
+++ b/proposals/tuple-equality.md
@@ -1,14 +1,16 @@
 # Support for == and != on tuple types
 
-Allow expressions `t1 == t2` where `t1` and `t2` are tuple types of same cardinality, and evaluate them as `temp1.Item1 == temp2.Item1 && temp1.Item2 == temp2.Item2` (assuming `var temp1 = t1; var temp2 = t2;`).
+Allow expressions `t1 == t2` where `t1` and `t2` are tuple or nullable tuple types of same cardinality, and evaluate them as `temp1.Item1 == temp2.Item1 && temp1.Item2 == temp2.Item2` (assuming `var temp1 = t1; var temp2 = t2;`).
 
 Conversely it would allow `t1 != t2` and evaluate it as `temp1.Item1 != temp2.Item1 || temp1.Item2 != temp2.Item2`.
+
+In the nullable case, additional checks for `temp1.HasValue` and `temp2.HasValue` are used. For instance, `nullableT1 == nullableT2` evaluates as `temp1.HasValue == temp2.HasValue ? (temp1.HasValue ? ... : true) : false`.
 
 As of C# 7.2, such code produces an error (`error CS0019: Operator '==' cannot be applied to operands of type '(...)' and '(...)'`).
 
 ## Details
 
-When binding the `==` (or `!=`) operator, if both operands of a comparison operator are tuples (have tuple types or are tuple literals) and have matching cardinality, then the comparison is performed element-wise.
+When binding the `==` (or `!=`) operator and existing binding rules failed, then if both operands of a comparison operator are tuples (have tuple types or are tuple literals) and have matching cardinality, then the comparison is performed element-wise. If either or both sides are nullable, then whether the nullables have values is checked before comparing elements.
 
 Both operands (and, in the case of tuple literals, their elements) are evaluated in order from left to right. Each pair of elements is then used as operands to bind the operator `==` (or `!=`), recursively. Any elements with compile-time type `dynamic` cause an error. The results of those element-wise comparisons are used as operands in a chain of conditional AND (or OR) operators.
 
@@ -19,15 +21,15 @@ When a tuple literal is used as operand (on either side), it receives a converte
 For instance, in `(1L, 2, "hello") == (1, 2L, null)`, the converted type for both tuple literals is `(long, long, string)` and the second literal has no natural type.
 
 ## Evaluation order
-The left-hand-side value is evaluated first (including conversions), then the right-hand-side value (also including conversions), then the element-wise comparisons from left to right (with early exit based on existing rules for conditional AND/OR operators).
+The left-hand-side value is evaluated first, then the right-hand-side value, then the element-wise comparisons from left to right (including conversions, and with early exit based on existing rules for conditional AND/OR operators).
 
 For instance, if there is a conversion from type `A` to type `B` and a method `(A, A) GetTuple()`, evaluating `(new A(1), (new B(2), new B(3))) == (new B(4), GetTuple())` means:
-- `new A(1)` and convert to `B`
+- `new A(1)`
 - `new B(2)`
 - `new B(3)`
-- `new A(1)` and convert to `B`
-- `GetTuple()` and convert to `(B, B)`
-- then the element-wise comparisons and conditional logic is evaluated
+- `new A(1)`
+- `GetTuple()`
+- then the element-wise conversions and comparisons and conditional logic is evaluated (convert `new A(1)` to type `B`, then compare it with `new B(4)`, and so on).
 
 ## Compatibility
 

--- a/proposals/tuple-equality.md
+++ b/proposals/tuple-equality.md
@@ -18,6 +18,17 @@ When a tuple literal is used as operand (on either side), it receives a converte
 
 For instance, in `(1L, 2, "hello") == (1, 2L, null)`, the converted type for both tuple literals is `(long, long, string)` and the second literal has no natural type.
 
+## Evaluation order
+The left-hand-side value is evaluated first (including conversions), then the right-hand-side value (also including conversions), then the element-wise comparisons from left to right (with early exit based on existing rules for conditional AND/OR operators).
+
+For instance, if there is a conversion from type `A` to type `B` and `(A, A) GetTuple()`, evaluating `(new A(1), (new B(2), new B(3))) == (new B(4), GetTuple())` means:
+- `new A(1)` and convert to `B`
+- `new B(2)`
+- `new B(3)`
+- `new A(1)` and convert to `B`
+- `GetTuple()` and convert to `(B, B)`
+- then the element-wise comparisons and conditional logic is evaluated
+
 ## Compatibility
 
 If someone wrote their own `ValueTuple` types, including an implementation of the comparison operator, the proposed rule would cause their operator to be ignored.

--- a/proposals/tuple-equality.md
+++ b/proposals/tuple-equality.md
@@ -1,0 +1,28 @@
+# Support for == and != on tuple types
+
+Allow expressions `t1 == t2` where `t1` and `t2` are tuple types of same cardinality, and evaluate them as `temp1.Item1 == temp2.Item1 && temp1.Item2 == temp2.Item2` (assuming `var temp1 = t1; var temp2 = t2;`).
+
+Conversely it would allow `t1 != t2` and evaluate it as `temp1.Item1 != temp2.Item1 || temp1.Item2 != temp2.Item2`.
+
+As of C# 7.2, such code produces an error (`error CS0019: Operator '==' cannot be applied to operands of type '(...)' and '(...)'`).
+
+## Details
+
+When binding the `==` (or `!=`) operator, if both operands of a comparison operator are tuples (have tuple types or are tuple literals) and have matching cardinality, then the comparison is performed element-wise.
+
+Both operands (and, in the case of tuple literals, their elements) are evaluated in order from left to right. Each pair of elements is then used as operands to bind the operator `==` (or `!=`), recursively. Any elements with compile-time type `dynamic` cause an error. The results of those element-wise comparisons are used as operands in a chain of conditional AND (or OR) operators.
+
+For instance, in the context of `(int, (int, int)) t1, t2;`, `t1 == (1, (2, 3))` would evaluate as `temp1.Item1 == temp2.Item1 && temp1.Item2.Item1 == temp2.Item2.Item1 && temp2.Item2.Item2 == temp2.Item2.Item2`.
+
+When a tuple literal is used as operand (on either side), it receives a converted tuple type formed by the element-wise conversions which are introduced when binding the operator `==` (or `!=`) element-wise. 
+
+For instance, in `(1L, 2, "hello") == (1, 2L, null)`, the converted type for both tuple literals is `(long, long, string)` and the second literal has no natural type.
+
+## Compatibility
+
+If someone wrote their own `ValueTuple` types, including an implementation of the comparison operator, the proposed rule would cause their operator to be ignored.
+
+----
+
+Relates to https://github.com/dotnet/csharplang/blob/master/spec/expressions.md#relational-and-type-testing-operators
+Relates to https://github.com/dotnet/csharplang/issues/190

--- a/proposals/tuple-equality.md
+++ b/proposals/tuple-equality.md
@@ -27,7 +27,7 @@ For instance, if there is a conversion from type `A` to type `B` and a method `(
 - `new A(1)`
 - `new B(2)`
 - `new B(3)`
-- `new A(1)`
+- `new B(4)`
 - `GetTuple()`
 - then the element-wise conversions and comparisons and conditional logic is evaluated (convert `new A(1)` to type `B`, then compare it with `new B(4)`, and so on).
 

--- a/proposals/tuple-equality.md
+++ b/proposals/tuple-equality.md
@@ -1,10 +1,12 @@
 # Support for == and != on tuple types
 
-Allow expressions `t1 == t2` where `t1` and `t2` are tuple or nullable tuple types of same cardinality, and evaluate them as `temp1.Item1 == temp2.Item1 && temp1.Item2 == temp2.Item2` (assuming `var temp1 = t1; var temp2 = t2;`).
+Allow expressions `t1 == t2` where `t1` and `t2` are tuple or nullable tuple types of same cardinality, and evaluate them roughly as `temp1.Item1 == temp2.Item1 && temp1.Item2 == temp2.Item2` (assuming `var temp1 = t1; var temp2 = t2;`).
 
 Conversely it would allow `t1 != t2` and evaluate it as `temp1.Item1 != temp2.Item1 || temp1.Item2 != temp2.Item2`.
 
 In the nullable case, additional checks for `temp1.HasValue` and `temp2.HasValue` are used. For instance, `nullableT1 == nullableT2` evaluates as `temp1.HasValue == temp2.HasValue ? (temp1.HasValue ? ... : true) : false`.
+
+When an element-wise comparison returns a non-bool result (for instance, when a non-bool user-defined `operator ==` or `operator !=` is used, or in a dynamic comparison), then that result will be either converted to `bool` or run through `operator true` or `operator false` to get a `bool`. The tuple comparison always ends up returning a `bool`.
 
 As of C# 7.2, such code produces an error (`error CS0019: Operator '==' cannot be applied to operands of type '(...)' and '(...)'`).
 
@@ -19,6 +21,8 @@ For instance, in the context of `(int, (int, int)) t1, t2;`, `t1 == (1, (2, 3))`
 When a tuple literal is used as operand (on either side), it receives a converted tuple type formed by the element-wise conversions which are introduced when binding the operator `==` (or `!=`) element-wise. 
 
 For instance, in `(1L, 2, "hello") == (1, 2L, null)`, the converted type for both tuple literals is `(long, long, string)` and the second literal has no natural type.
+
+TODO add more details on conversion back to `bool` when a non-bool user-defined `operator ==` or a `dynamic` operand is involed in one of the element-wise comparisons.
 
 ## Evaluation order
 The left-hand-side value is evaluated first, then the right-hand-side value, then the element-wise comparisons from left to right (including conversions, and with early exit based on existing rules for conditional AND/OR operators).

--- a/proposals/tuple-equality.md
+++ b/proposals/tuple-equality.md
@@ -12,7 +12,8 @@ As of C# 7.2, such code produces an error (`error CS0019: Operator '==' cannot b
 
 ## Details
 
-When binding the `==` (or `!=`) operator and existing binding rules failed, then if both operands of a comparison operator are tuples (have tuple types or are tuple literals) and have matching cardinality, then the comparison is performed element-wise. If either or both sides are nullable, then whether the nullables have values is checked before comparing elements.
+When binding the `==` (or `!=`) operator, the existing rules are: (1) dynamic case, (2) overload resolution, and (3) fail.
+This proposal adds a tuple case between (1) and (2): if both operands of a comparison operator are tuples (have tuple types or are tuple literals) and have matching cardinality, then the comparison is performed element-wise. This tuple equality is also lifted onto nullable tuples.
 
 Both operands (and, in the case of tuple literals, their elements) are evaluated in order from left to right. Each pair of elements is then used as operands to bind the operator `==` (or `!=`), recursively. Any elements with compile-time type `dynamic` cause an error. The results of those element-wise comparisons are used as operands in a chain of conditional AND (or OR) operators.
 
@@ -42,7 +43,7 @@ For instance, if there is a conversion from type `A` to type `B` and a method `(
 
 ## Compatibility
 
-Although the initial proposal had a compatiblity issue if someone wrote their own `ValueTuple` types with  an implementation of the comparison operator, the current proposal maintains the existing behavior because the new rule comes into play last.
+If someone wrote their own `ValueTuple` types with  an implementation of the comparison operator, it would have previously been picked up by overload resolution. But since the new tuple case comes before overload resolution, we would handle this case with tuple comparison instead of relying on the user-defined comparison.
 
 ----
 

--- a/proposals/tuple-equality.md
+++ b/proposals/tuple-equality.md
@@ -22,7 +22,12 @@ When a tuple literal is used as operand (on either side), it receives a converte
 
 For instance, in `(1L, 2, "hello") == (1, 2L, null)`, the converted type for both tuple literals is `(long, long, string)` and the second literal has no natural type.
 
-TODO add more details on conversion back to `bool` when a non-bool user-defined `operator ==` or a `dynamic` operand is involed in one of the element-wise comparisons.
+__TODO__ add more details on conversion back to `bool` when a non-bool user-defined `operator ==` or a `dynamic` operand is involed in one of the element-wise comparisons.
+
+### Deconstruction and conversions to tuple
+In `(a, b) == x`, the fact that `x` can deconstruct into two elements does not play a role. That could conceivably be in a future proposal, although it would raise questions about `x == y` (is this a simple comparison or an element-wise comparison, and if so using what cardinality?).
+Similarly, conversions to tuple play no role.
+
 
 ## Evaluation order
 The left-hand-side value is evaluated first, then the right-hand-side value, then the element-wise comparisons from left to right (including conversions, and with early exit based on existing rules for conditional AND/OR operators).

--- a/proposals/tuple-equality.md
+++ b/proposals/tuple-equality.md
@@ -33,7 +33,7 @@ For instance, if there is a conversion from type `A` to type `B` and a method `(
 
 ## Compatibility
 
-If someone wrote their own `ValueTuple` types, including an implementation of the comparison operator, the proposed rule would cause their operator to be ignored.
+Although the initial proposal had a compatiblity issue if someone wrote their own `ValueTuple` types with  an implementation of the comparison operator, the current proposal maintains the existing behavior because the new rule comes into play last.
 
 ----
 

--- a/proposals/tuple-equality.md
+++ b/proposals/tuple-equality.md
@@ -21,7 +21,7 @@ For instance, in `(1L, 2, "hello") == (1, 2L, null)`, the converted type for bot
 ## Evaluation order
 The left-hand-side value is evaluated first (including conversions), then the right-hand-side value (also including conversions), then the element-wise comparisons from left to right (with early exit based on existing rules for conditional AND/OR operators).
 
-For instance, if there is a conversion from type `A` to type `B` and `(A, A) GetTuple()`, evaluating `(new A(1), (new B(2), new B(3))) == (new B(4), GetTuple())` means:
+For instance, if there is a conversion from type `A` to type `B` and a method `(A, A) GetTuple()`, evaluating `(new A(1), (new B(2), new B(3))) == (new B(4), GetTuple())` means:
 - `new A(1)` and convert to `B`
 - `new B(2)`
 - `new B(3)`


### PR DESCRIPTION
Tagging @MadsTorgersen @dotnet/roslyn-compiler for review.

Update: I will update this proposal with input from Neal and Mads:
- the existence of a conversion from `e` to a 2-tuple does not affect `e == (x, y)` (ie. it fails)
- there is an open question on `(x, y) == (1, "")` versus `(x, y) == (1, null)` when there is an `==` between `x` and `byte`. The second one should clearly succeed since the tuple `(1, null)` has no natural type, we can give it type `(byte, string)`. But should the first one succeed too? (it does in my current prototype, but we'll have to figure out how to word this because the conversion from `1` to `byte` only works on constants, but the tuple is not a constant). I should test `(byte, string) t = ...` and `(byte x, string y) = ...` in those cases too.

Relates to championed issue https://github.com/dotnet/csharplang/issues/190