### PR TITLE
Minor, but important typo

### DIFF
--- a/meetings/2017/LDM-2017-10-11.md
+++ b/meetings/2017/LDM-2017-10-11.md
@@ -127,7 +127,7 @@ This is probably right. We'll think about this more, but let's go with covarianc
 
 # Null warnings
 
-Feedback: Fine to warn in most places where a null value is given a nonnullable type, but we should beware of a "sea of warnings" effect. Specifically, we shouldn't warn on array creation, as in `new string[10]`, even though it creates a hole array of undesired nulls, because it is so common in current code, and couldn't have been done "safely" before.
+Feedback: Fine to warn in most places where a null value is given a nonnullable type, but we should beware of a "sea of warnings" effect. Specifically, we shouldn't warn on array creation, as in `new string[10]`, even though it creates a whole array of undesired nulls, because it is so common in current code, and couldn't have been done "safely" before.
 
 ## Conclusion
 


### PR DESCRIPTION
Especially for non-native English readers, the phrase
> even though it creates a hole array of undesired nulls

sounds a bit weird.