### PR TITLE
Only allow static methods for applicable members

### DIFF
--- a/proposals/function-pointers.md
+++ b/proposals/function-pointers.md
@@ -176,6 +176,7 @@ In an unsafe context, an implicit conversion exists from an address-of expressio
 - A single method `M` is selected corresponding to a method invocation of the form `E(A)` with the following modifications:
    - The arguments list `A` is a list of expressions, each classified as a variable and with the type and modifier (`ref`, `out`, or `in`) of the corresponding _formal\_parameter\_list_ of `D`.
    - The candidate methods are only those methods that are only those methods that are applicable in their normal form, not those applicable in their expanded form.
+   - The candidate methods are only those methods that are static.
 - If the algorithm of Method invocations produces an error, then a compile-time error occurs. Otherwise, the algorithm produces a single best method `M` having the same number of parameters as `F` and the conversion is considered to exist.
 - The selected method `M` must be compatible (as defined above) with the function pointer type `F`. Otherwise, a compile-time error occurs.
 - The result of the conversion is a function pointer of type `F`.

--- a/proposals/function-pointers.md
+++ b/proposals/function-pointers.md
@@ -175,7 +175,7 @@ In an unsafe context, a method `M` is compatible with a function pointer type `F
 In an unsafe context, an implicit conversion exists from an address-of expression whose target is a method group `E` to a compatible function pointer type `F` if `E` contains at least one method that is applicable in its normal form to an argument list constructed by use of the parameter types and modifiers of `F`, as described in the following.
 - A single method `M` is selected corresponding to a method invocation of the form `E(A)` with the following modifications:
    - The arguments list `A` is a list of expressions, each classified as a variable and with the type and modifier (`ref`, `out`, or `in`) of the corresponding _formal\_parameter\_list_ of `D`.
-   - The candidate methods are only those methods that are only those methods that are applicable in their normal form, not those applicable in their expanded form.
+   - The candidate methods are only those methods that are applicable in their normal form, not those applicable in their expanded form.
    - The candidate methods are only those methods that are static.
 - If the algorithm of Method invocations produces an error, then a compile-time error occurs. Otherwise, the algorithm produces a single best method `M` having the same number of parameters as `F` and the conversion is considered to exist.
 - The selected method `M` must be compatible (as defined above) with the function pointer type `F`. Otherwise, a compile-time error occurs.


### PR DESCRIPTION
This fixes a very similar problem to https://github.com/dotnet/csharplang/issues/3277, where this code is unable to be resolved:
```cs
interface I1{}
interface I2{}

public unsafe class C : I1, I2 {
    void M(I1 i) {}
    static void M(I2 i) {}
    public void M1() {
        delegate*<C, void> a = M; // Ambiguous because both M's are applicable
    }
}
```
With this change, the instance method M is not applicable, so there is no ambiguity.