### PR TITLE
Improved syntax of switch condition (#16280)

### DIFF
--- a/spec/statements.md
+++ b/spec/statements.md
@@ -539,7 +539,7 @@ case 2:
 The governing type of a `switch` statement may be the type `string`. For example:
 ```csharp
 void DoCommand(string command) {
-    switch (command.ToLower()) {
+    switch (command?.ToLowerInvariant()) {
     case "run":
         DoRun();
         break;


### PR DESCRIPTION
## Summary

Addressed a concern on the switch condition potentially containing null values and being more of a correct example using `ToLowerInvariant` instead of `ToLower`.

I also agreed with @Thraka that the `InvalidCommand` case should not be changed and so I left out the null / empty case handling as well since it didn't make sense without the default case change.

Fixes dotnet/docs#16280