### PR TITLE
Add H1 to convariant returns

### DIFF
--- a/proposals/csharp-9.0/covariant-returns.md
+++ b/proposals/csharp-9.0/covariant-returns.md
@@ -1,3 +1,5 @@
+# Convariant returns
+
 ## Summary
 [summary]: #summary
 

--- a/proposals/csharp-9.0/covariant-returns.md
+++ b/proposals/csharp-9.0/covariant-returns.md
@@ -1,4 +1,4 @@
-# Convariant returns
+# Covariant returns
 
 ## Summary
 [summary]: #summary
@@ -225,4 +225,3 @@ class Digit : Cloneable
 - some discussion at <https://github.com/dotnet/roslyn/issues/357>.
 - https://github.com/dotnet/csharplang/blob/master/meetings/2020/LDM-2020-01-08.md
 - Offline discussion toward a decision to support overriding of class methods only in C# 9.0.
-


### PR DESCRIPTION
This fixes a build warning in dotnet/docs.