### PR TITLE
markdown lint changes to C# 7.0 proposals

### DIFF
--- a/proposals/csharp-7.0/binary-literals.md
+++ b/proposals/csharp-7.0/binary-literals.md
@@ -1,32 +1,36 @@
-Binary Literals
-===============
+# Binary literals
 
 There’s a relatively common request to add binary literals to C# and VB. For bitmasks (e.g. flag enums) this seems genuinely useful, but it would also be great just for educational purposes.
 
 Binary literals would look like this:
 
-``` c#
+```csharp
 int nineteen = 0b10011;
 ```
 
 Syntactically and semantically they are identical to hexadecimal literals, except for using `b`/`B` instead of `x`/`X`, having only digits `0` and `1` and being interpreted in base 2 instead of 16.
 
 There’s little cost to implementing these, and little conceptual overhead to users of the language.
-# Syntax
+
+## Syntax
 
 The grammar would be as follows:
 
-> _integer-literal:_
-> &emsp;  ...
-> &emsp;  _binary-integer-literal_
-> 
-> _binary-integer-literal:_
-> &emsp;  `0b`  &emsp;  _binary-digits_  &emsp;  _integer-type-suffixopt_
-> &emsp;  `0B`  &emsp;  _binary-digits_  &emsp;  _integer-type-suffixopt_
-> 
-> _binary-digits:_
-> &emsp;  _binary-digit_
-> &emsp;  _binary-digits_  &emsp;  _binary-digit_
-> 
-> _binary-digit:_  &emsp; one of
-> &emsp;  `0`  `1`
+```antlr
+integer-literal:
+    : ...
+    | binary-integer-literal
+    ;
+binary-integer-literal:
+    : `0b` binary-digits integer-type-suffix-opt
+    | `0B` binary-digits integer-type-suffix-opt
+    ;
+binary-digits:
+    : binary-digit
+    | binary-digits binary-digit
+    ;
+binary-digit:
+    : `0`
+    | `1`
+    ;
+```

--- a/proposals/csharp-7.0/digit-separators.md
+++ b/proposals/csharp-7.0/digit-separators.md
@@ -1,5 +1,4 @@
-Digit Separators
-================
+# Digit separators
 
 Being able to group digits in large numeric literals would have great readability impact and no significant downside. 
 
@@ -7,7 +6,7 @@ Adding binary literals (#215) would increase the likelihood of numeric literals 
 
 We would follow Java and others, and use an underscore `_` as a digit separator. It would be able to occur everywhere in a numeric literal (except as the first and last character), since different groupings may make sense in different scenarios and especially for different numeric bases:
 
-``` c#
+```csharp
 int bin = 0b1001_1010_0001_0100;
 int hex = 0x1b_a0_44_fe;
 int dec = 33_554_432;

--- a/proposals/csharp-7.0/local-functions.md
+++ b/proposals/csharp-7.0/local-functions.md
@@ -1,5 +1,4 @@
-Local Functions
-===============
+# Local functions
 
 We extend C# to support the declaration of functions in block scope. Local functions may use (capture) variables from the enclosing scope.
 
@@ -9,9 +8,7 @@ Local functions may be called from a lexical point before its definition. Local 
 
 TODO: _WRITE SPEC_
 
-
-Syntax Grammar
-==============
+## Syntax grammar
 
 This grammar is represented as a diff from the current spec grammar.
 

--- a/proposals/csharp-7.0/out-var.md
+++ b/proposals/csharp-7.0/out-var.md
@@ -1,5 +1,4 @@
-Out Variable Declarations
-=========================
+# Out variable declarations
 
 The *out variable declaration* feature enables a variable to be declared at the location that it is being passed as an `out` argument.
 
@@ -14,7 +13,7 @@ A variable declared this way is called an *out variable*. You may use the contex
 
 According to Language Specification (section 7.6.7 Element access) the argument-list of an element-access (indexing expression) does not contain ref or out arguments. However, they are permitted by the compiler for various scenarios, for example indexers declared in metadata that accept `out`.
 
-Within the scope of a local variable introduced by an argument_value, it is a compile-time error to refer to that local variable in a textual position that precedes its declaration. 
+Within the scope of a local variable introduced by an argument_value, it is a compile-time error to refer to that local variable in a textual position that precedes its declaration.
 
 It is also an error to reference an implicitly-typed (§8.5.1) out variable in the same argument list that immediately contains its declaration.
 

--- a/proposals/csharp-7.0/pattern-matching.md
+++ b/proposals/csharp-7.0/pattern-matching.md
@@ -1,9 +1,8 @@
-Pattern Matching for C# 7
-=========================
+# Pattern Matching for C# 7
 
 Pattern matching extensions for C# enable many of the benefits of algebraic data types and pattern matching from functional languages, but in a way that smoothly integrates with the feel of the underlying language. The basic features are: [record types](../records.md), which are types whose semantic meaning is described by the shape of the data; and pattern matching, which is a new expression form that enables extremely concise multilevel decomposition of these data types. Elements of this approach are inspired by related features in the programming languages [F#](http://www.msr-waypoint.net/pubs/79947/p29-syme.pdf "Extensible Pattern Matching Via a Lightweight Language") and [Scala](http://lampwww.epfl.ch/~emir/written/MatchingObjectsWithPatterns-TR.pdf "Matching Objects With Patterns").
 
-## Is Expression
+## Is expression
 
 The `is` operator is extended to test an expression against a *pattern*.
 
@@ -45,7 +44,7 @@ var_pattern
 
 > Note: There is technically an ambiguity between *type* in an `is-expression` and *constant_pattern*, either of which might be a valid parse of a qualified identifier. We try to bind it as a type for compatibility with previous versions of the language; only if that fails do we resolve it as we do in other contexts, to the first thing found (which must be either a constant or a type). This ambiguity is only present on the right-hand-side of an `is` expression.
 
-### Declaration Pattern
+### Declaration pattern
 
 The *declaration_pattern* both tests that an expression is of a given type and casts it to that type if the test succeeds. If the *simple_designation* is an identifier, it introduces a local variable of the given type named by the given identifier. That local variable is *definitely assigned* when the result of the pattern-matching operation is true.
 
@@ -59,20 +58,20 @@ The runtime semantic of this expression is that it tests the runtime type of the
 
 Certain combinations of static type of the left-hand-side and the given type are considered incompatible and result in compile-time error. A value of static type `E` is said to be *pattern compatible* with the type `T` if there exists an identity conversion, an implicit reference conversion, a boxing conversion, an explicit reference conversion, or an unboxing conversion from `E` to `T`. It is a compile-time error if an expression of type `E` is not pattern compatible with the type in a type pattern that it is matched with.
 
-> Note: [In C# 7.1 we extend this](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.1/generics-pattern-match.md) to permit a pattern-matching operation if either the input type or the type `T` is an open type. This paragraph is replaced by the following:
+> Note: [In C# 7.1 we extend this](../csharp-7.1/generics-pattern-match.md) to permit a pattern-matching operation if either the input type or the type `T` is an open type. This paragraph is replaced by the following:
 > 
 > Certain combinations of static type of the left-hand-side and the given type are considered incompatible and result in compile-time error. A value of static type `E` is said to be *pattern compatible* with the type `T` if there exists an identity conversion, an implicit reference conversion, a boxing conversion, an explicit reference conversion, or an unboxing conversion from `E` to `T`, **or if either `E` or `T` is an open type**. It is a compile-time error if an expression of type `E` is not pattern compatible with the type in a type pattern that it is matched with.
 
 The declaration pattern is useful for performing run-time type tests of reference types, and replaces the idiom
 
-```cs
+```csharp
 var v = expr as Type;
 if (v != null) { // code using v }
 ```
 
 With the slightly more concise
 
