### PR TITLE
Fix table rendering

### DIFF
--- a/proposals/csharp-9.0/top-level-statements.md
+++ b/proposals/csharp-9.0/top-level-statements.md
@@ -97,10 +97,10 @@ operations are omitted, no warning is produced.
 
 The signature of the generated entry point method is determined based on operations used by the top level
 statements as follows:
-**Async-operations\Return-with-expression** | **Present** | **Absent**
-----------------------------------------| -------------|-------------
-**Present** | ```static Task<int> Main(string[] args)```| ```static Task Main(string[] args)```
-**Absent**  | ```static int Main(string[] args)``` | ```static void Main(string[] args)```
+| **Async-operations\Return-with-expression** | **Present** | **Absent** |
+|----------------------------------------|-------------|-------------|
+| **Present** | ```static Task<int> Main(string[] args)```| ```static Task Main(string[] args)``` |
+| **Absent**  | ```static int Main(string[] args)``` | ```static void Main(string[] args)``` |
 
 The example above would yield the following `$Main` method declaration:
 


### PR DESCRIPTION
The previous table style worked for GFM, but was not valid for markdig.