### PR TITLE
Return storage that exists

### DIFF
--- a/proposals/csharp-7.2/readonly-ref.md
+++ b/proposals/csharp-7.2/readonly-ref.md
@@ -332,7 +332,7 @@ struct ImmutableArray<T>
     public ref readonly T ItemRef(int i)
     {
         // returning a readonly reference to an array element
-        return ref this.arrary[i];
+        return ref this.array[i];
     }
 }
 

--- a/proposals/csharp-7.2/readonly-ref.md
+++ b/proposals/csharp-7.2/readonly-ref.md
@@ -332,7 +332,7 @@ struct ImmutableArray<T>
     public ref readonly T ItemRef(int i)
     {
         // returning a readonly reference to an array element
-        return ref this.r1;
+        return ref this.arrary[i];
     }
 }
 


### PR DESCRIPTION
The sample returns a field that is not defined in the sample. I assume the code should return the referenced element in the array.

Fixes dotnet/docs#12301