### PR TITLE
Add H1 tag for Covariant returns

### DIFF
--- a/proposals/csharp-9.0/covariant-returns.md
+++ b/proposals/csharp-9.0/covariant-returns.md
@@ -1,3 +1,5 @@
+# Covariant Returns
+
 ## Summary
 [summary]: #summary
 


### PR DESCRIPTION
The lack of an H1 triggers a warning on the docs build.