### PR TITLE
Update types.md

### DIFF
--- a/spec/types.md
+++ b/spec/types.md
@@ -543,7 +543,7 @@ type_argument
 
 In unsafe code ([Unsafe code](unsafe-code.md)), a *type_argument* may not be a pointer type. Each type argument must satisfy any constraints on the corresponding type parameter ([Type parameter constraints](classes.md#type-parameter-constraints)).
 
-### Open and closed types
+### Open and closed types (open generics)
 
 All types can be classified as either ***open types*** or ***closed types***. An open type is a type that involves type parameters. More specifically:
 


### PR DESCRIPTION
I'm sure this is wrong but we need to get "Open generics" in a H3 or higher so we can get some SEO. Google **c# open generics** and nothing from ms.docs comes up.

See https://github.com/aspnet/Docs/issues/8891 (moved to https://github.com/aspnet/Docs/issues/8933)

I need to link to open generic.