### PR TITLE
Update unsafe-code.md to include decimal type

### DIFF
--- a/spec/unsafe-code.md
+++ b/spec/unsafe-code.md
@@ -667,6 +667,7 @@ The result of the `sizeof` operator is a value of type `int`. For certain predef
 | `sizeof(char)`   | `2`        |
 | `sizeof(float)`  | `4`        |
 | `sizeof(double)` | `8`        |
+| `sizeof(decimal)` | `16`        |
 | `sizeof(bool)`   | `1`        |
 
 For all other types, the result of the `sizeof` operator is implementation-defined and is classified as a value, not a constant.


### PR DESCRIPTION
@tannergooding And I came across this that the table seems to omit the decimal type. Decimal type have a size constant of 128 bits as shown in the following documentations:

https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/decimal

https://github.com/dotnet/csharplang/blob/98043cdc889303d956d540d7ab3bc4f5044a9d3b/spec/types.md#the-decimal-type