### PR TITLE
Update H1s to avoid duplication with vblang repo

### DIFF
--- a/spec/arrays.md
+++ b/spec/arrays.md
@@ -1,4 +1,4 @@
-﻿# Arrays
+﻿# Arrays - C# specification
 
 An array is a data structure that contains a number of variables which are accessed through computed indices. The variables contained in an array, also called the elements of the array, are all of the same type, and this type is called the element type of the array.
 


### PR DESCRIPTION
The dotnet/docs repository is built from both csharplang and vblang repositories.

Currently, [duplicate-h1s](https://review.docs.microsoft.com/en-us/help/contribute/validation-ref/duplicate-h1s?branch=master) is a suggestion that will become a warning next month.

This PR adds suffix to the headings to avoid duplication with vblang repo.

I'll open a PR in vblang to maintain consistency.