### PR TITLE
Remove outdated info from spec index

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -3,7 +3,7 @@ C# Language Specification
 
 __Version 6__
 
-This is an unofficial draft, posted here for convenience. When we submit a C# 6.0 spec proposal to ECMA (who is currently finalizing the C# 5.0 Standard), it will be shared here.
+This is an unofficial draft, posted here for convenience. When we submit a C# 6.0 spec proposal to ECMA, it will be shared here.
 
 <!--
 (This document is also available for download: [csharp.pdf](CSharp%20Language%20Specification.pdf?raw=true) and [csharp.docx](CSharp%20Language%20Specification.docx?raw=true))


### PR DESCRIPTION
The ECMA standard for C# 5.0 has already been released, so this is no longer accurate. It would be nice if the current status of standardizing C# 6.0 could be included here, but I don't have that information, so I just removed the outdated information.