### PR TITLE
Add missing `,` to record_base rule

### DIFF
--- a/proposals/csharp-9.0/records.md
+++ b/proposals/csharp-9.0/records.md
@@ -15,7 +15,7 @@ record_declaration
 record_base
     : ':' class_type argument_list?
     | ':' interface_type_list
-    | ':' class_type argument_list? interface_type_list
+    | ':' class_type argument_list? ',' interface_type_list
     ;
 
 record_body


### PR DESCRIPTION
The Roslyn compiler in VS 2019 requires a comma between the argument_list and the interface list to compile.

**With comma:**

![image](https://user-images.githubusercontent.com/118951/95065429-f363eb80-06f8-11eb-97c2-0718d0d381cd.png)

**Without comma:**

![image](https://user-images.githubusercontent.com/118951/95065494-0a0a4280-06f9-11eb-860f-ef92b77a1502.png)

