### PR TITLE
Fix ANTLR in Expression

### DIFF
--- a/spec/expressions.md
+++ b/spec/expressions.md
@@ -971,7 +971,7 @@ primary_expression
 
 primary_no_array_creation_expression
     : literal
-    | interpolated_string
+    | interpolated_string_expression
     | simple_name
     | parenthesized_expression
     | member_access


### PR DESCRIPTION
I try to assembly all the ANTLR spec together and my ANTLR Syntax Inspector found there's no definition of  `interpolated_string`, but the `interpolated_string_expression`.