### PR TITLE
Fix hrefs

### DIFF
--- a/proposals/csharp-9.0/function-pointers.md
+++ b/proposals/csharp-9.0/function-pointers.md
@@ -243,19 +243,19 @@ The section in unsafe code on operators is modified as such:
 
 > In an unsafe context, several constructs are available for operating on all _pointer\_type_s that are not _funcptr\_type_s:
 >
-> *  The `*` operator may be used to perform pointer indirection ([Pointer indirection](unsafe-code.md#pointer-indirection)).
-> *  The `->` operator may be used to access a member of a struct through a pointer ([Pointer member access](unsafe-code.md#pointer-member-access)).
-> *  The `[]` operator may be used to index a pointer ([Pointer element access](unsafe-code.md#pointer-element-access)).
-> *  The `&` operator may be used to obtain the address of a variable ([The address-of operator](unsafe-code.md#the-address-of-operator)).
-> *  The `++` and `--` operators may be used to increment and decrement pointers ([Pointer increment and decrement](unsafe-code.md#pointer-increment-and-decrement)).
-> *  The `+` and `-` operators may be used to perform pointer arithmetic ([Pointer arithmetic](unsafe-code.md#pointer-arithmetic)).
-> *  The `==`, `!=`, `<`, `>`, `<=`, and `=>` operators may be used to compare pointers ([Pointer comparison](unsafe-code.md#pointer-comparison)).
-> *  The `stackalloc` operator may be used to allocate memory from the call stack ([Fixed size buffers](unsafe-code.md#fixed-size-buffers)).
-> *  The `fixed` statement may be used to temporarily fix a variable so its address can be obtained ([The fixed statement](unsafe-code.md#the-fixed-statement)).
+> *  The `*` operator may be used to perform pointer indirection ([Pointer indirection](../../spec/unsafe-code.md#pointer-indirection)).
+> *  The `->` operator may be used to access a member of a struct through a pointer ([Pointer member access](../../spec/unsafe-code.md#pointer-member-access)).
+> *  The `[]` operator may be used to index a pointer ([Pointer element access](../../spec/unsafe-code.md#pointer-element-access)).
+> *  The `&` operator may be used to obtain the address of a variable ([The address-of operator](../../spec/unsafe-code.md#the-address-of-operator)).
+> *  The `++` and `--` operators may be used to increment and decrement pointers ([Pointer increment and decrement](../../spec/unsafe-code.md#pointer-increment-and-decrement)).
+> *  The `+` and `-` operators may be used to perform pointer arithmetic ([Pointer arithmetic](../../spec/unsafe-code.md#pointer-arithmetic)).
+> *  The `==`, `!=`, `<`, `>`, `<=`, and `=>` operators may be used to compare pointers ([Pointer comparison](../../spec/unsafe-code.md#pointer-comparison)).
+> *  The `stackalloc` operator may be used to allocate memory from the call stack ([Fixed size buffers](../../spec/unsafe-code.md#fixed-size-buffers)).
+> *  The `fixed` statement may be used to temporarily fix a variable so its address can be obtained ([The fixed statement](../../spec/unsafe-code.md#the-fixed-statement)).
 > 
 > In an unsafe context, several constructs are available for operating on all _funcptr\_type_s:
-> *  The `&` operator may be used to obtain the address of static methods ([Allow address-of to target methods](function-pointers.md#allow-address-of-to-target-methods))
-> *  The `==`, `!=`, `<`, `>`, `<=`, and `=>` operators may be used to compare pointers ([Pointer comparison](unsafe-code.md#pointer-comparison)).
+> *  The `&` operator may be used to obtain the address of static methods ([Allow address-of to target methods](#allow-address-of-to-target-methods))
+> *  The `==`, `!=`, `<`, `>`, `<=`, and `=>` operators may be used to compare pointers ([Pointer comparison](../../spec/unsafe-code.md#pointer-comparison)).
 
 Additionally, we modify all the sections in `Pointers in expressions` to forbid function pointer types, except `Pointer comparison` and `The sizeof operator`.
 

--- a/proposals/csharp-9.0/function-pointers.md
+++ b/proposals/csharp-9.0/function-pointers.md
@@ -142,7 +142,7 @@ funcptr_return_modifier
 
 If no `calling_convention_specifier` is provided, the default is `managed`. The precise metadata encoding
 of the `calling_convention_specifier` and what `identifier`s are valid in the `unmanaged_calling_convention` is
-covered in [Metadata Representation of Calling Conventions](#Metadata-Representation-of-Calling-Conventions).
+covered in [Metadata Representation of Calling Conventions](#metadata-representation-of-calling-conventions).
 
 ``` csharp
 delegate int Func1(string s);


### PR DESCRIPTION
This fixes a couple of build warnings that currently appear in https://github.com/dotnet/docs/pull/19736

![image](https://user-images.githubusercontent.com/31348972/88824276-72531a00-d1c6-11ea-8669-b583bdf419b4.png)

