### PR TITLE
Add base interfaces to declarations

### DIFF
--- a/proposals/default-interface-methods.md
+++ b/proposals/default-interface-methods.md
@@ -760,11 +760,11 @@ interface IA
 {
     void M(int x) { }
 }
-interface IB
+interface IB : IA
 {
     override void M(int y) { }
 }
-interface IC
+interface IC : IB
 {
     static void M2()
     {


### PR DESCRIPTION
In the modified sample, I think these base interfaces were missing.

I was reviewing this and taking notes as I start work on dotnet/docs#11604. This sample looked incorrect based on the proposed syntax.

I wasn't sure if `IC` was meant to derive only from `IB` or from `IB` and `IA` in its declaration.