### PR TITLE
fix two more broken links 

### DIFF
--- a/proposals/csharp-8.0/patterns.md
+++ b/proposals/csharp-8.0/patterns.md
@@ -3,7 +3,7 @@
 ## Summary
 [summary]: #summary
 
-Pattern matching extensions for C# enable many of the benefits of algebraic data types and pattern matching from functional languages, but in a way that smoothly integrates with the feel of the underlying language. The basic features are: [record types](records.md), which are types whose semantic meaning is described by the shape of the data; and pattern matching, which is a new expression form that enables extremely concise multilevel decomposition of these data types. Elements of this approach are inspired by related features in the programming languages [F#](http://www.msr-waypoint.net/pubs/79947/p29-syme.pdf "Extensible Pattern Matching Via a Lightweight Language") and [Scala](https://link.springer.com/content/pdf/10.1007%2F978-3-540-73589-2.pdf "Matching Objects With Patterns, page 273").
+Pattern matching extensions for C# enable many of the benefits of algebraic data types and pattern matching from functional languages, but in a way that smoothly integrates with the feel of the underlying language. The basic features are: [record types](../records.md), which are types whose semantic meaning is described by the shape of the data; and pattern matching, which is a new expression form that enables extremely concise multilevel decomposition of these data types. Elements of this approach are inspired by related features in the programming languages [F#](http://www.msr-waypoint.net/pubs/79947/p29-syme.pdf "Extensible Pattern Matching Via a Lightweight Language") and [Scala](https://link.springer.com/content/pdf/10.1007%2F978-3-540-73589-2.pdf "Matching Objects With Patterns, page 273").
 
 ## Detailed design
 [design]: #detailed-design

--- a/proposals/records.md
+++ b/proposals/records.md
@@ -103,7 +103,7 @@ Where, for each method named `With` that is an accessible instance member of *e1
 
 ### pattern-matching
 
-See the [Pattern Matching Specification](patterns.md) for a specification of `Deconstruct` and its relationship to pattern-matching.
+See the [Pattern Matching Specification](csharp-8.0/patterns.md#positional-pattern) for a specification of `Deconstruct` and its relationship to pattern-matching.
 
 > **Design Notes**: By virtue of the compiler-generated `Deconstruct` as specified herein, and the specification for pattern-matching, a record declaration
 > ```cs
@@ -246,7 +246,7 @@ For a *record struct* or a `sealed` *record class*, implementations of the metho
 
 A record type has a compiler-generated `public` method `void Deconstruct` unless one with any signature is provided by the user. Each parameter is an `out` parameter of the same name and type as the corresponding parameter of the record type. The compiler-provided implementation of this method shall assign each `out` parameter with the value of the corresponding property.
 
-See [the pattern-matching specification](patterns.md) for the semantics of `Deconstruct`.
+See [the pattern-matching specification](csharp-8.0/patterns.md#positional-pattern) for the semantics of `Deconstruct`.
 
 ##### `With` method
 


### PR DESCRIPTION
The 8.0 pattern matching spec links to records.md, and vice-versa.

It looked like Deconstruct semantics are described in 8.0, in the "Positional pattern" section. I added an anchor tag to resolve to that section.

This would fix the build warnings in dotnet/docs#11026

/cc @jcouv @MadsTorgersen 