### PR TITLE
Initial spec-work for single-line-namespace

### DIFF
--- a/spec/namespaces.md
+++ b/spec/namespaces.md
@@ -124,7 +124,7 @@ namespace Name
 }
 ```
 
-Specifically, the *extern_alias_directive*s, *using_directive*s and *type_declaration*s of a *single_line_namespace_declaration* act as if they were declared inside the *namespace_body* of a *namespace_declaration* with the same *qualified_identifier* as the first *namespace_member_declaration* of the *compilation_unit*.
+Specifically, *single_line_namespace_declaration* is treated the same as a *namespace_member_declaration* at the same location in the *compilation_unit* with the same *qualified_identifier*.  The *extern_alias_directive*s, *using_directive*s and *type_declaration*s of that *single_line_namespace_declaration* act as if they were declared inside the *namespace_body* of that *namespace_declaration*.
 
 A source file cannot contain both a *single_line_namespace_declaration* and a *namespace_declaration*.  A source file cannot contain multiple *single_line_namespace_declaration*s
 

--- a/spec/namespaces.md
+++ b/spec/namespaces.md
@@ -134,7 +134,7 @@ namespace Name
 
 Specifically, a *single_line_namespace_declaration* is treated the same as a *namespace_declaration* at the same location in the *compilation_unit* with the same *qualified_identifier*.  The *extern_alias_directive*s, *using_directive*s and *type_declaration*s of that *single_line_namespace_declaration* act as if they were declared in the same order inside the *namespace_body* of that *namespace_declaration*.
 
-A source file cannot contain both a *single_line_namespace_declaration* and a *namespace_declaration*.  A source file cannot contain multiple *single_line_namespace_declaration*s
+A source file cannot contain both a *single_line_namespace_declaration* and a *namespace_declaration*.  A source file cannot contain multiple *single_line_namespace_declaration*s.
 
 ## Extern aliases
 

--- a/spec/namespaces.md
+++ b/spec/namespaces.md
@@ -36,7 +36,8 @@ The two compilation units contribute to the single global namespace, in this cas
 
 ## Namespace declarations
 
-A *namespace_declaration* has two different forms.  The first consists of the keyword `namespace`, followed by a namespace name and body, optionally followed by a semicolon.  The second consists of the keyword `namespace`, followed by a namespace name, a semicolon and an optional list of directives and declarations.
+A *namespace_declaration* consists of the keyword `namespace`, followed by a namespace name and body, optionally followed by a semicolon.
+A *single_line_namespace_declaration* consists of the keyword `namespace`, followed by a namespace name, a semicolon and an optional list of directives and type declarations.
 
 ```antlr
 namespace_declaration

--- a/spec/namespaces.md
+++ b/spec/namespaces.md
@@ -39,7 +39,7 @@ class B {}
 
 The two compilation units contribute to the single global namespace, in this case declaring two classes with the fully qualified names `A` and `B`. Because the two compilation units contribute to the same declaration space, it would have been an error if each contained a declaration of a member with the same name.
 
