### PR TITLE
abstract/virtual parameters use InAttribute

### DIFF
--- a/proposals/csharp-7.2/readonly-ref.md
+++ b/proposals/csharp-7.2/readonly-ref.md
@@ -259,7 +259,7 @@ The formal life time of temporary variables is semantically significant in scena
 ## Metadata representation of `in` parameters.
 When `System.Runtime.CompilerServices.IsReadOnlyAttribute` is applied to a byref parameter, it means that the the parameter is an `in` parameter.
 
-In addition, if the method is *abstract* or *virtual*, then the signature of such parameters (and only such parameters) must have `modreq[System.Runtime.CompilerServices.IsReadOnlyAttribute]`.
+In addition, if the method is *abstract* or *virtual*, then the signature of such parameters (and only such parameters) must have `modreq[System.Runtime.InteropServices.InAttribute]`.
 
 **Motivation**: this is done to ensure that in a case of method overriding/implementing the `in` parameters match.
 


### PR DESCRIPTION
An `in` parameter must have the attribute `[IsReadOnly]`. It may have the attribute `[In]` if and only if it is either abstract or virtual.

issue #1655