### PR TITLE
Add placeholder documents for missing specifications.

### DIFF
--- a/proposals/csharp-6.0/enum-base-type.md
+++ b/proposals/csharp-6.0/enum-base-type.md
@@ -1,0 +1,5 @@
+﻿## Enum Base Type
+
+In C# 6.0 we relaxed the syntax of an enum base type to be a type syntax, but require that it bind to one of a specified set of types. So `System.Int32` is permitted. But the spec has not been updated; it still requires one of a set of keywords for the base.
+
+This is a placeholder for a specification of that change.

--- a/proposals/csharp-7.0/expression-bodied-everything.md
+++ b/proposals/csharp-7.0/expression-bodied-everything.md
@@ -1,0 +1,3 @@
+﻿## Expression Bodied Everything
+
+In C# 7.0, we added support for expression-bodied constructors, destructors, and accessors.  This is a placeholder for the specification.

--- a/proposals/csharp-7.0/tuples.md
+++ b/proposals/csharp-7.0/tuples.md
@@ -1,0 +1,3 @@
+﻿## Tuples
+
+In C# 7.0 we added support for *tuples*.  This is a placeholder for its specification.

--- a/proposals/csharp-7.2/readonly-struct.md
+++ b/proposals/csharp-7.2/readonly-struct.md
@@ -1,0 +1,3 @@
+﻿## Readonly structs
+
+In C# 7.2, we added a feature permitting a struct declaration to have the `readonly` modifier.  This is a placeholder for that feature's specification.

--- a/proposals/csharp-7.2/ref-extension-methods.md
+++ b/proposals/csharp-7.2/ref-extension-methods.md
@@ -1,0 +1,3 @@
+﻿## Ref Extension Methods
+
+In C# 7.2, we added support for *ref extension methods*.  This is a placeholder for the feature's specification.

--- a/proposals/csharp-7.2/ref-struct-and-span.md
+++ b/proposals/csharp-7.2/ref-struct-and-span.md
@@ -1,0 +1,3 @@
+﻿## Ref Structs and Span
+
+In C# 7.2 we added support for *ref struct* types.  This is a placeholder for the specification.

--- a/proposals/csharp-7.3/enum-delegate-constraints.md
+++ b/proposals/csharp-7.3/enum-delegate-constraints.md
@@ -1,0 +1,3 @@
+﻿## Enum and Delegate type parameter constraint
+
+In C# 7.3, we added support for type parameter constraint keywords `enum` and `delegate`.  This is a placeholder for their specification.

--- a/proposals/csharp-7.3/ref-loops.md
+++ b/proposals/csharp-7.3/ref-loops.md
@@ -1,0 +1,3 @@
+﻿## Ref loops
+
+In C# 7.3, we added support for *ref for loops* and *ref foreach loops*.  This is a placeholder for their specifications.

--- a/proposals/csharp-8.0/alternative-interpolated-verbatim.md
+++ b/proposals/csharp-8.0/alternative-interpolated-verbatim.md
@@ -1,0 +1,3 @@
+﻿## Alternative interpolated verbatim strings
+
+In C# 8.0 we added a feature that permits an interpolated verbatim string to be introduced with the characters `@$"` or the characters `$@"`.  This is a placeholder for its specification.

--- a/proposals/csharp-8.0/async-using.md
+++ b/proposals/csharp-8.0/async-using.md
@@ -1,0 +1,3 @@
+﻿## Async using declaration
+
+In C# 8.0 we added support for an *async using* statements. There are two forms. One has a block body that is the scope of the using declaratation. The other declares a local and is implicitly scoped to the end of the block. This is a placeholder for their specification.

--- a/proposals/csharp-8.0/constraints-in-overrides.md
+++ b/proposals/csharp-8.0/constraints-in-overrides.md
@@ -1,0 +1,3 @@
+﻿## Override with constraints
+
+In C# 8.0, we added a feature to permit the specification of certain type parameter constraints in an `override` method declaration. This is a placeholder for its specification.

--- a/proposals/csharp-8.0/constructed-unmanaged.md
+++ b/proposals/csharp-8.0/constructed-unmanaged.md
@@ -1,0 +1,3 @@
+﻿## Unmanaged constructed types
+
+In C# 8.0, we extended the concept of an *unmanaged* type to include constructed (generic) types. This is a placeholder for its specification.

--- a/proposals/csharp-8.0/notnull-constraint.md
+++ b/proposals/csharp-8.0/notnull-constraint.md
@@ -1,0 +1,3 @@
+﻿## Notnull constraint
+
+In C# 8.0, we added a language feature that permits the specification of a new type parameter constraint `notnull`. This is a placeholder for its specification.

--- a/proposals/csharp-8.0/obsolete-accessor.md
+++ b/proposals/csharp-8.0/obsolete-accessor.md
@@ -1,0 +1,3 @@
+﻿## Obsolete on property accessor
+
+In C# 8.0, we added support for declaring a property accessor `[Obsolete]`. This is a placeholder for the specification.

--- a/proposals/csharp-8.0/shadowing-in-nested-functions.md
+++ b/proposals/csharp-8.0/shadowing-in-nested-functions.md
@@ -1,0 +1,3 @@
+﻿## Name shadowing in nested functions
+
+In C# 8.0, we added a feature that permits parameters in lambdas and local functions to use parameter names that hide/shadow the names of locals or parameters from the enclosing scope. This is a placholder for its specification.

--- a/proposals/csharp-8.0/unconstrained-null-coalescing.md
+++ b/proposals/csharp-8.0/unconstrained-null-coalescing.md
@@ -1,0 +1,3 @@
+﻿## Unconstrained type parameter in null coalescing operator
+
+In C# 8.0 we introduced a feature that permits a null coalescing operator to have a left operand that is not known to be either a reference or value type (i.e. an unconstrained type parameter). This is a placeholder for its specification.


### PR DESCRIPTION
This PR adds placeholders for specifications that are currently missing from the csharplang repository. The intent is to add breadcrumbs to (1) encourage feature owners to fill in (or move) more complete language specifications to this repository, and (2) give a hint to other authors (such as ECMA or our docs team) what features are actually in each release.  Some of the features indexed here have no documentation whatsoever anywhere else.

@MadsTorgersen @jaredpar 
