### PR TITLE
remove syntax highlighting

### DIFF
--- a/spec/statements.md
+++ b/spec/statements.md
@@ -1136,7 +1136,7 @@ Exception in Main: G
 ```
 
 If the first catch block had thrown `e` instead of rethrowing the current exception, the output produced would be as follows:
-```csharp
+```
 Exception in F: G
 Exception in Main: F
 ```


### PR DESCRIPTION
'in' should not be highlighted