### PR TITLE
Add `init` accessors in `readonly struct`s and `readonly` properties

### DIFF
--- a/proposals/csharp-9.0/init.md
+++ b/proposals/csharp-9.0/init.md
@@ -247,7 +247,7 @@ also applies to interface implementation.
 `init` accessors (both auto-implemented accessors and manually-implemented
 accessors) are permitted on properties of `readonly struct`s, as well as
 `readonly` properties. `init` accessors are not permitted to be marked
-`readonly` themselves.
+`readonly` themselves, in both `readonly` and non-`readonly` `struct` types.
 
 ```cs
 readonly struct ReadonlyStruct1

--- a/proposals/csharp-9.0/init.md
+++ b/proposals/csharp-9.0/init.md
@@ -242,6 +242,27 @@ Restrictions of this feature:
 - All overrides of a property must have `init` if the base had `init`. This rule
 also applies to interface implementation.
 
+### Readonly structs
+
+`init` accessors (both auto-implemented accessors and manually-implemented
+accessors) are permitted on properties of `readonly struct`s, as well as
+`readonly` properties. `init` accessors are not permitted to be marked
+`readonly` themselves.
+
+```cs
+readonly struct ReadonlyStruct1
+{
+    public int Prop1 { get; init; } // Allowed
+}
+
+struct ReadonlyStruct2
+{
+    public readonly int Prop2 { get; init; } // Allowed
+
+    public int Prop3 { get; readonly init; } // Error
+}
+```
+
 ### Metadata encoding 
 Property `init` accessors will be emitted as a standard `set` accessor with
 the return type marked with a modreq of `IsExternalInit`. This is a new type


### PR DESCRIPTION
Fixes https://github.com/dotnet/csharplang/issues/3884.
