### PR TITLE
fix a number of broken links

### DIFF
--- a/proposals/csharp-9.0/covariant-returns.md
+++ b/proposals/csharp-9.0/covariant-returns.md
@@ -42,7 +42,7 @@ This is a first draft, so it was necessarily invented from scratch.  Many of the
 
 ### Class Method Override
 
-The [existing constraint on class override](https://github.com/dotnet/csharplang/blob/master/spec/classes.md#override-methods) methods
+The [existing constraint on class override](../../spec/classes.md#override-methods) methods
 
 > - The override method and the overridden base method have the same return type.
 
@@ -53,19 +53,19 @@ is modified to
 And the following additional requirements are appended to that list:
 
 > - The override method must have have a return type that is convertible by an identity or implicit reference conversion to the return type of every override of the overridden base method that is declared in a (direct or indirect) base type of the override method.
-> - The override method's return type must be at least as accessible as the override method  ([Accessibility domains](https://github.com/dotnet/csharplang/blob/master/spec/basic-concepts.md#accessibility-domains)).
+> - The override method's return type must be at least as accessible as the override method  ([Accessibility domains](../../spec/basic-concepts.md#accessibility-domains)).
 
 This constraint permits an override method in a `private` class to have a `private` return type.  However it requires a `public` override method in a `public` type to have a `public` return type.
 
 ### Class Property and Indexer Override
 
-The [existing constraint on class override](https://github.com/dotnet/csharplang/blob/master/spec/classes.md#virtual-sealed-override-and-abstract-property-accessors) properties
+The [existing constraint on class override](../../spec/classes.md#virtual-sealed-override-and-abstract-property-accessors) properties
 
 > An overriding property declaration shall specify the exact same accessibility modifiers and name as the inherited property, and there shall be an identity conversion ~~between the type of the overriding and the inherited property~~. If the inherited property has only a single accessor (i.e., if the inherited property is read-only or write-only), the overriding property shall include only that accessor. If the inherited property includes both accessors (i.e., if the inherited property is read-write), the overriding property can include either a single accessor or both accessors.
 
 is modified to
 
-> An overriding property declaration shall specify the exact same accessibility modifiers and name as the inherited property, and there shall be an identity conversion **or (if the inherited property is read-only) implicit reference conversion from the type of the overriding property to the type of the inherited property**. If the inherited property has only a single accessor (i.e., if the inherited property is read-only or write-only), the overriding property shall include only that accessor. If the inherited property includes both accessors (i.e., if the inherited property is read-write), the overriding property can include either a single accessor or both accessors. **The overriding property's type must be at least as accessible as the overriding property ([Accessibility domains](https://github.com/dotnet/csharplang/blob/master/spec/basic-concepts.md#accessibility-domains)).**
+> An overriding property declaration shall specify the exact same accessibility modifiers and name as the inherited property, and there shall be an identity conversion **or (if the inherited property is read-only) implicit reference conversion from the type of the overriding property to the type of the inherited property**. If the inherited property has only a single accessor (i.e., if the inherited property is read-only or write-only), the overriding property shall include only that accessor. If the inherited property includes both accessors (i.e., if the inherited property is read-write), the overriding property can include either a single accessor or both accessors. **The overriding property's type must be at least as accessible as the overriding property ([Accessibility domains](../../spec/basic-concepts.md#accessibility-domains)).**
 
 ***The remainder of the draft specification below proposes a further extension to covariant returns of interface methods to be considered later.***
 

--- a/proposals/csharp-9.0/extending-partial-methods.md
+++ b/proposals/csharp-9.0/extending-partial-methods.md
@@ -7,7 +7,7 @@ methods in C#. The goal being to expand the set of scenarios in which these
 methods can work with source generators as well as being a more general 
 declaration form for C# methods.
 
-See also the [original partial methods specification](/spec/classes.md#partial-methods).
+See also the [original partial methods specification](../../spec/classes.md#partial-methods).
 
 ## Motivation
 C# has limited support for developers splitting methods into declarations and 

--- a/proposals/csharp-9.0/lambda-discard-parameters.md
+++ b/proposals/csharp-9.0/lambda-discard-parameters.md
@@ -20,12 +20,12 @@ Note: if a single parameter is named `_` then it is a regular parameter for back
 Discard parameters do not introduce any names to any scopes.
 Note this implies they do not cause any `_` (underscore) names to be hidden.
 
-[Simple names](https://github.com/dotnet/csharplang/blob/master/spec/expressions.md#simple-names)
-If `K` is zero and the *simple_name* appears within a *block* and if the *block*'s (or an enclosing *block*'s) local variable declaration space ([Declarations](basic-concepts.md#declarations)) contains a local variable, parameter (with the exception of discard parameters) or constant with name `I`, then the *simple_name* refers to that local variable, parameter or constant and is classified as a variable or value.
+[Simple names](../../spec/expressions.md#simple-names)
+If `K` is zero and the *simple_name* appears within a *block* and if the *block*'s (or an enclosing *block*'s) local variable declaration space ([Declarations](../../spec/basic-concepts.md#declarations)) contains a local variable, parameter (with the exception of discard parameters) or constant with name `I`, then the *simple_name* refers to that local variable, parameter or constant and is classified as a variable or value.
 
-[Scopes](https://github.com/dotnet/csharplang/blob/master/spec/basic-concepts.md#scopes)
-With the exception of discard parameters, the scope of a parameter declared in a *lambda_expression* ([Anonymous function expressions](expressions.md#anonymous-function-expressions)) is the *anonymous_function_body* of that *lambda_expression*
-With the exception of discard parameters, the scope of a parameter declared in an *anonymous_method_expression* ([Anonymous function expressions](expressions.md#anonymous-function-expressions)) is the *block* of that *anonymous_method_expression*.
+[Scopes](../../spec/basic-concepts.md#scopes)
+With the exception of discard parameters, the scope of a parameter declared in a *lambda_expression* ([Anonymous function expressions](../../spec/expressions.md#anonymous-function-expressions)) is the *anonymous_function_body* of that *lambda_expression*
+With the exception of discard parameters, the scope of a parameter declared in an *anonymous_method_expression* ([Anonymous function expressions](../../spec/expressions.md#anonymous-function-expressions)) is the *block* of that *anonymous_method_expression*.
 
 ## Related spec sections
-- [Corresponding parameters](https://github.com/dotnet/csharplang/blob/master/spec/expressions.md#corresponding-parameters)
+- [Corresponding parameters](../../spec/expressions.md#corresponding-parameters)

--- a/proposals/csharp-9.0/local-function-attributes.md
+++ b/proposals/csharp-9.0/local-function-attributes.md
@@ -2,15 +2,15 @@
 
 ## Attributes
 
-Local function declarations are now permitted to have [attributes](../spec/attributes.md). Parameters and type parameters on local functions are also allowed to have attributes.
+Local function declarations are now permitted to have [attributes](../../spec/attributes.md). Parameters and type parameters on local functions are also allowed to have attributes.
 
 Attributes with a specified meaning when applied to a method, its parameters, or its type parameters will have the same meaning when applied to a local function, its parameters, or its type parameters, respectively.
 
-A local function can be made conditional in the same sense as a [conditional method](../spec/attributes.md#the-conditional-attribute) by decorating it with a `[ConditionalAttribute]`. A conditional local function must also be `static`. All restrictions on conditional methods also apply to conditional local functions, including that the return type must be `void`.
+A local function can be made conditional in the same sense as a [conditional method](../../spec/attributes.md#the-conditional-attribute) by decorating it with a `[ConditionalAttribute]`. A conditional local function must also be `static`. All restrictions on conditional methods also apply to conditional local functions, including that the return type must be `void`.
 
 ## Extern
 
-The `extern` modifier is now permitted on local functions. This makes the local function external in the same sense as an [external method](../spec/classes.md#external-methods).
+The `extern` modifier is now permitted on local functions. This makes the local function external in the same sense as an [external method](../../spec/classes.md#external-methods).
 
 Similarly to an external method, the *local-function-body* of an external local function must be a semicolon. A semicolon *local-function-body* is only permitted on an external local function. 
 
@@ -18,7 +18,7 @@ An external local function must also be `static`.
 
 ## Syntax
 
-The [local functions grammar](csharp-7.0/local-functions.md#syntax-grammar) is modified as follows:
+The [local functions grammar](../csharp-7.0/local-functions.md#syntax-grammar) is modified as follows:
 ```
 local-function-header
     : attributes? local-function-modifiers? return-type identifier type-parameter-list?

--- a/proposals/csharp-9.0/native-integers.md
+++ b/proposals/csharp-9.0/native-integers.md
@@ -189,7 +189,7 @@ Compound assignment operations `x op= y` where `x` or `y` are native ints follow
 Specifically the expression is bound as `x = (T)(x op y)` where `T` is the type of `x` and where `x` is only evaluated once.
 
 The shift operators should mask the number of bits to shift - to 5 bits if `sizeof(nint)` is 4, and to 6 bits if `sizeof(nint)` is 8.
-(see [shift operators](https://github.com/dotnet/csharplang/blob/master/spec/expressions.md#shift-operators) in C# spec).
+(see [shift operators](../../spec/expressions.md#shift-operators) in C# spec).
 
 ### Dynamic
 

--- a/proposals/csharp-9.0/target-typed-conditional-expression.md
+++ b/proposals/csharp-9.0/target-typed-conditional-expression.md
@@ -17,8 +17,8 @@ We change
 > 
 > Given an implicit conversion `C1` that converts from an expression `E` to a type `T1`, and an implicit conversion `C2` that converts from an expression `E` to a type `T2`, `C1` is a ***better conversion*** than `C2` if `E` does not exactly match `T2` and at least one of the following holds:
 > 
-> * `E` exactly matches `T1` ([Exactly matching Expression](expressions.md#exactly-matching-expression))
-> * `T1` is a better conversion target than `T2` ([Better conversion target](expressions.md#better-conversion-target))
+> * `E` exactly matches `T1` ([Exactly matching Expression](../../spec/expressions.md#exactly-matching-expression))
+> * `T1` is a better conversion target than `T2` ([Better conversion target](../../spec/expressions.md#better-conversion-target))
 
 to
 
@@ -26,15 +26,15 @@ to
 > 
 > Given an implicit conversion `C1` that converts from an expression `E` to a type `T1`, and an implicit conversion `C2` that converts from an expression `E` to a type `T2`, `C1` is a ***better conversion*** than `C2` if `E` does not exactly match `T2` and at least one of the following holds:
 > 
-> * `E` exactly matches `T1` ([Exactly matching Expression](expressions.md#exactly-matching-expression))
+> * `E` exactly matches `T1` ([Exactly matching Expression](../../spec/expressions.md#exactly-matching-expression))
 > * **`C1` is not a *conditional expression conversion* and `C2` is a *conditional expression conversion***.
-> * `T1` is a better conversion target than `T2` ([Better conversion target](expressions.md#better-conversion-target)) **and either `C1` and `C2` are both *conditional expression conversions* or neither is a *conditional expression conversion***.
+> * `T1` is a better conversion target than `T2` ([Better conversion target](../../spec/expressions.md#better-conversion-target)) **and either `C1` and `C2` are both *conditional expression conversions* or neither is a *conditional expression conversion***.
 
 ## Cast Expression
 
 The current C# language specification says
 
-> A *cast_expression* of the form `(T)E`, where `T` is a *type* and `E` is a *unary_expression*, performs an explicit conversion ([Explicit conversions](conversions.md#explicit-conversions)) of the value of `E` to type `T`.
+> A *cast_expression* of the form `(T)E`, where `T` is a *type* and `E` is a *unary_expression*, performs an explicit conversion ([Explicit conversions](../../spec/conversions.md#explicit-conversions)) of the value of `E` to type `T`.
 
 In the presence of the *conditional expression conversion* there may be more than one possible conversion from `E` to `T`. With the addition of *conditional expression conversion*, we prefer any other conversion to a *conditional expression conversion*, and use the *conditional expression conversion* only as a last resort.
 


### PR DESCRIPTION
These were found building dotnet/docs#19736

- Add correct folders for several spec references.
- Correct casing of one anchor tag.
- Replace absolute links with relative links.