-```cs
+```csharp
 if (expr is Type v) { // code using v }
 ```
 
@@ -80,14 +79,14 @@ It is an error if *type* is a nullable value type.
 
 The declaration pattern can be used to test values of nullable types: a value of type `Nullable<T>` (or a boxed `T`) matches a type pattern `T2 id` if the value is non-null and the type of `T2` is `T`, or some base type or interface of `T`. For example, in the code fragment
 
-```cs
+```csharp
 int? x = 3;
 if (x is int v) { // code using v }
 ```
 
 The condition of the `if` statement is `true` at runtime and the variable `v` holds the value `3` of type `int` inside the block.
 
-### Constant Pattern
+### Constant pattern
 
 ```antlr
 constant_pattern
@@ -101,8 +100,7 @@ If both *e* and *c* are of integral types, the pattern is considered matched if 
 
 Otherwise the pattern is considered matching if `object.Equals(e, c)` returns `true`. In this case it is a compile-time error if the static type of *e* is not *pattern compatible* with the type of the constant.
 
-
-### Var Pattern
+### Var pattern
 
 ```antlr
 var_pattern
@@ -114,8 +112,7 @@ An expression *e* matches a *var_pattern* always. In other words, a match to a *
 
 It is an error if the name `var` binds to a type.
 
-
-## Switch Statement
+## Switch statement
 
 The `switch` statement is extended to select for execution the first block having an associated pattern that matches the *switch expression*.
 
@@ -141,8 +138,7 @@ A pattern variable declared in a *switch_label* is definitely assigned in its ca
 
 [TODO: We should specify when a *switch block* is reachable.]
 
-
-### Scope of Pattern Variables
+### Scope of pattern variables
 
 The scope of a variable declared in a pattern is as follows:
 
@@ -156,7 +152,7 @@ Otherwise the variable is declared in an *is_pattern* expression, and its scope 
 - If the expression is in an *iteration_statement*, its scope is just that statement.
 - Otherwise if the expression is in some other statement form, its scope is the scope containing the statement.
 
-For the purpose of determing the scope, an *embedded_statement* is considered to be in its own scope. For example, the grammar for an *if_statement* is
+For the purpose of determining the scope, an *embedded_statement* is considered to be in its own scope. For example, the grammar for an *if_statement* is
 
 ``` antlr
 if_statement
@@ -167,7 +163,7 @@ if_statement
 
 So if the controlled statement of an *if_statement* declares a pattern variable, its scope is restricted to that *embedded_statement*:
 
-``` c#
+```csharp
 if (x) M(y is var z);
 ```
 
@@ -175,15 +171,10 @@ In this case the scope of `z` is the embedded statement `M(y is var z);`.
 
 Other cases are errors for other reasons (e.g. in a parameter's default value or an attribute, both of which are an error because those contexts require a constant expression).
 
-> [In C# 7.3 we added the following contexts](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.3/expression-variables-in-initializers.md) in which a pattern variable may be declared:
+> [In C# 7.3 we added the following contexts](../proposals/csharp-7.3/expression-variables-in-initializers.md) in which a pattern variable may be declared:
 > - If the expression is in a *constructor initializer*, its scope is the *constructor initializer* and the constructor's body.
 > - If the expression is in a field initializer, its scope is the *equals_value_clause* in which it appears.
 > - If the expression is in a query clause that is specified to be translated into the body of a lambda, its scope is just that expression.
-
-
-
-
-
 
 ## Changes to syntactic disambiguation
 
@@ -191,7 +182,7 @@ There are situations involving generics where the C# grammar is ambiguous, and t
 
 > #### 7.6.5.2 Grammar ambiguities
 > The productions for *simple-name* (§7.6.3) and *member-access* (§7.6.5) can give rise to ambiguities in the grammar for expressions. For example, the statement:
-> ```cs
+> ```csharp
 > F(G<A,B>(7));
 > ```
 > could be interpreted as a call to `F` with two arguments, `G < A` and `B > (7)`. Alternatively, it could be interpreted as a call to `F` with one argument, which is a call to a generic method `G` with two type arguments and one regular argument.
@@ -201,77 +192,77 @@ There are situations involving generics where the C# grammar is ambiguous, and t
 > (  )  ]  }  :  ;  ,  .  ?  ==  !=  |  ^
 > ```
 > then the *type-argument-list* is retained as part of the *simple-name*, *member-access* or *pointer-member-access* and any other possible parse of the sequence of tokens is discarded. Otherwise, the *type-argument-list* is not considered to be part of the *simple-name*, *member-access* or > *pointer-member-access*, even if there is no other possible parse of the sequence of tokens. Note that these rules are not applied when parsing a *type-argument-list* in a *namespace-or-type-name* (§3.8). The statement
-> ```cs
+> ```csharp
 > F(G<A,B>(7));
 > ```
 > will, according to this rule, be interpreted as a call to `F` with one argument, which is a call to a generic method `G` with two type arguments and one regular argument. The statements
-> ```cs
+> ```csharp
 > F(G < A, B > 7);
 > F(G < A, B >> 7);
 > ```
 > will each be interpreted as a call to `F` with two arguments. The statement
-> ```cs
+> ```csharp
 > x = F < A > +y;
 > ```
 > will be interpreted as a less than operator, greater than operator, and unary plus operator, as if the statement had been written `x = (F < A) > (+y)`, instead of as a *simple-name* with a *type-argument-list* followed by a binary plus operator. In the statement
-> ```cs
+> ```csharp
 > x = y is C<T> + z;
 > ```
 > the tokens `C<T>` are interpreted as a *namespace-or-type-name* with a *type-argument-list*.
 
 There are a number of changes being introduced in C# 7 that make these disambiguation rules no longer sufficient to handle the complexity of the language.
 
-### out variable declarations
+### Out variable declarations
 
 It is now possible to declare a variable in an out argument:
 
-```cs
+```csharp
 M(out Type name);
 ```
 
 However, the type may be generic: 
 
-```cs
+```csharp
 M(out A<B> name);
 ```
 
 Since the language grammar for the argument uses *expression*, this context is subject to the disambiguation rule. In this case the closing `>` is followed by an *identifier*, which is not one of the tokens that permits it to be treated as a *type-argument-list*. I therefore propose to **add *identifier* to the set of tokens that triggers the disambiguation to a *type-argument-list*.**
 
-### tuples and deconstruction declarations
+### Tuples and deconstruction declarations
 
 A tuple literal runs into exactly the same issue. Consider the tuple expression
 
-```cs
+```csharp
 (A < B, C > D, E < F, G > H)
 ```
 
 Under the old C# 6 rules for parsing an argument list, this would parse as a tuple with four elements, starting with `A < B` as the first. However, when this appears on the left of a deconstruction, we want the disambiguation triggered by the *identifier* token as described above:
 
-```cs
+```csharp
 (A<B,C> D, E<F,G> H) = e;
 ```
 
 This is a deconstruction declaration which declares two variables, the first of which is of type `A<B,C>` and named `D`. In other words, the tuple literal contains two expressions, each of which is a declaration expression.
 
-For simplicitly of the specification and compiler, I propose that this tuple literal be parsed as a two-element tuple wherever it appears (whether or not it appears on the left-hand-side of an assignment). That would be a natural result of the disambiguation described in the previous section.
+For simplicity of the specification and compiler, I propose that this tuple literal be parsed as a two-element tuple wherever it appears (whether or not it appears on the left-hand-side of an assignment). That would be a natural result of the disambiguation described in the previous section.
 
-### pattern-matching
+### Pattern-matching
 
 Pattern matching introduces a new context where the expression-type ambiguity arises. Previously the right-hand-side of an `is` operator was a type. Now it can be a type or expression, and if it is a type it may be followed by an identifier. This can, technically, change the meaning of existing code:
 
-```cs
+```csharp
 var x = e is T < A > B;
 ```
 
 This could be parsed under C#6 rules as
 
-```cs
+```csharp
 var x = ((e is T) < A) > B;
 ```
 
 but under under C#7 rules (with the disambiguation proposed above) would be parsed as
 
-```cs
+```csharp
 var x = e is T<A> B;
 ```
 
@@ -279,14 +270,14 @@ which declares a variable `B` of type `T<A>`. Fortunately, the native and Roslyn
 
 Pattern-matching introduces additional tokens that should drive the ambiguity resolution toward selecting a type. The following examples of existing valid C#6 code would be broken without additional disambiguation rules:
 
-```cs
+```csharp
 var x = e is A<B> && f;            // &&
 var x = e is A<B> || f;            // ||
 var x = e is A<B> & f;             // &
 var x = e is A<B>[];               // [
 ```
 
-### proposed change to the disambiguation rule
+### Proposed change to the disambiguation rule
 
 I propose to revise the specification to change the list of disambiguating tokens from
 
@@ -304,7 +295,7 @@ to
 
 And, in certain contexts, we treat *identifier* as a disambiguating token. Those contexts are where the sequence of tokens being disambiguated is immediately preceded by one of the keywords `is`, `case`, or `out`, or arises while parsing the first element of a tuple literal (in which case the tokens are preceded by `(` or `:` and the identifier is followed by a `,`) or a subsequent element of a tuple literal.
 
-### modified disambiguation rule
+### Modified disambiguation rule
 
 The revised disambiguation rule would be something like this
 
@@ -316,7 +307,7 @@ The revised disambiguation rule would be something like this
 > 
 > If the following token is among this list, or an identifier in such a context, then the *type-argument-list* is retained as part of the *simple-name*, *member-access* or  *pointer-member-access* and any other possible parse of the sequence of tokens is discarded.  Otherwise, the *type-argument-list* is not considered to be part of the *simple-name*, *member-access* or *pointer-member-access*, even if there is no other possible parse of the sequence of tokens. Note that these rules are not applied when parsing a *type-argument-list* in a *namespace-or-type-name* (§3.8).
 
-### breaking changes due to this proposal
+### Breaking changes due to this proposal
 
 No breaking changes are known due to this proposed disambiguation rule.
 
@@ -336,14 +327,13 @@ The expression `e is A<B> C` uses a declaration expression.
 
 The case label `case A<B> C:` uses a declaration expression.
 
-
-## Some Examples of Pattern Matching
+## Some examples of pattern matching
 
 ### Is-As
 
 We can replace the idiom
 
-```cs
+```csharp
 var v = expr as Type;	
 if (v != null) {
     // code using v
@@ -352,7 +342,7 @@ if (v != null) {
 
 With the slightly more concise and direct
 
-```cs
+```csharp
 if (expr is Type v) {
     // code using v
 }
@@ -362,7 +352,7 @@ if (expr is Type v) {
 
 We can replace the idiom
 
-```cs
+```csharp
 Type? v = x?.y?.z;
 if (v.HasValue) {
     var value = v.GetValueOrDefault();
@@ -372,7 +362,7 @@ if (v.HasValue) {
 
 With the slightly more concise and direct
 
-```cs
+```csharp
 if (x?.y?.z is Type value) {
     // code using value
 }
@@ -382,7 +372,7 @@ if (x?.y?.z is Type value) {
 
 Suppose we define a set of recursive types to represent expressions (per a separate proposal):
 
-```cs
+```csharp
 abstract class Expr;
 class X() : Expr;
 class Const(double Value) : Expr;
@@ -393,7 +383,7 @@ class Neg(Expr Value) : Expr;
 
 Now we can define a function to compute the (unreduced) derivative of an expression:
 
-```cs
+```csharp
 Expr Deriv(Expr e)
 {
   switch (e) {
@@ -411,7 +401,7 @@ Expr Deriv(Expr e)
 
 An expression simplifier demonstrates positional patterns:
 
-```cs
+```csharp
 Expr Simplify(Expr e)
 {
   switch (e) {

--- a/proposals/csharp-7.0/throw-expression.md
+++ b/proposals/csharp-7.0/throw-expression.md
@@ -19,7 +19,7 @@ The type rules are as follows:
 
 A *throw expression* throws the value produced by evaluating the *null_coalescing_expression*, which must denote a value of the class type `System.Exception`, of a class type that derives from `System.Exception` or of a type parameter type that has `System.Exception` (or a subclass thereof) as its effective base class. If evaluation of the expression produces `null`, a `System.NullReferenceException` is thrown instead.
 
-The behavior at runtime of the evaluation of a *throw expression* is the same [as specified for a *throw statement*](https://github.com/dotnet/csharplang/blob/master/spec/statements.md#the-throw-statement).
+The behavior at runtime of the evaluation of a *throw expression* is the same [as specified for a *throw statement*](../../spec/statements.md#the-throw-statement).
 
 The flow-analysis rules are as follows:
 


### PR DESCRIPTION
These changes are to improve the experience for publishing these proposals.

One change should be carefully reviewed to ensure I didn't introduce any technical errors:
I translated the binary literals grammar into ANTLR to match all other specs and proposals.  See changes in proposals/csharp-7.0/binary-literals.md

Other changes are:
1. Use  consistent ATX headers, with one H1 per proposal.
1. use `csharp` as language identifier in code snippets
1. Use relative links to other markdown from the dotnet/csharplang repo. That way, when published on docs.microsoft.com, the links will resolve to the publsihed articles on the same site. (Links to content not being published are not modified.)
1. spelling / capitalization found by the lint tool.

/cc @mairaw @jcouv @agocke 