### PR TITLE
Properties with a private accessor (add question to notes where it is answered)

### DIFF
--- a/meetings/2018/LDM-2018-10-17.md
+++ b/meetings/2018/LDM-2018-10-17.md
@@ -75,6 +75,45 @@ No override keyword in interfaces. This should resolve all listed questions.
 
 #### Properties with a private accessor
 
+We say that private members are not virtual, and the combination of virtual and private is disallowed. But what about a property with a private accessor?
+
+``` c#
+interface IA
+{
+    public virtual int P
+    {
+        get => 3;
+        private set => { } 
+    }
+}
+```
+
+Is this allowed? Is the `set` accessor here `virtual` or not? Can it be overridden where it is accessible? Does the following implicitly implement only the `get` accessor?
+
+``` c#
+class C : IA
+{
+    public int P
+    {
+        get => 4;
+        set { }
+    }
+}
+```
+
+Is the following presumably an error because IA.P.set isn't virtual and also because it isn't accessible?
+
+``` c#
+class C : IA
+{
+    int IA.P
+    {
+        get => 4;
+        set { }
+    }
+}
+```
+
 The first example looks valid, while the last does not. This is resolved
 analogously to how it already works in C#.
 


### PR DESCRIPTION
Add the details of a question (Properties with a private accessor) so the resolution makes sense in context.

/cc @agocke @AlekseyTs 