### PR TITLE
Disallow ref-reassignment of struct `this`

### DIFF
--- a/proposals/csharp-7.2/ref-local-reassignment.md
+++ b/proposals/csharp-7.2/ref-local-reassignment.md
@@ -14,6 +14,8 @@ The `=ref` operator is called the ***ref assignment operator***. It is not a *co
 
 The right operand must be definitely assigned at the point of the ref assignment.
 
+The left operand cannot be a `this` reference in a struct instance method.
+
 When the left operand binds to an `out` parameter, it is an error if that `out` parameter has not been definitely assigned at at the beginning of the ref assignment operator.
 
 If the left operand is a writeable ref (i.e. it designates anything other than a `ref readonly` local or  `in` parameter), then the right operand must be a writeable lvalue.


### PR DESCRIPTION
I propose we add an additional rule to disallow ref-reassignment of the struct `this` parameter. I can think of no good reason to allow this.