### PR TITLE
Remove extraneous code comment

### DIFF
--- a/proposals/csharp-9.0/function-pointers.md
+++ b/proposals/csharp-9.0/function-pointers.md
@@ -185,9 +185,6 @@ unsafe class Util {
 
     void Use() {
         delegate*<void> ptr1 = &Util.Log;
-
-        // Error: type "delegate*<void>" not compatible with "delegate*<int>";
-
    }
 }
 ```


### PR DESCRIPTION
This is a follow on to https://github.com/dotnet/csharplang/commit/eade6b9b5501bd0313aa88934f0f1ee1c1c4cc9a#diff-c5d292723e1e43121acb1f8360545e53 which removed the code associated with the comment.