### PR TITLE
Fix operator '*' to '-' in unary operators section

### DIFF
--- a/spec/expressions.md
+++ b/spec/expressions.md
@@ -117,7 +117,7 @@ The following table summarizes all operators in order of precedence from highest
 | __Section__                                                                                   | __Category__                | __Operators__ | 
 |-----------------------------------------------------------------------------------------------|-----------------------------|---------------|
 | [Primary expressions](expressions.md#primary-expressions)                                     | Primary                     | `x.y`  `f(x)`  `a[x]`  `x++`  `x--`  `new`  `typeof`  `default`  `checked`  `unchecked`  `delegate` | 
-| [Unary operators](expressions.md#unary-operators)                                             | Unary                       | `+`  `*`  `!`  `~`  `++x`  `--x`  `(T)x` | 
+| [Unary operators](expressions.md#unary-operators)                                             | Unary                       | `+`  `-`  `!`  `~`  `++x`  `--x`  `(T)x` | 
 | [Arithmetic operators](expressions.md#arithmetic-operators)                                   | Multiplicative              | `*`  `/`  `%` | 
 | [Arithmetic operators](expressions.md#arithmetic-operators)                                   | Additive                    | `+`  `-`      | 
 | [Shift operators](expressions.md#shift-operators)                                             | Shift                       | `<<`  `>>`    | 


### PR DESCRIPTION
Just fixed typo in unary operators section.
Operator '*' is in the position of '-'.