### PR TITLE
spec/lexical-structure.md: fixed definition of delimited comment

### DIFF
--- a/spec/lexical-structure.md
+++ b/spec/lexical-structure.md
@@ -110,7 +110,7 @@ new_line_character
     ;
 
 delimited_comment
-    : '/*' delimited_comment_section* asterisk* '/'
+    : '/*' delimited_comment_section* asterisk* '*/'
     ;
 
 delimited_comment_section

--- a/spec/lexical-structure.md
+++ b/spec/lexical-structure.md
@@ -110,7 +110,7 @@ new_line_character
     ;
 
 delimited_comment
-    : '/*' delimited_comment_section* asterisk* '*/'
+    : '/*' delimited_comment_section* asterisk+ '/'
     ;
 
 delimited_comment_section
@@ -673,7 +673,7 @@ open_brace_escape_sequence
     : '{{'
     ;
 
-    close_brace_escape_sequence
+close_brace_escape_sequence
     : '}}'
     ;
     


### PR DESCRIPTION
According to the current definition of the delimited comment in the [specification](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#comments) the line 
```csharp
/*/
```
 is a valid comment, which is not true.