### PR TITLE
First set of changes for tuples from feature spec and LDM notes.

### DIFF
--- a/proposals/csharp-7.0/tuples.md
+++ b/proposals/csharp-7.0/tuples.md
@@ -4,6 +4,8 @@ This proposal specifies the changes required to the [C# 6.0 (draft) Language spe
 
 ## Changes to [Lexical structure](../../spec/lexical-structure.md)
 
+### Literals
+
 > The grammar for [Literals](../../spec/lexical-structure.md#literals) is extended to include `tuple_literal`:
 
 ```antlr
@@ -16,7 +18,15 @@ literal
     | null_literal
     | tuple_literal // new
     ;
+```
 
+> Add the following section after [The null literal](../../spec/lexical-structure.md#The-null-literal):
+
+#### Tuple literals
+
+A tuple literal consists of two or more tuple literal elements, each of which is optionally named.
+
+```antlr
 tuple_literal
     : '(' tuple_literal_element_list ')'
     ;
@@ -31,7 +41,49 @@ tuple_literal_element
     ;
 ```
 
-Note that because it is not a constant expression, a tuple literal cannot be used as default value for an optional parameter.
+A tuple literal is *target typed* whenever possible; that is, its type is determined by the context in which it is used.
+
+**ISSUE:** If the term target-typed is specific to this context, we probably need a complete definition somewhere.
+
+\[Example:
+```csharp
+var t1 = (0, 2);              // infer tuple type from values
+var t2 = (sum: 0, count: 1);  // infer tuple type from names and values
+```
+end example\]
+
+A tuple literal has a "conversion from expression" to any tuple type having the same number of elements, as long as each of the element expressions of the tuple literal has an implicit conversion to the type of the corresponding element of the tuple type.
+
+\[Example:
+```csharp
+(string name, byte age) t = (null, 5); // OK: the expressions null and 5 convert to string and byte, respectively
+```
+end example\]
+
+In cases where a tuple literal is not part of a conversion, it acquires its *natural type*, which means a tuple type where the element types are the types of the constituent expressions, in lexical order. Since not all expressions have types, not all tuple literals have a natural type either:
+
+**ISSUE:** Is natural type specific to tuples? Need we say more about this term?
+
+\[Example:
+```csharp
+var t = ("John", 5); // OK: the type of t is (string, int)
+var t = (null, 5);   // Error: null doesn't have a type
+```
+end example\]
+
+If a tuple literal includes element names, those names become part of the natural type: 
+
+\[Example:
+```csharp
+var t = (name: "John", age: 5); // The type of t is (string name, int age)
+```
+end example\]
+
+A tuple literal is *not* a [constant expression](../../spec/expressions.md#Constant-expressions). As such, a tuple literal cannot be used as the default value for an optional parameter.
+
+**ISSUE:** Consider removing the second sentence above, as it sounds like just one example of usage prohibition (rather than a spec requirement); there likely are others. If that is true, either completely omit that sentence, or delete it from here and add an example showing that such a usage fails.
+
+For a discussion of tuple literals as tuple initializers, see [Tuple types](../../spec/types.md#Tuple-types).
 
 ## Changes to [Types](../../spec/types.md)
 
@@ -47,7 +99,19 @@ value_type
     | enum_type
     | tuple_type // new
     ;
+```
 
+## Additions to [Types](../../spec/types.md)
+
+> Add the following sections after [Nullable types](../../spec/types.md#nullable-types) (at the end of the current *Value types* section.)
+
+### Tuple types
+
+#### General
+
+A tuple type is declared using the following syntax:
+
+```antlr
 tuple_type
     : '(' tuple_type_element_list ')'
     ;
@@ -62,164 +126,113 @@ tuple_type_element
     ;
 ```
 
-## Additions to [Types](../../spec/types.md)
+A ***tuple*** is an anonymous data structure type that contains an ordered sequence of two or more ***elements***. Each element is public. Each unique, ordered combination of element types designates a distinct tuple type.
 
-> The following sections should be added after [Nullable types](../../spec/types.md#nullable-types) (at the end of the current *Value types* section.)
+An element in a tuple is accessed using the [member-access operator `.`](../../spec/expressions.md#Member-access).
 
-### Tuple types
-
-Tuple types are declared with the following syntax:
+Given the following,
 
 ```csharp
-public (int sum, int count) Tally(IEnumerable<int> values) { ... }
-
-var t = Tally(myValues);
-Console.WriteLine($"Sum: {t.sum}, count: {t.count}");
- ```
-
-The syntax `(int sum, int count)` indicates an anonymous data structure with public fields of the given names and types, referred to as *tuple*.
-
-Tuple values can be created using *tuple literals*:
-
-```csharp
-var t1 = (sum: 0, count: 1);
-var t2 = (0, 1);     // field names are optional
+(int code, string message) pair1 = (3, "hello");
+System.Console.WriteLine("first = {0}, second = {1}", pair1.code, pair1.message);
 ```
 
-Tuples cannot be created with the `new` operator. The `new` operator can be used to initialize arrays of tuples, or nullable tuples:
+the syntax `(int code, string message)` declares a tuple type having two elements, each with the given type and name.
+
+As shown, a tuple can be initialized using a [tuple literal](../../spec/lexical-structure.md#Tuple-literals).
+
+An element need not have a name.
+
+The type of a tuple is the ordered set of types of its elements along with their names. An element without a name is unnamed. If a tuple declarator contains the type of all the tuple's elements, that set of types cannot be changed or augmented based on the context in which it is used; otherwise, element type information shall be inferred from the usage context. Likewise for element names.
+
+A tuple's type can be declared explicitly. Consider the following declarations:
 
 ```csharp
-var array = new (int x, int y)[10];
-var nullable = new (int x, int y)?();
+(int, string) pair2 = (2, "Goodbye"); 
+(int code, string message) pair3 = (2, "Goodbye");
+(int code, string) pair4 = (2, "Goodbye"); 
+(int, string message) pair5 = (2, "Goodbye"); 
+(int code, string) pair6 = (2, message: "Goodbye");	// Warning: can't give a name to the second element
+(int code, string) pair7 = (newName: 2, "Goodbye");	// Warning: can't change the name of element code
 ```
 
-Tuples can be created for a known target type:
+The type of `pair2` is `(int, string)` with unknown element names. Similarly, the type of `pair3` is `(int, string)` but this time with the element names `code` and `message`, respectively. For `pair4` and `pair5`, one element is named, the other not.
+
+In the case of `pair6`, the second element is declared as being unanmed, and any attempt to provide a name in an initializing context shall be ignored. Likewise for any attempt to change an element's name, as in the case of `pair7`.
+
+A tuple's type can be wholely inferred from the context in which it is used. Consider the following declarations:
 
 ```csharp
-public (int sum, int count) Tally(IEnumerable<int> values)
-{
-    var s = 0; var c = 0;
-    foreach (var value in values) { s += value; c++; }
-    return (s, c); // target typed to (int sum, int count)
-}
+var pair10 = (1, "Hello"); 
+var pair11 = (code: 1, message: "Hello");
+var pair12 = (code: 1, "Hello");
+var pair13 = (1, message: "Hello");
 ```
 
-Specifying field names is optional. Duplicate names are disallowed.
+The type of `pair10` is inferred from the initializer's tuple literal, as `(int, string)` with unknown element names. Similarly, the type of `pair11` is inferred from the initialer's tuple literal, as `(int, string)` but this time with the element names `code` and `message`, respectively. For `pair12` and `pair13`, the element types are inferred, and one element is named, the other not.
 
+Elements within a tuple type shall have distinct names or be unnamed.
+
+\[Example:
 ```csharp
-var t1 = (sum: 0, count: 1); // OK, all fields are named
-var t2 = (sum: 0, 1);       // Ok, implies (int sum, int);
-var t3 = (sum: 0, sum: 1);  // error! duplicate names.
+(int e1, float e1) t = (10, 1.2);					// Error: both elements have the same name
+(int e1, (int e1, int e2) e2) t = (10, (20, 30));	// OK: element names in each tuple type are distinct
 ```
+end example\]
 
-### Tuple literals
+The name of any element in a partial type declaration shall be the same for an element in the same position in any other partial declaration for that type.
 
-```csharp
-var t1 = (0, 2);              // infer tuple type from values
-var t2 = (sum: 0, count: 1);  // infer tuple type from names and values
-```
-
-A tuple literal is "target typed" whenever possible. The tuple literal has a "conversion from expression" to any tuple type, as long as the element expressions of the tuple literal have an implicit conversion to the element types of the tuple type.
-
-```csharp
-(string name, byte age) t = (null, 5); // Ok: the expressions null and 5 convert to string and byte
-```
-
-In cases where the tuple literal is not part of a conversion, it acquires its "natural type", which means a tuple type where the element types are the types of the constituent expressions. Since not all expressions have types, not all tuple literals have a natural type either:
-
-```csharp
-var t = ("John", 5); // Ok: the type of t is (string, int)
-var t = (null, 5); //   Error: null doesn't have a type
-```
-
-A tuple literal may include names, in which case they become part of the natural type:
-
-```csharp
-var t = (name: "John", age: 5); // The type of t is (string name, int age)
-```
-
-Tuple literals may be deconstructed directly:
-
-```csharp
-(string x, byte y, var z) = (null, 1, 2);
-(string x, byte y) t = (null, 1);
-```
-
-Or for deconstructing assignment:
-
-```csharp
-string x;
-byte y;
-
-(x, y) = (null, 1);
-(x, y) = (y, x); // swap!
-```
-
-The evaluation order of deconstruction assignment expressions is "breadth first":
-
-1. Evaluate the LHS: Evaluate each of the expressions inside of it one by one, left to right, to yield side effects and establish a storage location for each.
-1. Evaluate the RHS: Evaluate each of the expressions inside of it one by one, left to right to yield side effects
-1. Convert each of the RHS expressions to the LHS types expected, one by one, left to right.
-1. Assign each of the conversion results from 3 to the storage locations found in 
-
-> **Note to reviewers**: I found this in the LDM notes for July 13-16, 2016. I don't think it is still accurate:
-
-A deconstructing assignment is a *statement-expression* whose type could be `void`.
-
-### Duality with underlying type
-
-Tuples map to underlying types of particular names.
-
-```csharp
-System.ValueTuple<T1, T2>
-System.ValueTuple<T1, T2, T3>
-...
-System.ValueTuple<T1, T2, T3,..., T7, TRest>
-```
-
-Tuple types behave exactly like underlying types. The only additional enhancement is the more expressive field names given by the programmer.
-
-```csharp
-var t = (sum: 0, count: 1);
-t.sum   = 1;        // sum   is the name for the field #1
-t.Item1 = 1;        // Item1 is the name of underlying field #1 and is also available
-
-var t1 = (0, 1); // tuple omits the field names.
-t.Item1 = 1;     // underlying field name is still available
-
-t.ToString();     // ToString on the underlying tuple type is called.
-
-System.ValueTuple<int, int> vt = t; // identity conversion
-(int moo, int boo) t2 = vt;         // identity conversion
-
-```
-
-Because of the dual nature of tuples, it is not allowed to assign field names that overlap with preexisting member names of the underlying type. The only exception is the use of predefined `Item1`, `Item2`,...`ItemN` at corresponding position N, since that would not be ambiguous.
-
-```csharp
-var t =  (ToString: 0, ObjectEquals: 1);  // error: names match underlying member names
-var t1 = (Item1: 0, Item2: 1);            // valid
-var t2 = (misc: 0, Item1: 1);             // error: "Item1" was used in a wrong position
-```
-
-If the tuple is bigger than the limit of 7, the implementation will nest the "tail" as a tuple into the eighth element recursively. This nesting is visible by accessing the `Rest` field of a tuple, but that field my be hidden from e.g. auto-completion, just as the `ItemX` field names may be hidden but allowed when a tuple has named elements.
-
-A well formed "big tuple" will have names `Item1` etc. all the way up to the number of tuple elements, even though the underlying type doesn't physically have those fields directly defined. The same goes for the tuple returned from the `Rest` field, only with the numbers "shifted" appropriately.
-
-For tuple element names occurring in partial type declarations, the names must be the same.
-
+\[Example:
 ```csharp
 partial class C : IEnumerable<(string name, int age)> { ... }
-partial class C : IEnumerable<(string fullname, int)> { ... } // error: names must be specified and the same
+partial class C : IEnumerable<(string fullname, int)> { ... } // Error: names must be specified and the same
 ```
+end example\]
 
-When tuple elements names are used in overridden signatures, or implementations of interface methods, tuple element names in parameter and return types must be preserved. It is an error for the same generic interface to be inherited or implemented twice with identity convertible type arguments that have conflicting tuple element names
+A tuple cannot be created with the `new` operator. However, the `new` operator can be used to create and initialize an array of tuple or a nullable tuple.
 
-> note:
->
-> For the purpose of overloading, overriding and hiding, tuples of the same types and lengths as well as their underlying ValueTuple types are considered equivalent. All other differences are immaterial. When overriding a member it is permitted to use tuple types with same or different field names than in the base member.
->
-> A situation where same field names are used for non-matching fields between base and derived member signatures, a warning is reported by the compiler.  
+#### A tuple's underlying type
+
+Each tuple type maps to an underlying type. Specifically, a tuple having two elements maps to `System.ValueTuple<T1, T2>`, one with three elements maps to `System.ValueTuple<T1, T2, T3>`, and so on, up to seven elements. Tuple types having eight or more elements map to `System.ValueTuple<T1, T2, T3,..., T7, TRest>`. The first element in an underlying type has the public name `Item1`, the second `Item2`, and so on through `Item7`. Any elements beyond seven can be accesed as a group by the public name `Rest`, whose type is "tuple of the remaining elements". Alternatively, those elements can be accessed individually using the names `Item8` through `Item`*N*, where *N* is the total number of elements, even though the underlying type has no such names defined.
+
+A tuple type shall behave exactly like its underlying type. The only additional enhancement in the tuple type case is the ability to provide a more expressive name for each element.
+
+\[Example:
+```csharp
+var t1 = (sum: 0, 1);
+t1.sum   = 1;		// access the first element by its declared name
+t1.Item1 = 1;		// access the first element by its underlying name
+t1.Item2 = 3;		// access the second element by its underlying name
+
+System.ValueTuple<int, int> vt = t1;	// identity conversion
+
+ var t2 = (1, 2, 3, 4, 5, 6, 7, 8, 9);	// t2 is a System.ValueTuple<T1, T2, T3,..., T7, TRest>
+ var t3 = t4.Rest;						// t3 is a (int, int); that is, a System.ValueTuple<T1, T2>
+ System.Console.WriteLine("Item9 = {0}", t1.Item9);	// outputs 9 even though no such name Item9 exists!
+```
+end example\]
+
+**ISSUE:** Where will the type System.Value be defined (and its public names listed)?
+
+The name given explicitly to any element shall not be the same as any name in the underlying type, except that an explicit name may have the form `Item`*N* provided it corresponds position-wise with an element of the same name in the underlying type.
+
+\[Example:
+```csharp
+var t =  (ToString: 0, GetHashCode: 1);	// Error: names match underlying member names
+var t1 = (Item1: 0, Item2: 1);			// OK
+var t2 = (misc: 0, Item1: 1);			// Error: "Item1" used in a wrong position
+```
+end example\]
+
+#### Element names and overloading, overriding, and hiding
+
+When tuple element names are used in overridden signatures or implementations of interface methods, tuple element names in parameter and return types shall be preserved. It is an error for the same generic interface to be inherited or implemented twice with identity-convertible type arguments that have conflicting tuple element names.
+
+For the purpose of overloading, overriding and hiding, tuples of the same types and lengths as well as their underlying ValueTuple types shall be considered equivalent. All other differences are immaterial. When overriding a member it is permitted to use tuple types with the same names or names different than in the base member.
+
+**ISSUE:** Re the mention of "tuple length", which is not mentioned elsewhere; it seems to me that a tuple type includes an implied length based on the number of elements.
+
+If the same element name is used for non-matching elements in base and derived member signatures, the implementation shall issue a warning.  
 
 ```csharp
 class Base
@@ -228,60 +241,68 @@ class Base
 }
 class Derived : Base
 {
-    override void M1((int c, int d) arg){...} // valid override, signatures are equivalent
+    override void M1((int c, int d) arg){...}	// valid override, signatures are equivalent
 }
 class Derived2 : Derived 
 {
-    override void M1((int c1, int c) arg){...} // also valid, warning on possible misuse of name 'c' 
+    override void M1((int c1, int c) arg){...}	// also valid, warning on possible misuse of name 'c' 
 }
 
 class InvalidOverloading 
 {
     virtual void M1((int c, int d) arg){...}
-    virtual void M1((int x, int y) arg){...}        // invalid overload, signatures are eqivalent
-    virtual void M1(ValueTuple<int, int> arg){...}  // also invalid
+    virtual void M1((int x, int y) arg){...}		// invalid overload, signatures are eqivalent
+    virtual void M1(ValueTuple<int, int> arg){...}	// also invalid
 }
 ```
 
-> endnote.
+### Tuple element name erasure at runtime
 
-### Tuple field name erasure at runtime
+A tuple element name is not part of the runtime representation of a tuple of that type; an element's name is tracked only by the compiler. [*Note*: As a result, element names are not available to a third-party observer of a tuple instance (such as with reflection or dynamic code). *end note*]
 
-Tuple field names aren't part of the runtime representation of tuples, but are tracked only by the compiler. As a result, the field names will not be available to a 3rd party observer of a tuple instance - such as reflection or dynamic code.
+In alignment with the identity conversions, a boxed tuple shall not retain the names of the elements, and shall unbox to any tuple type that has the same element types in the same order.
 
-In alignment with the identity conversions, a boxed tuple does not retain the names of the fields and will unbox to any tuple type that has the same element types in the same order.
-
+\[Example:
 ```csharp
 object o = (a: 1, b: 2);           // boxing conversion
 var t = ((int moo, int boo))o;     // unboxing conversion
 ```
+end example\]
 
 ## Additions to [Variables](../../spec/variables.md)
 
-> The following text should be added at the end of the [Variables](../../spec/variables.md) section.
+> Add the following text at the end of the [Variables](../../spec/variables.md) section.
 
-### "Discards"
+**ISSUE:** see my commetns later w.r.t deconstruction, assignment, patterns, and section organization
 
-The `_` can be used as a *discard* under these rules:
+## Discards
 
-- A standalone `_` is a discard when no `_` is defined in scope.
-- A "designator" `var _` or `T _` in deconstruction, pattern matching and out vars is a discard.
-- Discards are like unassigned variables, and do not have a value. They can only occur in contexts where they are assigned to.
+**ISSUE:** We need a definition for "discard" 
 
-Examples:
+The identifier `_` can be used as a *discard* in the following circumstances:
 
+- When no identifier `_` is defined in the current scope.
+- A "designator" `var _` or `T _` in [deconstruction](XXX), [pattern matching](XXX) and [out vars](XXX).
+
+Like unassigned variables, discards do not have a value. A discard may only occur in contexts where it is assigned to.
+
+\[Example:
 ```csharp
-M(out _, out var _, out int _); // three out variable discards
-(_, var _, int _) = GetCoordinates(); // deconstruction into discards
-if (x is var _ && y is int _) { ... } // discards in patterns
+M(out _, out var _, out int _);			// three out variable discards
+(_, var _, int _) = GetCoordinates();	// deconstruction into discards
+if (x is var _ && y is int _) { ... }	// discards in patterns
 ```
+end example\]
 
 ## Changes to [Conversions](../spec/conversions.md)
 
-> The following text should be added to [Identity conversions](../../spec/conversions.md#identity-conversions), after the bullet point on `object` and `dynamic`:
+### Identity conversion
 
-* Element names are immaterial to tuple conversions. Tuples with the same types in the same order are identity convertible to each other or to and from corresponding underlying `ValueTuple` types, regardless of the names.
+> Add the following text to [Identity conversion](../../spec/conversions.md#identity-conversion), after the bullet point on `object` and `dynamic`:
 
+* Element names are immaterial to tuple conversions. Tuples with the same element type set in the same order are identity-convertible to each other or to and from corresponding underlying `ValueTuple` types, regardless of the names.
+
+\[Example:
 ```csharp
 var t = (sum: 0, count: 1);
 
@@ -290,36 +311,36 @@ System.ValueTuple<int, int> vt = t;  // identity conversion
 
 t2.moo = 1;
 ```
+end example\]
 
-> note:
->
-> An element name at one position on one side of a conversion, and the same name at another position on the other side almost certainly have bug in the code:
+In teh case in which an element name at one position on one side of a conversion, and the same name at a different position on the other side, the copmpiler shall issue a warning.
 
+\[Example:
 ```csharp
 (string first, string last) GetNames() { ... }
 (string last, string first) names = GetNames(); // Oops!
 ```
-
-> Compilers should issue a warning for the preceding code.
->
-> endnote.
+end example\]
 
 ### Boxing conversions
 
-> The following text should be added to [Boxing conversions](../../spec/conversions.md#boxing-conversions) after the first paragraph:
+> Add the following text to [Boxing conversions](../../spec/conversions.md#boxing-conversions) after the first paragraph:
 
-Tuples, like all value types, have a boxing conversion. Importantly, the names aren't part of the runtime representation of tuples, but are tracked only by the compiler. Thus, once you've "cast away" the names, you cannot recover them. In alignment with the identity conversions, a boxed tuple will unbox to any tuple type that has the same element types in the same order.
+Tuples have a boxing conversion. Importantly, the element names aren't part of the runtime representation of tuples, but are tracked only by the compiler. Thus, once element names have been "cast away", they cannot be recovered. In alignment with identity conversion, a boxed tuple unboxes to any tuple type that has the same element types in the same order.
 
 ### Tuple conversions
 
-> This section should be added after [Implicit enumeration conversions](../../spec/conversions.md#implicit-enumeration-conversions)
+> Add this section after [Implicit enumeration conversions](../../spec/conversions.md#implicit-enumeration-conversions)
 
-Tuple types and expressions support a variety of conversions by "lifting" conversions of the elements into overall *tuple conversion*.
-For the classification purpose, all element conversions are considered recursively. For example: To have an implicit conversion, all element expressions/types must have implicit conversions to the corresponding element types.
+Tuple types and expressions support a variety of conversions by "lifting" conversions of the elements into overall *tuple conversion*. For the classification purpose, all element conversions are considered recursively. For example, to have an implicit conversion, all element expressions/types shall have implicit conversions to the corresponding element types.
 
 Tuple conversions are *Standard Conversions* and therefore can stack with user-defined operators to form user-defined conversions.
 
+**ISSUE:** Is 'stack' a defined term in this context?
+
 An implicit tuple conversion is a standard conversion. It applies between two tuple types of equal arity when there is any implicit conversion between each corresponding pair of types.
+
+**ISSUE:** Re 'arity' does this mean number of elements, with their types and names? In any event, perhaps we should define this in terms of tuples and consistently use it throughout, as in, "The arity of a tuple is ...".
 
 An explicit tuple conversion is a standard conversion. It applies between two tuple types of equal arity when there is any explicit conversion between each corresponding pair of types.
 
@@ -329,13 +350,15 @@ On top of the member-wise conversions implied by target typing, implicit convers
 
 ### Target typing
 
-> This section should be added after [Anonymous function conversions and method group conversions](../../spec.md#Anonymous-function-conversions-and-method-group-conversions)
+> Add this section after [Anonymous function conversions and method group conversions](../../spec.md#Anonymous-function-conversions-and-method-group-conversions)
 
 A tuple literal is "target typed" when used in a context specifying a tuple type. The tuple literal has a "conversion from expression" to any tuple type, as long as the element expressions of the tuple literal have an implicit conversion to the element types of the tuple type.
 
+\[Example:
 ```csharp
 (string name, byte age) t = (null, 5); // Ok: the expressions null and 5 convert to string and byte
 ```
+end example\]
 
 A successful conversion from tuple expression to tuple type is classified as an *ImplicitTuple* conversion, unless the tuple's natural type matches the target type exactly, in such case it is an *Identity* conversion.
 
@@ -349,6 +372,8 @@ M1(("hi", "hello"));   // second overload is used. Implicit tuple conversion is 
 
 Target typing will "see through" nullable target types. A successful conversion from tuple expression to a nullable tuple type is classified as *ImplicitNullable* conversion.
 
+**ISSUE:** Replace "see through" with something not quoted.
+
 ```csharp
 ((int x, int y, int z)?, int t)? SpaceTime()
 {
@@ -360,31 +385,58 @@ Target typing will "see through" nullable target types. A successful conversion 
 
 ### Overload resolution and tuples with no natural types
 
-> The following text is added after after the bullet list in [Exactly matching expressions](../../spec/expressions.md#Exactly-matching-expressions):
+> Add the following text after the bullet list in [Exactly matching expressions](../../spec/expressions.md#Exactly-matching-expressions):
 
-The exact match rule for tuple expressions is based on the natural types of the constituent tuple arguments. The rule is mutually recursive with respect to other containing or contained expressions not in a possession of a natural type.
+The exact-match rule for tuple expressions is based on the natural types of the constituent tuple arguments. The rule is mutually recursive with respect to other containing or contained expressions not in a possession of a natural type.
+
+**ISSUE:** The use of "argument" here doesn't seem right; arguments are passed to methods! Should it be "elements" instead?
 
 ### Deconstruction expressions
 
-> This section should be added at the end of the [Expressions](../../spec/expressions.md) chapter.
+> Add this section at the end of the [Expressions](../../spec/expressions.md) chapter.
 
-Tuple deconstruction expressions receive and "split out" a tuple:
+A tuple-deconstruction expression copies from a source tuple zero or more of its element values to corresponding destinations.
 
-```csharp
-(var sum, var count) = Tally(myValues); // deconstruct result
-Console.WriteLine($"Sum: {sum}, count: {count}");  
+**ISSUE:** I whipped up the following grammar; it needs to be made correct/complete. I'm guessing we can leverage on existing productions. Also, destination can be a declaration of a new local variable (explicit or var), or it can be the name of an existing one. My tests show that destination_list can't contain a combination of the two, however.
+
+```antlr
+tuple_deconstruction_expression
+    : '(' destination_list ')'
+    ;
+    
+destination_list
+    : destination ',' destination
+    | destination_list ',' destination
+    ;
+    
+destination
+    : type identifier
+    ;
 ```
 
-The `_` wildcard indicates that the one or more of the tuple fields are discarded:
+**ISSUE:** Is this expression constrained to being only on the LHS of simple (compound?) assignment, where the RHS is a tuple having at least as many elements as positions indicated by the LHS? See also my issue later w.r.t "deconstruction assignment expressions".
 
+Element values are copied from the source tuple to the destinations. Each element's position is inferred from the destination position within *destination_list*. A destination with identifier `_` indicates that the corresponding element is discarded rather than being copied. The destination list shall accouint for every element in the tuple.
+
+\[Example:
 ```csharp
-(var sum, _) = Tally(myValues); // deconstruct result
-Console.WriteLine($"Sum: {sum}, count was ignored");  
+int code;
+string message;
+
+(code, message) = (10, "hello");				// copy both element values to existing variables
+(code, _) = (11, "Go!");						// copy element 1 to code and discard element 2
+(_, _) = (12, "Stop!");							// discard both element values
+(int code2, string message2) = (20, "left");	// copy both element values to newly created variables
+(code, string message3) = (21, "right");		// Error: can't mix existing and new variables
+(code, _) = (30, 2.5, (10, 20));			    // Error: can't deconstruct tuple of 3 elements into 2 values
+(code, _, _) = (30, 2.5, (10, 20));				// OK: deconstructing 3 elements into 3 values
 ```
+end example\]
 
-Any object may be deconstructed by providing an accessible `Deconstruct` method, either as a member or as an extension method. A `Deconstruct` method converts an object to a set of discrete values. The Deconstruct method "returns" the component values by use of individual `out` parameters. Deconstruct is overloadable.
+**ISSUE:** As this is an operator, what is the result type? `void`?
+**ISSUE:** Presumably the scope of any newly created variable is from the point of declaration on to the end of the block, or does this fall-out of saying its a local variable?
 
-The deconstructor pattern could be implemented as a member method, or an extension method:
+Any object may be deconstructed by providing an accessible `Deconstruct` method, either as a member or as an extension method. A `Deconstruct` method converts an object to a set of discrete values. The Deconstruct method "returns" the component values by use of individual `out` parameters. `Deconstruct` is overloadable. Consider the following:
 
 ```csharp
 class Name
@@ -399,33 +451,60 @@ static class Extensions
 }
 ```
 
-Overload resolution for `Deconstruct` methods considers only the arity of the `Deconstruct` method. If multiple `Deconstruct` methods of the same arity are accessible, the expression is ambiguous and a binding time error occurs.
+**ISSUE:** I think we need to say more about this code (which is not an example, but is intended to show/say just what is going on/needed).
 
-If necessary to satisfy implicit conversions of the tuple member types, the compiler passes temporary variables to the `Deconstruct` method, instead of the ones declared in the deconstruction. For example, if `p` has
+Overload resolution for `Deconstruct` methods considers only the arity of the `Deconstruct` method. If multiple `Deconstruct` methods of the same arity are accessible, the expression is ambiguous and a binding-time error shall occur.
+
+If necessary to satisfy implicit conversions of the tuple member types, the compiler passes temporary variables to the `Deconstruct` method, instead of the ones declared in the deconstruction. For example, if object `p` has the following method:
 
 ```csharp
 void Deconstruct(out byte x, out byte y) ...;
 ```
 
-The compiler translates
+the compiler translates
 
 ```csharp
 (int x, int y) = p;
 ```
 
-equivalently to:
+to:
 
 ```csharp
 p.Deconstruct(out byte __x, out byte __y);
 (int x, int y) = (__x, __y);
 ```
 
+The evaluation order of deconstruction assignment expressions is "breadth first":
+
+**ISSUE:** This is the first place I've seen deconstruction mentioned in the same breath as assignment. If deconstruction can only occur on the LHS of a (simple?, compound?) assignment, should deconstruction be covered under assignment rather than in its own section? If the two are in spearate sections, the expression grammar needs to have the new production, tuple_deconstruction_expression, plugged into it. From my experience with tuples, patterns, and _ wildcards in other languages, I'm thinking that the V7.0 support for tuple deconstruction is the beginning of a more general pattern support mechanism to come later. If that is the case, perhaps we should admit that and start using pattern-related terminology and organization. If so, that suggests tuple deconstruction should be separate from the assignment operator, in a (pre-)patterns section that will be expanded over future spec versions.
+
+1. Evaluate the LHS: Evaluate each of the expressions inside of it one by one, left to right, to yield side effects and establish a storage location for each.
+1. Evaluate the RHS: Evaluate each of the expressions inside of it one by one, left to right to yield side effects
+1. Convert each of the RHS expressions to the LHS types expected, one by one, left to right.
+1. Assign each of the conversion results from Step 3 to the storage locations found in (???)
+
+> **Note to reviewers**: I found this in the LDM notes for July 13-16, 2016. I don't think it is still accurate:
+
+**ISSUE:** flesh out the following example
+
+\[Example:
+```csharp
+string x;
+byte y;
+
+(x, y) = (y, x); // swap!
+```
+end example\]
+
+A deconstructing assignment is a *statement-expression* whose type could be `void`.
+
 ### Additions to [Classes](../../spec/classes.md)
 
-> The following note should be added to the end of the section on [extension methods](../../spec/classes.md#extension-methods):
+### Extension methods
 
-> note: 
->Extension methods on a tuple type apply to tuples with different element names:
+> Add the following note to the end of the section on [extension methods](../../spec/classes.md#extension-methods):
+
+[*Note*: Extension methods on a tuple type apply to tuples with different element names:
 
 ```csharp
 static void M(this (int x, int y) t) { ... }
@@ -433,5 +512,6 @@ static void M(this (int x, int y) t) { ... }
 (int a, int b) t = ...;
 t.M(); // Sure
 ```
+*endnote*].
 
-> endnote.
+**ISSUE:** Explain what the comment "Sure" means.

--- a/proposals/csharp-7.0/tuples.md
+++ b/proposals/csharp-7.0/tuples.md
@@ -68,7 +68,7 @@ tuple_type_element
 
 ### Tuple types
 
-Tuple types are declared with a syntax very similar to a parameter list:
+Tuple types are declared with the following syntax:
 
 ```csharp
 public (int sum, int count) Tally(IEnumerable<int> values) { ... }
@@ -157,10 +157,10 @@ byte y;
 
 The evaluation order of deconstruction assignment expressions is "breadth first":
 
-1. **Evaluate the LHS**. That means evaluate each of the expressions inside of it one by one, left to right, to yield side effects and establish a storage location for each.
-1. **Evaluate the RHS**. That means evaluate each of the expressions inside of it one by one, left to right to yield side effects
+1. Evaluate the LHS: Evaluate each of the expressions inside of it one by one, left to right, to yield side effects and establish a storage location for each.
+1. Evaluate the RHS: Evaluate each of the expressions inside of it one by one, left to right to yield side effects
 1. Convert each of the RHS expressions to the LHS types expected, one by one, left to right.
-1. Assign each of the conversion results from 3 to the storage locations found in 1.
+1. Assign each of the conversion results from 3 to the storage locations found in 
 
 > **Note to reviewers**: I found this in the LDM notes for July 13-16, 2016. I don't think it is still accurate:
 
@@ -168,7 +168,7 @@ A deconstructing assignment is a *statement-expression* whose type could be `voi
 
 ### Duality with underlying type
 
-Tuples map to underlying types of particular names -
+Tuples map to underlying types of particular names.
 
 ```csharp
 System.ValueTuple<T1, T2>
@@ -177,17 +177,17 @@ System.ValueTuple<T1, T2, T3>
 System.ValueTuple<T1, T2, T3,..., T7, TRest>
 ```
 
-Tuple types behave exactly like underlying types with only additional optional enhancement of the more expressive field names given by the programmer.
+Tuple types behave exactly like underlying types. The only additional enhancement is the more expressive field names given by the programmer.
 
 ```csharp
 var t = (sum: 0, count: 1);
 t.sum   = 1;        // sum   is the name for the field #1
 t.Item1 = 1;        // Item1 is the name of underlying field #1 and is also available
 
-var t1 = (0, 1);    // tuple omits the field names.
-t.Item1 = 1;        // underlying field name is still available
+var t1 = (0, 1); // tuple omits the field names.
+t.Item1 = 1;     // underlying field name is still available
 
-t.ToString();        // ToString on the underlying tuple type is called.
+t.ToString();     // ToString on the underlying tuple type is called.
 
 System.ValueTuple<int, int> vt = t; // identity conversion
 (int moo, int boo) t2 = vt;         // identity conversion
@@ -202,7 +202,7 @@ var t1 = (Item1: 0, Item2: 1);            // valid
 var t2 = (misc: 0, Item1: 1);             // error: "Item1" was used in a wrong position
 ```
 
-If the tuple is bigger than the limit of 7, the implementation will nest the "tail" as a tuple into the eighth element recursively. This nesting is visible by accessing the `Rest` field of a tuple, but that field is considered an implementation detail, and is hidden from e.g. auto-completion, just as the `ItemX` field names are hidden but allowed when a tuple has named elements.
+If the tuple is bigger than the limit of 7, the implementation will nest the "tail" as a tuple into the eighth element recursively. This nesting is visible by accessing the `Rest` field of a tuple, but that field my be hidden from e.g. auto-completion, just as the `ItemX` field names may be hidden but allowed when a tuple has named elements.
 
 A well formed "big tuple" will have names `Item1` etc. all the way up to the number of tuple elements, even though the underlying type doesn't physically have those fields directly defined. The same goes for the tuple returned from the `Rest` field, only with the numbers "shifted" appropriately.
 
@@ -215,11 +215,11 @@ partial class C : IEnumerable<(string fullname, int)> { ... } // error: names mu
 
 When tuple elements names are used in overridden signatures, or implementations of interface methods, tuple element names in parameter and return types must be preserved. It is an error for the same generic interface to be inherited or implemented twice with identity convertible type arguments that have conflicting tuple element names
 
-### Overloading, overriding, hiding
-
-For the purpose of overloading, overriding and hiding, tuples of the same types and lengths as well as their underlying ValueTuple types are considered equivalent. All other differences are immaterial. When overriding a member it is permitted to use tuple types with same or different field names than in the base member.
-
-A situation where same field names are used for non-matching fields between base and derived member signatures, a warning is reported by the compiler.  
+> note:
+>
+> For the purpose of overloading, overriding and hiding, tuples of the same types and lengths as well as their underlying ValueTuple types are considered equivalent. All other differences are immaterial. When overriding a member it is permitted to use tuple types with same or different field names than in the base member.
+>
+> A situation where same field names are used for non-matching fields between base and derived member signatures, a warning is reported by the compiler.  
 
 ```csharp
 class Base
@@ -242,6 +242,8 @@ class InvalidOverloading
     virtual void M1(ValueTuple<int, int> arg){...}  // also invalid
 }
 ```
+
+> endnote.
 
 ### Tuple field name erasure at runtime
 
@@ -289,20 +291,24 @@ System.ValueTuple<int, int> vt = t;  // identity conversion
 t2.moo = 1;
 ```
 
-That said, if you have an element name at one position on one side of a conversion, and the same name at another position on the other side, you almost certainly have bug in your code:
+> note:
+>
+> An element name at one position on one side of a conversion, and the same name at another position on the other side almost certainly have bug in the code:
 
 ```csharp
 (string first, string last) GetNames() { ... }
 (string last, string first) names = GetNames(); // Oops!
 ```
 
-Compilers should issue a warning for the preceding code.
+> Compilers should issue a warning for the preceding code.
+>
+> endnote.
 
 ### Boxing conversions
 
 > The following text should be added to [Boxing conversions](../../spec/conversions.md#boxing-conversions) after the first paragraph:
 
-As a *value_type*, tuples naturally have a boxing conversion. Importantly, the names aren't part of the runtime representation of tuples, but are tracked only by the compiler. Thus, once you've "cast away" the names, you cannot recover them. In alignment with the identity conversions, a boxed tuple will unbox to any tuple type that has the same element types in the same order.
+Tuples, like all value types, have a boxing conversion. Importantly, the names aren't part of the runtime representation of tuples, but are tracked only by the compiler. Thus, once you've "cast away" the names, you cannot recover them. In alignment with the identity conversions, a boxed tuple will unbox to any tuple type that has the same element types in the same order.
 
 ### Tuple conversions
 
@@ -313,20 +319,13 @@ For the classification purpose, all element conversions are considered recursive
 
 Tuple conversions are *Standard Conversions* and therefore can stack with user-defined operators to form user-defined conversions.
 
-A tuple conversion can be classified as a valid instance conversion for an extension method invocation as long as all element conversions are applicable as instance conversions.
-
-On top of the member-wise conversions implied by target typing, we can certainly allow implicit conversions between tuple types themselves.
-
-Specifically, covariance seems straightforward, because the tuples are value types: As long as each member of the assigned tuple is assignable to the type of the corresponding member of the receiving tuple, things should be good.
-
 An implicit tuple conversion is a standard conversion. It applies between two tuple types of equal arity when there is any implicit conversion between each corresponding pair of types.
 
 An explicit tuple conversion is a standard conversion. It applies between two tuple types of equal arity when there is any explicit conversion between each corresponding pair of types.
 
-```csharp
-(double sum, long count) weaken = Tally(...); // why not?
-(int s, int c) rename = Tally(...) // why not?
-```
+A tuple conversion can be classified as a valid instance conversion or an extension method invocation as long as all element conversions are applicable as instance conversions.
+
+On top of the member-wise conversions implied by target typing, implicit conversions between tuple types themselves are allowed.
 
 ### Target typing
 
@@ -338,25 +337,7 @@ A tuple literal is "target typed" when used in a context specifying a tuple type
 (string name, byte age) t = (null, 5); // Ok: the expressions null and 5 convert to string and byte
 ```
 
-In cases where the tuple literal is not part of a conversion, a tuple is used by its "natural type", which means a tuple type where the element types are the types of the constituent expressions. Since not all expressions have types, not all tuple literals have a natural type either:
-
-```csharp
-var t = ("John", 5);              //   Ok: the type of t is (string, int)
-var t = (null, 5);                //   Error: tuple expression doesn't have a type because null does not have a type
-((1,2, null), 5).ToString();      //   Error: tuple expression doesn't have a type
-
-ImmutableArray.Create((()=>1, 1));               //   Error: tuple expression doesn't have a type because lambda does not have a type
-ImmutableArray.Create(((Func<int>)(()=>1), 1)); //   ok
-```
-
-A tuple literal may include names, in which case they become part of the natural type:
-
-```csharp
-var t = (name: "John", age: 5); // The type of t is (string name, int age)
-t.age++;                        // t has field named age.
-```
-
-A successful conversion from tuple expression to tuple type is classified as an *ImplicitTuple* conversion, unless tuple's natural type matches the target type exactly, in such case it is an *Identity* conversion.
+A successful conversion from tuple expression to tuple type is classified as an *ImplicitTuple* conversion, unless the tuple's natural type matches the target type exactly, in such case it is an *Identity* conversion.
 
 ```csharp
 void M1((int x, int y) arg){...};
@@ -401,8 +382,6 @@ The `_` wildcard indicates that the one or more of the tuple fields are discarde
 Console.WriteLine($"Sum: {sum}, count was ignored");  
 ```
 
-> Note: Should the `_` be added as a token? How was that resolved?
-
 Any object may be deconstructed by providing an accessible `Deconstruct` method, either as a member or as an extension method. A `Deconstruct` method converts an object to a set of discrete values. The Deconstruct method "returns" the component values by use of individual `out` parameters. Deconstruct is overloadable.
 
 The deconstructor pattern could be implemented as a member method, or an extension method:
@@ -445,9 +424,8 @@ p.Deconstruct(out byte __x, out byte __y);
 
 > The following note should be added to the end of the section on [extension methods](../../spec/classes.md#extension-methods):
 
-Note: Extension methods
-
-on a tuple type apply to tuples with different element names:
+> note: 
+>Extension methods on a tuple type apply to tuples with different element names:
 
 ```csharp
 static void M(this (int x, int y) t) { ... }
@@ -455,3 +433,5 @@ static void M(this (int x, int y) t) { ... }
 (int a, int b) t = ...;
 t.M(); // Sure
 ```
+
+> endnote.

--- a/proposals/csharp-7.0/tuples.md
+++ b/proposals/csharp-7.0/tuples.md
@@ -1,0 +1,457 @@
+# Tuples 
+
+This proposal specifies the changes required to the [C# 6.0 (draft) Language specification](../../spec/introduction.md) to support *Tuples* as a new [value type](../../spec/types.md#value-types).
+
+## Changes to [Lexical structure](../../spec/lexical-structure.md)
+
+> The grammar for [Literals](../../spec/lexical-structure.md#literals) is extended to include `tuple_literal`:
+
+```antlr
+literal
+    : boolean_literal
+    | integer_literal
+    | real_literal
+    | character_literal
+    | string_literal
+    | null_literal
+    | tuple_literal // new
+    ;
+
+tuple_literal
+    : '(' tuple_literal_element_list ')'
+    ;
+
+tuple_literal_element_list
+    : tuple_literal_element ',' tuple_literal_element
+    | tuple_literal_element_list ',' tuple_literal_element
+    ;
+
+tuple_literal_element
+    : ( identifier ':' )? expression
+    ;
+```
+
+Note that because it is not a constant expression, a tuple literal cannot be used as default value for an optional parameter.
+
+## Changes to [Types](../../spec/types.md)
+
+> The first paragraph of [Value types](../../spec/types.md#value-types) is replaced with the following text:
+
+A value type is either a `struct` type, an enumeration type, or a tuple type. C# provides a set of predefined struct types called the ***simple types***. The simple types are identified through reserved words.
+
+> The `value_type` grammar is updated to include `tuple_type`:
+
+```antlr
+value_type
+    : struct_type
+    | enum_type
+    | tuple_type // new
+    ;
+
+tuple_type
+    : '(' tuple_type_element_list ')'
+    ;
+    
+tuple_type_element_list
+    : tuple_type_element ',' tuple_type_element
+    | tuple_type_element_list ',' tuple_type_element
+    ;
+    
+tuple_type_element
+    : type identifier?
+    ;
+```
+
+## Additions to [Types](../../spec/types.md)
+
+> The following sections should be added after [Nullable types](../../spec/types.md#nullable-types) (at the end of the current *Value types* section.)
+
+### Tuple types
+
+Tuple types are declared with a syntax very similar to a parameter list:
+
+```csharp
+public (int sum, int count) Tally(IEnumerable<int> values) { ... }
+
+var t = Tally(myValues);
+Console.WriteLine($"Sum: {t.sum}, count: {t.count}");
+ ```
+
+The syntax `(int sum, int count)` indicates an anonymous data structure with public fields of the given names and types, referred to as *tuple*.
+
+Tuple values can be created using *tuple literals*:
+
+```csharp
+var t1 = (sum: 0, count: 1);
+var t2 = (0, 1);     // field names are optional
+```
+
+Tuples cannot be created with the `new` operator. The `new` operator can be used to initialize arrays of tuples, or nullable tuples:
+
+```csharp
+var array = new (int x, int y)[10];
+var nullable = new (int x, int y)?();
+```
+
+Tuples can be created for a known target type:
+
+```csharp
+public (int sum, int count) Tally(IEnumerable<int> values)
+{
+    var s = 0; var c = 0;
+    foreach (var value in values) { s += value; c++; }
+    return (s, c); // target typed to (int sum, int count)
+}
+```
+
+Specifying field names is optional. Duplicate names are disallowed.
+
+```csharp
+var t1 = (sum: 0, count: 1); // OK, all fields are named
+var t2 = (sum: 0, 1);       // Ok, implies (int sum, int);
+var t3 = (sum: 0, sum: 1);  // error! duplicate names.
+```
+
+### Tuple literals
+
+```csharp
+var t1 = (0, 2);              // infer tuple type from values
+var t2 = (sum: 0, count: 1);  // infer tuple type from names and values
+```
+
+A tuple literal is "target typed" whenever possible. The tuple literal has a "conversion from expression" to any tuple type, as long as the element expressions of the tuple literal have an implicit conversion to the element types of the tuple type.
+
+```csharp
+(string name, byte age) t = (null, 5); // Ok: the expressions null and 5 convert to string and byte
+```
+
+In cases where the tuple literal is not part of a conversion, it acquires its "natural type", which means a tuple type where the element types are the types of the constituent expressions. Since not all expressions have types, not all tuple literals have a natural type either:
+
+```csharp
+var t = ("John", 5); // Ok: the type of t is (string, int)
+var t = (null, 5); //   Error: null doesn't have a type
+```
+
+A tuple literal may include names, in which case they become part of the natural type:
+
+```csharp
+var t = (name: "John", age: 5); // The type of t is (string name, int age)
+```
+
+Tuple literals may be deconstructed directly:
+
+```csharp
+(string x, byte y, var z) = (null, 1, 2);
+(string x, byte y) t = (null, 1);
+```
+
+Or for deconstructing assignment:
+
+```csharp
+string x;
+byte y;
+
+(x, y) = (null, 1);
+(x, y) = (y, x); // swap!
+```
+
+The evaluation order of deconstruction assignment expressions is "breadth first":
+
+1. **Evaluate the LHS**. That means evaluate each of the expressions inside of it one by one, left to right, to yield side effects and establish a storage location for each.
+1. **Evaluate the RHS**. That means evaluate each of the expressions inside of it one by one, left to right to yield side effects
+1. Convert each of the RHS expressions to the LHS types expected, one by one, left to right.
+1. Assign each of the conversion results from 3 to the storage locations found in 1.
+
+> **Note to reviewers**: I found this in the LDM notes for July 13-16, 2016. I don't think it is still accurate:
+
+A deconstructing assignment is a *statement-expression* whose type could be `void`.
+
+### Duality with underlying type
+
+Tuples map to underlying types of particular names -
+
+```csharp
+System.ValueTuple<T1, T2>
+System.ValueTuple<T1, T2, T3>
+...
+System.ValueTuple<T1, T2, T3,..., T7, TRest>
+```
+
+Tuple types behave exactly like underlying types with only additional optional enhancement of the more expressive field names given by the programmer.
+
+```csharp
+var t = (sum: 0, count: 1);
+t.sum   = 1;        // sum   is the name for the field #1
+t.Item1 = 1;        // Item1 is the name of underlying field #1 and is also available
+
+var t1 = (0, 1);    // tuple omits the field names.
+t.Item1 = 1;        // underlying field name is still available
+
+t.ToString();        // ToString on the underlying tuple type is called.
+
+System.ValueTuple<int, int> vt = t; // identity conversion
+(int moo, int boo) t2 = vt;         // identity conversion
+
+```
+
+Because of the dual nature of tuples, it is not allowed to assign field names that overlap with preexisting member names of the underlying type. The only exception is the use of predefined `Item1`, `Item2`,...`ItemN` at corresponding position N, since that would not be ambiguous.
+
+```csharp
+var t =  (ToString: 0, ObjectEquals: 1);  // error: names match underlying member names
+var t1 = (Item1: 0, Item2: 1);            // valid
+var t2 = (misc: 0, Item1: 1);             // error: "Item1" was used in a wrong position
+```
+
+If the tuple is bigger than the limit of 7, the implementation will nest the "tail" as a tuple into the eighth element recursively. This nesting is visible by accessing the `Rest` field of a tuple, but that field is considered an implementation detail, and is hidden from e.g. auto-completion, just as the `ItemX` field names are hidden but allowed when a tuple has named elements.
+
+A well formed "big tuple" will have names `Item1` etc. all the way up to the number of tuple elements, even though the underlying type doesn't physically have those fields directly defined. The same goes for the tuple returned from the `Rest` field, only with the numbers "shifted" appropriately.
+
+For tuple element names occurring in partial type declarations, the names must be the same.
+
+```csharp
+partial class C : IEnumerable<(string name, int age)> { ... }
+partial class C : IEnumerable<(string fullname, int)> { ... } // error: names must be specified and the same
+```
+
+When tuple elements names are used in overridden signatures, or implementations of interface methods, tuple element names in parameter and return types must be preserved. It is an error for the same generic interface to be inherited or implemented twice with identity convertible type arguments that have conflicting tuple element names
+
+### Overloading, overriding, hiding
+
+For the purpose of overloading, overriding and hiding, tuples of the same types and lengths as well as their underlying ValueTuple types are considered equivalent. All other differences are immaterial. When overriding a member it is permitted to use tuple types with same or different field names than in the base member.
+
+A situation where same field names are used for non-matching fields between base and derived member signatures, a warning is reported by the compiler.  
+
+```csharp
+class Base
+{
+    virtual void M1(ValueTuple<int, int> arg){...}
+}
+class Derived : Base
+{
+    override void M1((int c, int d) arg){...} // valid override, signatures are equivalent
+}
+class Derived2 : Derived 
+{
+    override void M1((int c1, int c) arg){...} // also valid, warning on possible misuse of name 'c' 
+}
+
+class InvalidOverloading 
+{
+    virtual void M1((int c, int d) arg){...}
+    virtual void M1((int x, int y) arg){...}        // invalid overload, signatures are eqivalent
+    virtual void M1(ValueTuple<int, int> arg){...}  // also invalid
+}
+```
+
+### Tuple field name erasure at runtime
+
+Tuple field names aren't part of the runtime representation of tuples, but are tracked only by the compiler. As a result, the field names will not be available to a 3rd party observer of a tuple instance - such as reflection or dynamic code.
+
+In alignment with the identity conversions, a boxed tuple does not retain the names of the fields and will unbox to any tuple type that has the same element types in the same order.
+
+```csharp
+object o = (a: 1, b: 2);           // boxing conversion
+var t = ((int moo, int boo))o;     // unboxing conversion
+```
+
+## Additions to [Variables](../../spec/variables.md)
+
+> The following text should be added at the end of the [Variables](../../spec/variables.md) section.
+
+### "Discards"
+
+The `_` can be used as a *discard* under these rules:
+
+- A standalone `_` is a discard when no `_` is defined in scope.
+- A "designator" `var _` or `T _` in deconstruction, pattern matching and out vars is a discard.
+- Discards are like unassigned variables, and do not have a value. They can only occur in contexts where they are assigned to.
+
+Examples:
+
+```csharp
+M(out _, out var _, out int _); // three out variable discards
+(_, var _, int _) = GetCoordinates(); // deconstruction into discards
+if (x is var _ && y is int _) { ... } // discards in patterns
+```
+
+## Changes to [Conversions](../spec/conversions.md)
+
+> The following text should be added to [Identity conversions](../../spec/conversions.md#identity-conversions), after the bullet point on `object` and `dynamic`:
+
+* Element names are immaterial to tuple conversions. Tuples with the same types in the same order are identity convertible to each other or to and from corresponding underlying `ValueTuple` types, regardless of the names.
+
+```csharp
+var t = (sum: 0, count: 1);
+
+System.ValueTuple<int, int> vt = t;  // identity conversion
+(int moo, int boo) t2 = vt;          // identity conversion
+
+t2.moo = 1;
+```
+
+That said, if you have an element name at one position on one side of a conversion, and the same name at another position on the other side, you almost certainly have bug in your code:
+
+```csharp
+(string first, string last) GetNames() { ... }
+(string last, string first) names = GetNames(); // Oops!
+```
+
+Compilers should issue a warning for the preceding code.
+
+### Boxing conversions
+
+> The following text should be added to [Boxing conversions](../../spec/conversions.md#boxing-conversions) after the first paragraph:
+
+As a *value_type*, tuples naturally have a boxing conversion. Importantly, the names aren't part of the runtime representation of tuples, but are tracked only by the compiler. Thus, once you've "cast away" the names, you cannot recover them. In alignment with the identity conversions, a boxed tuple will unbox to any tuple type that has the same element types in the same order.
+
+### Tuple conversions
+
+> This section should be added after [Implicit enumeration conversions](../../spec/conversions.md#implicit-enumeration-conversions)
+
+Tuple types and expressions support a variety of conversions by "lifting" conversions of the elements into overall *tuple conversion*.
+For the classification purpose, all element conversions are considered recursively. For example: To have an implicit conversion, all element expressions/types must have implicit conversions to the corresponding element types.
+
+Tuple conversions are *Standard Conversions* and therefore can stack with user-defined operators to form user-defined conversions.
+
+A tuple conversion can be classified as a valid instance conversion for an extension method invocation as long as all element conversions are applicable as instance conversions.
+
+On top of the member-wise conversions implied by target typing, we can certainly allow implicit conversions between tuple types themselves.
+
+Specifically, covariance seems straightforward, because the tuples are value types: As long as each member of the assigned tuple is assignable to the type of the corresponding member of the receiving tuple, things should be good.
+
+An implicit tuple conversion is a standard conversion. It applies between two tuple types of equal arity when there is any implicit conversion between each corresponding pair of types.
+
+An explicit tuple conversion is a standard conversion. It applies between two tuple types of equal arity when there is any explicit conversion between each corresponding pair of types.
+
+```csharp
+(double sum, long count) weaken = Tally(...); // why not?
+(int s, int c) rename = Tally(...) // why not?
+```
+
+### Target typing
+
+> This section should be added after [Anonymous function conversions and method group conversions](../../spec.md#Anonymous-function-conversions-and-method-group-conversions)
+
+A tuple literal is "target typed" when used in a context specifying a tuple type. The tuple literal has a "conversion from expression" to any tuple type, as long as the element expressions of the tuple literal have an implicit conversion to the element types of the tuple type.
+
+```csharp
+(string name, byte age) t = (null, 5); // Ok: the expressions null and 5 convert to string and byte
+```
+
+In cases where the tuple literal is not part of a conversion, a tuple is used by its "natural type", which means a tuple type where the element types are the types of the constituent expressions. Since not all expressions have types, not all tuple literals have a natural type either:
+
+```csharp
+var t = ("John", 5);              //   Ok: the type of t is (string, int)
+var t = (null, 5);                //   Error: tuple expression doesn't have a type because null does not have a type
+((1,2, null), 5).ToString();      //   Error: tuple expression doesn't have a type
+
+ImmutableArray.Create((()=>1, 1));               //   Error: tuple expression doesn't have a type because lambda does not have a type
+ImmutableArray.Create(((Func<int>)(()=>1), 1)); //   ok
+```
+
+A tuple literal may include names, in which case they become part of the natural type:
+
+```csharp
+var t = (name: "John", age: 5); // The type of t is (string name, int age)
+t.age++;                        // t has field named age.
+```
+
+A successful conversion from tuple expression to tuple type is classified as an *ImplicitTuple* conversion, unless tuple's natural type matches the target type exactly, in such case it is an *Identity* conversion.
+
+```csharp
+void M1((int x, int y) arg){...};
+void M1((object x, object y) arg){...};
+
+M1((1, 2));            // first overload is used. Identity conversion is better than implicit conversion.
+M1(("hi", "hello"));   // second overload is used. Implicit tuple conversion is better than no conversion.
+```
+
+Target typing will "see through" nullable target types. A successful conversion from tuple expression to a nullable tuple type is classified as *ImplicitNullable* conversion.
+
+```csharp
+((int x, int y, int z)?, int t)? SpaceTime()
+{
+    return ((1,2,3), 7);  // valid, implicit nullable conversion
+}
+```
+
+## Additions to [Expressions](../../spec/expressions.md)
+
+### Overload resolution and tuples with no natural types
+
+> The following text is added after after the bullet list in [Exactly matching expressions](../../spec/expressions.md#Exactly-matching-expressions):
+
+The exact match rule for tuple expressions is based on the natural types of the constituent tuple arguments. The rule is mutually recursive with respect to other containing or contained expressions not in a possession of a natural type.
+
+### Deconstruction expressions
+
+> This section should be added at the end of the [Expressions](../../spec/expressions.md) chapter.
+
+Tuple deconstruction expressions receive and "split out" a tuple:
+
+```csharp
+(var sum, var count) = Tally(myValues); // deconstruct result
+Console.WriteLine($"Sum: {sum}, count: {count}");  
+```
+
+The `_` wildcard indicates that the one or more of the tuple fields are discarded:
+
+```csharp
+(var sum, _) = Tally(myValues); // deconstruct result
+Console.WriteLine($"Sum: {sum}, count was ignored");  
+```
+
+> Note: Should the `_` be added as a token? How was that resolved?
+
+Any object may be deconstructed by providing an accessible `Deconstruct` method, either as a member or as an extension method. A `Deconstruct` method converts an object to a set of discrete values. The Deconstruct method "returns" the component values by use of individual `out` parameters. Deconstruct is overloadable.
+
+The deconstructor pattern could be implemented as a member method, or an extension method:
+
+```csharp
+class Name
+{
+    public void Deconstruct(out string first, out string last) { first = First; last = Last; }
+    ...
+}
+// or
+static class Extensions
+{
+    public static void Deconstruct(this Name name, out string first, out string last) { first = name.First; last = name.Last; }
+}
+```
+
+Overload resolution for `Deconstruct` methods considers only the arity of the `Deconstruct` method. If multiple `Deconstruct` methods of the same arity are accessible, the expression is ambiguous and a binding time error occurs.
+
+If necessary to satisfy implicit conversions of the tuple member types, the compiler passes temporary variables to the `Deconstruct` method, instead of the ones declared in the deconstruction. For example, if `p` has
+
+```csharp
+void Deconstruct(out byte x, out byte y) ...;
+```
+
+The compiler translates
+
+```csharp
+(int x, int y) = p;
+```
+
+equivalently to:
+
+```csharp
+p.Deconstruct(out byte __x, out byte __y);
+(int x, int y) = (__x, __y);
+```
+
+### Additions to [Classes](../../spec/classes.md)
+
+> The following note should be added to the end of the section on [extension methods](../../spec/classes.md#extension-methods):
+
+Note: Extension methods
+
+on a tuple type apply to tuples with different element names:
+
+```csharp
+static void M(this (int x, int y) t) { ... }
+
+(int a, int b) t = ...;
+t.M(); // Sure
+```


### PR DESCRIPTION
Fixes dotnet/docs#15046

This PR updates the C# 7.0 proposal document so that it could be used as a proposed delta to the C# standard.

To make these edits, I did the following:
1. Update the language to conform to the standard language.
1. Update the changes based on C# LDM meeting notes in this repo, and the dotnet/roslyn repo. Note that I only incorporated changes that were released in C# 7.0. Later changes to tuples (such as equality) are not included.
1. Edit and review.
1. Test against current compiler set to `<LangVersion>7.0</LangVersion>`.

This is the first PR for this larger task. I have notes for reviewers, and questions about how to continue proceeding. 

Questions / notes for reviewers:

1. Are the proposals useful in their current form? This PR updates the tuples proposal in place, assuming the proposal has served its purpose.
1. Are the notes about where changes / additions to the standard go clear? If not, does anyone have a better formatting suggestion?
1. This PR removes language about how the IDE would treat tuples, or made them informative note text. Is that the best strategy?
1. I removed any text that communicated a decision to *not* implement a behavior. Are there cases where we should do that? 
1. I'm not sure the content on overloading / overriding and natural type is in the correct location. Should it move to be in "overload resolution" in general?

Thoughts on proceeding with other proposals:

This will help keep the C# language reference section of docs concise. I will keep making progress on these (although slowly). After finishing each release, I think a second set of edits should re-organize the changes to the standard by major clause rather than feature. (Updates to **Lexical structure(**, updates to **Basic concepts**, **Types**, **Variables**, etc). Thoughts on that work?

/cc @MadsTorgersen @gafter @jcouv @agocke @jaredpar 
