### PR TITLE
Specify readonly members behavior for events

### DIFF
--- a/proposals/readonly-instance-members.md
+++ b/proposals/readonly-instance-members.md
@@ -159,6 +159,11 @@ public event Action<EventArgs> Event3
     readonly add { }
     readonly remove { }
 }
+public static readonly event Event4
+{
+    add { }
+    remove { }
+}
 ```
 
 Some other syntax examples:

--- a/proposals/readonly-instance-members.md
+++ b/proposals/readonly-instance-members.md
@@ -131,7 +131,7 @@ public int Prop3
 }
 ```
 
-Readonly can be applied to auto-implemented properties, but it won't have a meaningful effect. The compiler will treat all auto-implemented getters as readonly whether or not the `readonly` keyword is present.
+Readonly can be applied to some auto-implemented properties, but it won't have a meaningful effect. The compiler will treat all auto-implemented getters as readonly whether or not the `readonly` keyword is present.
 ```cs
 // Allowed
 public readonly int Prop4 { get; }
@@ -143,6 +143,18 @@ public readonly int Prop7 { get; set; }
 public int Prop8 { get; readonly set; }
 ```
 
+Readonly can be applied to manually-implemented events, but not field-like events. Readonly cannot be applied to individual event accessors (add/remove).
+```cs
+// Allowed
+public readonly event Action<EventArgs> Event1
+{
+    add { }
+    remove { }
+}
+
+// Not allowed
+public readonly event Action<EventArgs> Event2;
+```
 
 Some other syntax examples:
 * Expression bodied members: `public readonly float ExpressionBodiedMember => (x * x) + (y * y);`

--- a/proposals/readonly-instance-members.md
+++ b/proposals/readonly-instance-members.md
@@ -154,6 +154,11 @@ public readonly event Action<EventArgs> Event1
 
 // Not allowed
 public readonly event Action<EventArgs> Event2;
+public event Action<EventArgs> Event3
+{
+    readonly add { }
+    readonly remove { }
+}
 ```
 
 Some other syntax examples:


### PR DESCRIPTION
Added detail to the speclet about how to handle `readonly` events. This design is meant to be as consistent as possible with what's allowed within a `readonly struct` declaration.