### PR TITLE
Added case to clarify code change (Fixes #16279)

### DIFF
--- a/spec/statements.md
+++ b/spec/statements.md
@@ -512,6 +512,7 @@ is valid. The example does not violate the "no fall through" rule because the la
 The "no fall through" rule prevents a common class of bugs that occur in C and C++ when `break` statements are accidentally omitted. In addition, because of this rule, the switch sections of a `switch` statement can be arbitrarily rearranged without affecting the behavior of the statement. For example, the sections of the `switch` statement above can be reversed without affecting the behavior of the statement:
 ```csharp
 switch (i) {
+case 2:
 default:
     CaseAny();
     break;


### PR DESCRIPTION
## Summary

Added the case statement described in the issue. Technically it was already covered by the default case's fall through, but when illustrating a before and after in a language specification, it's probably best to be explicit and avoid confusion.

Fixes dotnet/docs#16279