### PR TITLE
Add the missing letter

### DIFF
--- a/spec/introduction.md
+++ b/spec/introduction.md
@@ -622,7 +622,7 @@ Each member of a class has an associated accessibility, which controls the regio
 
 ### Type parameters
 
-A class definition may specify a set of type parameters by following the class name with angle brackets enclosing a list of type parameter names. The type parameters can the be used in the body of the class declarations to define the members of the class. In the following example, the type parameters of `Pair` are `TFirst` and `TSecond`:
+A class definition may specify a set of type parameters by following the class name with angle brackets enclosing a list of type parameter names. The type parameters can then be used in the body of the class declarations to define the members of the class. In the following example, the type parameters of `Pair` are `TFirst` and `TSecond`:
 
 ```csharp
 public class Pair<TFirst,TSecond>


### PR DESCRIPTION
"The type parameters can the be used" -> "The type parameters can then be used"