### PR TITLE
Fix example description

### DIFF
--- a/spec/namespaces.md
+++ b/spec/namespaces.md
@@ -426,7 +426,7 @@ namespace N2
 	}
 }
 ```
-`N1` contains a type member `A`, and `C` contains a static method `A`, and because `N2` imports both, referencing `A` as a *simple_name* is ambiguous and a compile-time error. 
+`N1` contains a type member `A`, and `C` contains a static field `A`, and because `N2` imports both, referencing `A` as a *simple_name* is ambiguous and a compile-time error. 
 
 Like a *using_alias_directive*, a *using_namespace_directive* does not contribute any new members to the underlying declaration space of the compilation unit or namespace, but rather affects only the compilation unit or namespace body in which it appears.
 


### PR DESCRIPTION
No method `A` in the Class `C`.
Instead, there is a static field `A`.