-A *single_line_namespace* will contribute members corresponding to the *namespace_declaration* it is semanticall equivalent to.  See ([Namespace Declarations](#namespace-declarations)) for more details.
+A *single_line_namespace* will contribute members corresponding to the *namespace_declaration* it is semantically equivalent to.  See ([Namespace Declarations](#namespace-declarations)) for more details.
 
 ## Namespace declarations
 

--- a/spec/namespaces.md
+++ b/spec/namespaces.md
@@ -6,11 +6,16 @@ Using directives ([Using directives](namespaces.md#using-directives)) are provid
 
 ## Compilation units
 
-A *compilation_unit* defines the overall structure of a source file. A compilation unit consists of zero or more *using_directive*s followed by zero or more *global_attributes* followed by zero or more *namespace_member_declaration*s.
+A *compilation_unit* defines the overall structure of a source file. A compilation unit consists of zero or more *using_directive*s followed by zero or more *global_attributes* followed by a *compilation_unit_body*. A *compilation_unit_body* can either be a *single_line_namespace* or zero or more *namespace_member_declaration*s.
 
 ```antlr
 compilation_unit
-    : extern_alias_directive* using_directive* global_attributes? (single_line_namespace | (namespace_member_declaration*))
+    : extern_alias_directive* using_directive* global_attributes? compilation_unit_body
+    ;
+
+compilation_unit_body
+    : namespace_member_declaration*
+    | single_line_namespace
     ;
 ```
 
@@ -33,6 +38,8 @@ class B {}
 ```
 
 The two compilation units contribute to the single global namespace, in this case declaring two classes with the fully qualified names `A` and `B`. Because the two compilation units contribute to the same declaration space, it would have been an error if each contained a declaration of a member with the same name.
+
+A *single_line_namespace* will contribute members corresponding to the *namespace_declaration* it is semanticall equivalent to.  See ([Namespace Declarations](#namespace-declarations)) for more details.
 
 ## Namespace declarations
 

--- a/spec/namespaces.md
+++ b/spec/namespaces.md
@@ -134,7 +134,7 @@ namespace Name
 
 Specifically, a *single_line_namespace_declaration* is treated the same as a *namespace_declaration* at the same location in the *compilation_unit* with the same *qualified_identifier*.  The *extern_alias_directive*s, *using_directive*s and *type_declaration*s of that *single_line_namespace_declaration* act as if they were declared in the same order inside the *namespace_body* of that *namespace_declaration*.
 
-A source file cannot contain both a *single_line_namespace_declaration* and a *namespace_declaration*.  A source file cannot contain multiple *single_line_namespace_declaration*s.
+A source file cannot contain both a *single_line_namespace_declaration* and a *namespace_declaration*.  A source file cannot contain multiple *single_line_namespace_declaration*s. A *compilation_unit* cannot contain both a *single_line_namespace_declaration* and any *statement* at the top level.
 
 ## Extern aliases
 

--- a/spec/namespaces.md
+++ b/spec/namespaces.md
@@ -102,15 +102,10 @@ the two namespace declarations above contribute to the same declaration space, i
 A *single_line_namespace_declaration* permits a namespace declaration to be written without the `{ ... }` block.  For example:
 
 ```csharp
-extern alias OuterAliases;
-using OuterUsings;
-
-[assembly: Attributes]
-
 namespace Name;
 
-extern alias InnerAlias;
-using InnerUsing;
+extern alias A;
+using B;
 
 class C
 {
@@ -118,15 +113,10 @@ class C
 ```
 is semantically equivalent to
 ```csharp
-extern alias OuterAliases;
-using OuterUsings;
-
-[assembly: Attributes]
-
 namespace Name
 {
-    extern alias InnerAliases;
-    using InnerUsings;
+    extern alias A;
+    using B;
 
     class C
     {

--- a/spec/namespaces.md
+++ b/spec/namespaces.md
@@ -125,7 +125,7 @@ namespace Name
 }
 ```
 
-Specifically, a *single_line_namespace_declaration* is treated the same as a *namespace_member_declaration* at the same location in the *compilation_unit* with the same *qualified_identifier*.  The *extern_alias_directive*s, *using_directive*s and *type_declaration*s of that *single_line_namespace_declaration* act as if they were declared inside the *namespace_body* of that *namespace_declaration*.
+Specifically, a *single_line_namespace_declaration* is treated the same as a *namespace_declaration* at the same location in the *compilation_unit* with the same *qualified_identifier*.  The *extern_alias_directive*s, *using_directive*s and *type_declaration*s of that *single_line_namespace_declaration* act as if they were declared in the same order inside the *namespace_body* of that *namespace_declaration*.
 
 A source file cannot contain both a *single_line_namespace_declaration* and a *namespace_declaration*.  A source file cannot contain multiple *single_line_namespace_declaration*s
 

--- a/spec/namespaces.md
+++ b/spec/namespaces.md
@@ -124,6 +124,8 @@ namespace Name
 }
 ```
 
+Specifically, the *extern_alias_directive*s, *using_directive*s and *type_declaration*s of a *single_line_namespace_declaration* act as if they were declared inside the *namespace_body* of a *namespace_declaration* with the same *qualified_identifier* as the first *namespace_member_declaration* of the *compilation_unit*.
+
 A source file cannot contain both a *single_line_namespace_declaration* and a *namespace_declaration*.  A source file cannot contain multiple *single_line_namespace_declaration*s
 
 ## Extern aliases

--- a/spec/namespaces.md
+++ b/spec/namespaces.md
@@ -10,7 +10,7 @@ A *compilation_unit* defines the overall structure of a source file. A compilati
 
 ```antlr
 compilation_unit
-    : extern_alias_directive* using_directive* global_attributes? namespace_member_declaration*
+    : extern_alias_directive* using_directive* global_attributes? (single_line_namespace | (namespace_member_declaration*))
     ;
 ```
 
@@ -36,11 +36,15 @@ The two compilation units contribute to the single global namespace, in this cas
 
 ## Namespace declarations
 
-A *namespace_declaration* consists of the keyword `namespace`, followed by a namespace name and body, optionally followed by a semicolon.
+A *namespace_declaration* has two different forms.  The first consists of the keyword `namespace`, followed by a namespace name and body, optionally followed by a semicolon.  The second consists of the keyword `namespace`, followed by a namespace name, a semicolon and an optional list of directives and declarations.
 
 ```antlr
 namespace_declaration
     : 'namespace' qualified_identifier namespace_body ';'?
+    ;
+    
+single_line_namespace_declaration
+    : 'namespace' qualified_identifier ';' extern_alias_directive* using_directive* type_declaration*
     ;
 
 qualified_identifier
@@ -94,6 +98,32 @@ namespace N1.N2
 }
 ```
 the two namespace declarations above contribute to the same declaration space, in this case declaring two classes with the fully qualified names `N1.N2.A` and `N1.N2.B`. Because the two declarations contribute to the same declaration space, it would have been an error if each contained a declaration of a member with the same name.
+
+A *single_line_namespace_declaration* permits a namespace declaration to be written without the `{ ... }` block.  For example:
+
+```csharp
+namespace Name;
+extern alias X;
+using U;
+
+class C
+{
+}
+```
+is semantically equivalent to
+```csharp
+namespace Name
+{
+    extern alias X;
+    using U;
+
+    class C
+    {
+    }
+}
+```
+
+A source file cannot contain both a *single_line_namespace_declaration* and a *namespace_declaration*.  A source file cannot contain multiple *single_line_namespace_declaration*s
 
 ## Extern aliases
 

--- a/spec/namespaces.md
+++ b/spec/namespaces.md
@@ -124,7 +124,7 @@ namespace Name
 }
 ```
 
-Specifically, *single_line_namespace_declaration* is treated the same as a *namespace_member_declaration* at the same location in the *compilation_unit* with the same *qualified_identifier*.  The *extern_alias_directive*s, *using_directive*s and *type_declaration*s of that *single_line_namespace_declaration* act as if they were declared inside the *namespace_body* of that *namespace_declaration*.
+Specifically, a *single_line_namespace_declaration* is treated the same as a *namespace_member_declaration* at the same location in the *compilation_unit* with the same *qualified_identifier*.  The *extern_alias_directive*s, *using_directive*s and *type_declaration*s of that *single_line_namespace_declaration* act as if they were declared inside the *namespace_body* of that *namespace_declaration*.
 
 A source file cannot contain both a *single_line_namespace_declaration* and a *namespace_declaration*.  A source file cannot contain multiple *single_line_namespace_declaration*s
 

--- a/spec/namespaces.md
+++ b/spec/namespaces.md
@@ -102,9 +102,15 @@ the two namespace declarations above contribute to the same declaration space, i
 A *single_line_namespace_declaration* permits a namespace declaration to be written without the `{ ... }` block.  For example:
 
 ```csharp
+extern alias OuterAliases;
+using OuterUsings;
+
+[assembly: Attributes]
+
 namespace Name;
-extern alias X;
-using U;
+
+extern alias InnerAlias;
+using InnerUsing;
 
 class C
 {
@@ -112,10 +118,15 @@ class C
 ```
 is semantically equivalent to
 ```csharp
+extern alias OuterAliases;
+using OuterUsings;
+
+[assembly: Attributes]
+
 namespace Name
 {
-    extern alias X;
-    using U;
+    extern alias InnerAliases;
+    using InnerUsings;
 
     class C
     {


### PR DESCRIPTION
Initial spec changes for https://github.com/dotnet/csharplang/issues/137.  To be taken to LDM.

There is an open question on what to do here for top-level-statements.  We could consider either:

```
compilation_unit
    : extern_alias_directive* using_directive* global_attributes? (single_line_namespace_declaration | (statement* namespace_member_declaration*))
    ;
```

or


```
compilation_unit
    : extern_alias_directive* using_directive* global_attributes? statement* (single_line_namespace_declaration | namespace_member_declaration*))
    ;
```

The effective difference between the two is if you can have a file with top-level-statements and a single-line namespace. I personally feel like it's a bit weird to have both.  But i suppose no more weird than top level statements followed by a namespace-declaration.

--

Update: LDM decision is we will not allow top level statements with a single-line namespace.