### PR TITLE
Update LDM-2019-02-13.md

### DIFF
--- a/meetings/2019/LDM-2019-02-13.md
+++ b/meetings/2019/LDM-2019-02-13.md
@@ -144,7 +144,7 @@ Only allow `!` in simple `out` parameters with no declaration.
 See [dotnet/roslyn#30297](https://github.com/dotnet/roslyn/issues/30297)
 
 ```cs
-string s = null;
+string s = string.Empty;
 if (!(s is object)) { s.ToString(); /* could warn? */ }
 if (!(s is string)) { s.ToString(); /* could warn? */ }
 ```

--- a/meetings/2019/LDM-2019-02-13.md
+++ b/meetings/2019/LDM-2019-02-13.md
@@ -144,7 +144,7 @@ Only allow `!` in simple `out` parameters with no declaration.
 See [dotnet/roslyn#30297](https://github.com/dotnet/roslyn/issues/30297)
 
 ```cs
-string? s = null;
+string s = null;
 if (!(s is object)) { s.ToString(); /* could warn? */ }
 if (!(s is string)) { s.ToString(); /* could warn? */ }
 ```


### PR DESCRIPTION
I believe `string? s = null` was meant to be  `string s = null`, as otherwise `s.ToString();` would definitely warn, since it remains possibly null.