### PR TITLE
Error from Obsolete Attribute does not affect Overload Resolution

### DIFF
--- a/spec/attributes.md
+++ b/spec/attributes.md
@@ -717,7 +717,7 @@ namespace System
 }
 ```
 
-If a program uses a type or member that is decorated with the `Obsolete` attribute, the compiler issues a warning or an error. Specifically, the compiler issues a warning if no error parameter is provided, or if the error parameter is provided and has the value `false`. The compiler issues an error if the error parameter is specified and has the value `true`.
+If a program uses a type or member that is decorated with the `Obsolete` attribute, the compiler issues a warning or an error. Specifically, the compiler issues a warning if no error parameter is provided, or if the error parameter is provided and has the value `false`. The compiler issues an error if the error parameter is specified and has the value `true`. The error does not affect Overload Resolution.
 
 In the example
 


### PR DESCRIPTION
https://sharplab.io/#v2:EYLgZgpghgLgrgJwgZwLQDs4BstWFiVKABwEsAfAAQAYACSgRgG4BYAKEoGZ6AmWgYVoBvdrTH1ujAGz0ALLQCyUUugAUASlHiRbcXsWqAHrQC8APlqGAdAEl0yGFHQBjCOta7xAXy1iu9BhlKeQVVSgBWAB4AQQAaAOoLKHVhX1ofTzE0/2k5AwjIgCF4gHtgACsIZxgklJ09DIz2HL5o9nrxAG0AeWBkEoIYCFUAIhH4mAQ4NwBdbMkGOjsHJ1dhAHMIGCZG9mbJPkL2+doAZUmVddplxxcIDa2d9i8gA=

For example