### PR TITLE
Update lexical-structure.md

### DIFF
--- a/spec/lexical-structure.md
+++ b/spec/lexical-structure.md
@@ -2,7 +2,7 @@
 
 ## Programs
 
-A C# ***program*** consists of one or more ***source files***, known formally as ***compilation units*** ([Compilation units](namespaces.md#compilation-units)). A source file is an ordered sequence of Unicode characters. Source files typically have a one-to-one correspondence with files in a file system, but this correspondence is not required. For maximal portability, it is recommended that files in a file system be encoded with the UTF-8 encoding.
+A C# ***program*** consists of one or more ***source files***, known formally as ***compilation units*** ([Compilation units](namespaces.md#compilation-units)). A source file is a strictly ordered collection of Unicode characters. Source files typically have a one-to-one correspondence with files in a file system, but this correspondence is not required. For maximal portability, it is recommended that files in a file system be encoded with the UTF-8 encoding.
 
 Conceptually speaking, a program is compiled using three steps:
 

--- a/spec/lexical-structure.md
+++ b/spec/lexical-structure.md
@@ -2,7 +2,7 @@
 
 ## Programs
 
-A C# ***program*** consists of one or more ***source files***, known formally as ***compilation units*** ([Compilation units](namespaces.md#compilation-units)). A source file is a strictly ordered collection of Unicode characters. Source files typically have a one-to-one correspondence with files in a file system, but this correspondence is not required. For maximal portability, it is recommended that files in a file system be encoded with the UTF-8 encoding.
+A C# ***program*** consists of one or more ***source files***, known formally as ***compilation units*** ([Compilation units](namespaces.md#compilation-units)). A source file is a sequence of Unicode characters. Source files typically have a one-to-one correspondence with files in a file system, but this correspondence is not required. For maximal portability, it is recommended that files in a file system be encoded with the UTF-8 encoding.
 
 Conceptually speaking, a program is compiled using three steps:
 


### PR DESCRIPTION
The first paragraph of Lexical Structure defines what is a source file in way that is not entirely correct (by stating that it is "an ordered sequence"). Every sequence is ordered already by definition as each and every element of any sequence has a distinct and unique position. Also, there is no such thing as "an unordered sequence". Hence the term "an ordered sequence" is something of a semantic pleonasm. If there is a need to stress that the order in which characters appear in the source file is of crucial importance, why not use "strictly ordered collection".