### PR TITLE
remove locale

### DIFF
--- a/proposals/csharp-7.2/private-protected.md
+++ b/proposals/csharp-7.2/private-protected.md
@@ -22,7 +22,7 @@ Directly providing support for this access level in C# enables these circumstanc
 
 ### `private protected` access modifier
 
-We propose to add a new access modifier combination `private protected` (which can appear in any order among the modifiers). This maps to the CLR notion of protectedAndInternal, and borrows the same syntax currently used in [C++/CLI](https://msdn.microsoft.com/en-us/library/ke3a209d.aspx#BKMK_Member_visibility).
+We propose to add a new access modifier combination `private protected` (which can appear in any order among the modifiers). This maps to the CLR notion of protectedAndInternal, and borrows the same syntax currently used in [C++/CLI](https://msdn.microsoft.com/library/ke3a209d.aspx#BKMK_Member_visibility).
 
 A member declared `private protected` can be accessed within a subclass of its container if that subclass is in the same assembly as the member.
 

--- a/proposals/csharp-7.2/readonly-ref.md
+++ b/proposals/csharp-7.2/readonly-ref.md
@@ -24,7 +24,7 @@ Here I just want to acknowledge that the idea by itself is not very new.
 ### Motivation
 
 Prior to this feature C# did not have an efficient way of expressing a desire to pass struct variables into method calls for readonly purposes with no intention of modifying. Regular by-value argument passing implies copying, which adds unnecessary costs.  That drives users to use by-ref argument passing and rely on comments/documentation to indicate that the data is not supposed to be mutated by the callee. It is not a good solution for many reasons.  
-The examples are numerous - vector/matrix math operators in graphics libraries like [XNA](https://msdn.microsoft.com/en-us/library/bb194944.aspx) are known to have ref operands purely because of performance considerations. There is code in Roslyn compiler itself that uses structs to avoid allocations and then passes them by reference to avoid copying costs.
+The examples are numerous - vector/matrix math operators in graphics libraries like [XNA](https://msdn.microsoft.com/library/bb194944.aspx) are known to have ref operands purely because of performance considerations. There is code in Roslyn compiler itself that uses structs to avoid allocations and then passes them by reference to avoid copying costs.
 
 ### Solution (`in` parameters)
 


### PR DESCRIPTION
These two links both contained the "en-us" locale. That directs  readers to the English version, rather than the localized version based on their browser environment.

