### PR TITLE
update 7.2 proposals for markdown lint concerns

### DIFF
--- a/proposals/csharp-7.2/conditional-ref.md
+++ b/proposals/csharp-7.2/conditional-ref.md
@@ -1,9 +1,10 @@
-# Conditional ref operator
+# Conditional ref expressions
 
 The pattern of binding a ref variable to one or another expression conditionally is not currently expressible in C#.
 
 The typical workaround is to introduce a method like:
-```CS
+
+```csharp
 ref T Choice(bool condition, ref T consequence, ref T alternative)
 {
     if (condition)
@@ -16,22 +17,25 @@ ref T Choice(bool condition, ref T consequence, ref T alternative)
     }
 }
 ```
+
 Note that this is not an exact replacement of a ternary since all arguments must be evaluated at the call site.
 
 The following will not work as expected:
-```CS
+
+```csharp
        // will crash with NRE because 'arr[0]' will be executed unconditionally
       ref var r = ref Choice(arr != null, ref arr[0], ref otherArr[0]);
 ```
 
 The proposed syntax would look like:
-```CS
+
+```csharp
      <condition> ? ref <consequence> : ref <alternative>;
 ```
 
 The above attempt with "Choice" can be _correctly_ written using ref ternary as:
 
-```CS
+```csharp
      ref var r = ref (arr != null ? ref arr[0]: ref otherArr[0]);
 ```
 
@@ -46,7 +50,7 @@ Safe-to-return will be assumed conservatively from the conditional operands. If 
 
 Ref ternary is an LValue and as such it can be passed/assigned/returned by reference;
 
-```CS
+```csharp
      // pass by reference
      foo(ref (arr != null ? ref arr[0]: ref otherArr[0]));
 
@@ -56,14 +60,14 @@ Ref ternary is an LValue and as such it can be passed/assigned/returned by refer
 
 Being an LValue, it can also be assigned to. 
 
-```CS
+```csharp
     // assign to
     (arr != null ? ref arr[0]: ref otherArr[0]) = 1;
 ```
 
 Ref ternary can be used in a regular (not ref) context as well. Although it would not be common since you could as well just use a regular ternary.
 
-```CS
+```csharp
      int x = (arr != null ? ref arr[0]: ref otherArr[0]);
 ```
 
@@ -76,5 +80,3 @@ The complexity of the implementation would seem to be the size of a moderate-to-
 I do not think we need any changes to the syntax or parsing.
 There is no effect on metadata or interop. The feature is completely expression based.
 No effect on debugging/PDB either
-
-

--- a/proposals/csharp-7.2/leading-separator.md
+++ b/proposals/csharp-7.2/leading-separator.md
@@ -1,8 +1,8 @@
 # Allow digit separator after 0b or 0x
 
-In C# 7.2, we extend the set of places that digit separators (the underscore character) can appear in integral literals. [Beginning in C# 7.0, separators are permitted between the digits of a literal](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.0/digit-separators.md). Now, in C# 7.2, we also permit digit separators before the first significant digit of a binary or hexadecimal literal, after the prefix.
+In C# 7.2, we extend the set of places that digit separators (the underscore character) can appear in integral literals. [Beginning in C# 7.0, separators are permitted between the digits of a literal](../csharp-7.0/digit-separators.md). Now, in C# 7.2, we also permit digit separators before the first significant digit of a binary or hexadecimal literal, after the prefix.
 
-``` c#
+```csharp
     123      // permitted in C# 1.0 and later
     1_2_3    // permitted in C# 7.0 and later
     0x1_2_3  // permitted in C# 7.0 and later

--- a/proposals/csharp-7.2/non-trailing-named-arguments.md
+++ b/proposals/csharp-7.2/non-trailing-named-arguments.md
@@ -10,13 +10,13 @@ Allow named arguments to be used in non-trailing position, as long as they are u
 The main motivation is to avoid typing redundant information. It is common to name an argument that is a literal (such as `null`, `true`) for the purpose of clarifying the code, rather than of passing arguments out-of-order.
 That is currently disallowed (`CS1738`) unless all the following arguments are also named.
 
-```C#
+```csharp
 DoSomething(isEmployed:true, name, age); // currently disallowed, even though all arguments are in position
 // CS1738 "Named argument specifications must appear after all fixed arguments have been specified"
 ```
 
 Some additional examples:
-```C#
+```csharp
 public void DoSomething(bool isEmployed, string personName, int personAge) { ... }
 
 DoSomething(isEmployed:true, name, age); // currently CS1738, but would become legal
@@ -27,7 +27,7 @@ DoSomething(true, personAge:age, personName:name); // already legal
 ```
 
 This would also work with params:
-```C#
+```csharp
 public class Task
 {
     public static Task When(TaskStatus all, TaskStatus any, params Task[] tasks);
@@ -55,7 +55,8 @@ In other words, non-trailing named arguments are only allowed when the name and 
 [drawbacks]: #drawbacks
 
 This proposal exacerbates existing subtleties with named arguments in overload resolution. For instance:
-```
+
+```csharp
 void M(int x, int y) { }
 void M<T>(T y, int x) { }
 
@@ -68,7 +69,8 @@ void M2()
 ```
 
 You could get this situation today by swapping the parameters:
-```
+
+```csharp
 void M(int y, int x) { }
 void M<T>(int x, T y) { }
 


### PR DESCRIPTION
Primarily these changes:

1. ATX style headers.
1. `csharp` as the language identifier
1. relative link to other published proposals.