### PR TITLE
Allow semi-colon after block body for record declarations

### DIFF
--- a/proposals/csharp-9.0/records.md
+++ b/proposals/csharp-9.0/records.md
@@ -19,7 +19,7 @@ record_base
     ;
 
 record_body
-    : '{' class_member_declaration* '}'
+    : '{' class_member_declaration* '}' ';'?
     | ';'
     ;
 ```


### PR DESCRIPTION
Since we allow `class C { };`...
Tagging @dotnet/roslyn-compiler for review