### PR TITLE
 Fix vertical escape in table 

### DIFF
--- a/spec/expressions.md
+++ b/spec/expressions.md
@@ -125,12 +125,12 @@ The following table summarizes all operators in order of precedence from highest
 | [Relational and type-testing operators](expressions.md#relational-and-type-testing-operators) | Equality                    | `==`  `!=`    | 
 | [Logical operators](expressions.md#logical-operators)                                         | Logical AND                 | `&`           | 
 | [Logical operators](expressions.md#logical-operators)                                         | Logical XOR                 | `^`           | 
-| [Logical operators](expressions.md#logical-operators)                                         | Logical OR                  | `|`           |
+| [Logical operators](expressions.md#logical-operators)                                         | Logical OR                  | <code>&#124;</code>           |
 | [Conditional logical operators](expressions.md#conditional-logical-operators)                 | Conditional AND             | `&&`          | 
-| [Conditional logical operators](expressions.md#conditional-logical-operators)                 | Conditional OR              | `||`          | 
+| [Conditional logical operators](expressions.md#conditional-logical-operators)                 | Conditional OR              | <code>&#124;&#124;</code>          | 
 | [The null coalescing operator](expressions.md#the-null-coalescing-operator)                   | Null coalescing             | `??`          | 
 | [Conditional operator](expressions.md#conditional-operator)                                   | Conditional                 | `?:`          | 
-| [Assignment operators](expressions.md#assignment-operators), [Anonymous function expressions](expressions.md#anonymous-function-expressions)  | Assignment and lambda expression | `=`  `*=`  `/=`  `%=`  `+=`  `-=`  `<<=`  `>>=`  `&=`  `^=`  `|=`  `=>` | 
+| [Assignment operators](expressions.md#assignment-operators), [Anonymous function expressions](expressions.md#anonymous-function-expressions)  | Assignment and lambda expression | `=`  `*=`  `/=`  `%=`  `+=`  `-=`  `<<=`  `>>=`  `&=`  `^=`  <code>&#124;=</code>  `=>` | 
 
 When an operand occurs between two operators with the same precedence, the associativity of the operators controls the order in which the operations are performed:
 
@@ -3505,7 +3505,7 @@ bool? operator |(bool? x, bool? y);
 
 The following table lists the results produced by these operators for all combinations of the values `true`, `false`, and `null`.
 
-| `x`     | `y`     | `x & y` | `x | y` |
+| `x`     | `y`     | `x & y` | <code>x &#124; y</code> |
 |:-------:|:-------:|:-------:|:-------:|
 | `true`  | `true`  | `true`  | `true`  | 
 | `true`  | `false` | `false` | `true`  | 

--- a/spec/introduction.md
+++ b/spec/introduction.md
@@ -277,13 +277,13 @@ The following table summarizes C#'s operators, listing the operator categories i
 |                                  | `x != y`          | Not equal |
 | Logical AND                      | `x & y`           | Integer bitwise AND, boolean logical AND |
 | Logical XOR                      | `x ^ y`           | Integer bitwise XOR, boolean logical XOR |
-| Logical OR                       | `x | y`           | Integer bitwise OR, boolean logical OR |
+| Logical OR                       | <code>x &#124; y</code> | Integer bitwise OR, boolean logical OR |
 | Conditional AND                  | `x && y`          | Evaluates `y` only if `x` is `true` |
-| Conditional OR                   | `x || y`          | Evaluates `y` only if `x` is `false` |
+| Conditional OR                   | <code>x &#124;&#124; y</code> | Evaluates `y` only if `x` is `false` |
 | Null coalescing                  | `X ?? y`          | Evaluates to `y` if `x` is `null`, to `x` otherwise |
 | Conditional                      | `x ? y : z`       | Evaluates `y` if `x` is `true`, `z` if `x` is `false` |
 | Assignment or anonymous function | `x = y`           | Assignment |
-|                                  | `x op= y`         | Compound assignment; supported operators are `*=` `/=` `%=` `+=` `-=` `<<=` `>>=` `&=` `^=` `|=` |
+|                                  | `x op= y`         | Compound assignment; supported operators are `*=` `/=` `%=` `+=` `-=` `<<=` `>>=` `&=` `^=` <code>&#124;=</code> |
 |                                  | `(T x) => y`      | Anonymous function (lambda expression) |
 
 ## Statements


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/8034.
I didn't format the table. If you want to, please directly modify them.