### PR TITLE
Mention implicit interpolated string conversions in the list of implicit converions

### DIFF
--- a/spec/conversions.md
+++ b/spec/conversions.md
@@ -16,7 +16,8 @@ The following conversions are classified as implicit conversions:
 
 *  Identity conversions
 *  Implicit numeric conversions
-*  Implicit enumeration conversions.
+*  Implicit enumeration conversions
+*  Implicit interpolated string conversions
 *  Implicit nullable conversions
 *  Null literal conversions
 *  Implicit reference conversions


### PR DESCRIPTION
There is the [section](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/conversions#implicit-interpolated-string-conversions) about implicit interpolated string conversions, but they are not in the list of implicit conversions.