### PR TITLE
Unquote right_shift in the syntax for overloadable_binary_operator

### DIFF
--- a/spec/classes.md
+++ b/spec/classes.md
@@ -3532,7 +3532,7 @@ binary_operator_declarator
 
 overloadable_binary_operator
     : '+'   | '-'   | '*'   | '/'   | '%'   | '&'   | '|'   | '^'   | '<<'
-    | 'right_shift' | '=='  | '!='  | '>'   | '<'   | '>='  | '<='
+    | right_shift | '=='  | '!='  | '>'   | '<'   | '>='  | '<='
     ;
 
 conversion_operator_declarator


### PR DESCRIPTION
Since `right_shift` is another production rule and not a literal sequence of characters, is should not be enclosed in quotes.