### PR TITLE
fix grammar rule

### DIFF
--- a/spec/lexical-structure.md
+++ b/spec/lexical-structure.md
@@ -110,7 +110,7 @@ new_line_character
     ;
 
 delimited_comment
-    : '/*' delimited_comment_section* asterisk* '/'
+    : '/*' delimited_comment_section* asterisk+ '/'
     ;
 
 delimited_comment_section


### PR DESCRIPTION
The current syntax does not require a multiline comment to end with '*/'.
So,
```antlr
delimited_comment
    : '/*' delimited_comment_section* asterisk* '/'
    ;
```
should be:
```antlr
delimited_comment
    : '/*' delimited_comment_section* asterisk+ '/'
    ;
```