### PR TITLE
Binary literals: Minor editorial fixes

### DIFF
--- a/proposals/csharp-7.0/binary-literals.md
+++ b/proposals/csharp-7.0/binary-literals.md
@@ -40,12 +40,12 @@ hex_digit
     : '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
     | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'a' | 'b' | 'c' | 'd' | 'e' | 'f';
 
-binary_integer_literal:
+binary_integer_literal
     : '0b' binary_digit+ integer_type_suffix?
     | '0B' binary_digit+ integer_type_suffix?
     ;
 
-binary_digit:
+binary_digit
     : '0'
     | '1'
     ;

--- a/proposals/csharp-7.2/leading-separator.md
+++ b/proposals/csharp-7.2/leading-separator.md
@@ -1,32 +1,17 @@
 # Allow digit separator after 0b or 0x
 
-This proposal specifies the changes required to the [C# 7.1 (draft) Language specification](XXX) to support leading underscores in binary and hex literals. It builds on top of the changes added in 7.0 when binary literals were introduced.
+In C# 7.2, we extend the set of places that digit separators (the underscore character) can appear in integral literals. [Beginning in C# 7.0, separators are permitted between the digits of a literal](../csharp-7.0/digit-separators.md). Now, in C# 7.2, we also permit digit separators before the first significant digit of a binary or hexadecimal literal, after the prefix.
 
-## Changes to [Lexical structure](../../spec/lexical-structure.md)
-
-### Literals
-
-#### Integer literals
-
-> The grammar for [integer literals](../../spec/lexical-structure.md#Integer-literals) is modified to allow one or more `_` separators before the first digit of a hex or binary literal.
-
-```antlr
-hex_digits
-    : '_'? hex_digit
-    | '_'? hex_digit hex_digits_and_underscores? hex_digit
-    ;
-
-binary_digits
-    : '_'? binary_digit
-    | '_'? binary_digit binary_digits_and_underscores? binary_digit
-    ;
-```
-
-> Make the following changes to the examples:
-
-\[Example:
 ```csharp
-0x_abc               // hex, int
-0B__111              // binary, int
+    123      // permitted in C# 1.0 and later
+    1_2_3    // permitted in C# 7.0 and later
+    0x1_2_3  // permitted in C# 7.0 and later
+    0b101    // binary literals added in C# 7.0
+    0b1_0_1  // permitted in C# 7.0 and later
+
+    // in C# 7.2, _ is permitted after the `0x` or `0b`
+    0x_1_2   // permitted in C# 7.2 and later
+    0b_1_0_1 // permitted in C# 7.2 and later
 ```
-end example\]
+
+We do not permit a decimal integer literal to have a leading underscore. A token such as `_123` is an identifier.


### PR DESCRIPTION
Remove the trailing ":" from production names in the grammar.