### PR TITLE
Restore missing code example from Function Pointers doc

### DIFF
--- a/proposals/csharp-9.0/function-pointers.md
+++ b/proposals/csharp-9.0/function-pointers.md
@@ -187,7 +187,7 @@ unsafe class Util {
         delegate*<void> ptr1 = &Util.Log;
 
         // Error: type "delegate*<void>" not compatible with "delegate*<int>";
-
+        delegate*<int> ptr2 = &Util.Log;
    }
 }
 ```


### PR DESCRIPTION
Restoring a code example removed by eade6b9, per @333fred. See https://github.com/dotnet/csharplang/pull/3848#issuecomment-687390497.



