### PR TITLE
Fix code format

### DIFF
--- a/proposals/csharp-7.3/auto-prop-field-attrs.md
+++ b/proposals/csharp-7.3/auto-prop-field-attrs.md
@@ -17,7 +17,8 @@ In short, the following would be legal C# and not produce a warning:
 
 ```cs
 [Serializable]
-public class Foo {
+public class Foo 
+{
     [field: NonSerialized]
     public string MySecret { get; set; }
 }
@@ -27,13 +28,15 @@ This would result in the field-targeted attributes being applied to the compiler
 
 ```cs
 [Serializable]
-public class Foo {
+public class Foo 
+{
     [NonSerialized]
-    private string MySecret_backingField;
+    private string _mySecretBackingField;
     
-    public string MySecret {
-        get { return MySecret_backingField; }
-        set { MySecret_backingField = value; }
+    public string MySecret
+    {
+        get { return _mySecretBackingField; }
+        set { _mySecretBackingField = value; }
     }
 }
 ```
@@ -42,7 +45,8 @@ As mentioned, this brings parity with event syntax from C# 1.0 as the following 
 
 ```cs
 [Serializable]
-public class Foo {
+public class Foo
+{
     [field: NonSerialized]
     public event EventHandler MyEvent;
 }


### PR DESCRIPTION
We use [Allman style](http://en.wikipedia.org/wiki/Indent_style#Allman_style) braces, where each brace begins on a new line. 

We should use `_camelCase` for internal and private fields

See: [coding-style.md](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md )