### PR TITLE
Fix typo 'retconn'

### DIFF
--- a/meetings/2020/LDM-2020-06-24.md
+++ b/meetings/2020/LDM-2020-06-24.md
@@ -113,7 +113,7 @@ Because these members are `static` and non-virtual, there aren't any safety issu
 derive a looser/more restricted member in some fashion by subtyping the interface and overriding
 the member. We also considered whether this could potentially interfere with some of the other
 enhancements we hope to make regarding roles, type classes, and extensions. These should all be
-fine: we won't be able to retconn the existing static members to be virtual-by-default for interfaces,
+fine: we won't be able to retcon the existing static members to be virtual-by-default for interfaces,
 as that would end up being a breaking change on multiple levels, even without changing the variance
 behavior here.
 

--- a/meetings/2020/LDM-2020-10-26.md
+++ b/meetings/2020/LDM-2020-10-26.md
@@ -86,7 +86,7 @@ https://github.com/dotnet/csharplang/issues/3980
 
 This is a proposal that, depending on the exact specification, would either be a breaking change or have complicated lookup rules
 designed to avoid the breaking change. It also requires some deep thought into how the exact scoping rules would work. Today,
-locals introduced in the `base` call are visible throughout the constructor, so we would have to retconn the scoping rules to
+locals introduced in the `base` call are visible throughout the constructor, so we would have to retcon the scoping rules to
 work something like this:
 
 1. Outermost scope, contains static local functions

--- a/meetings/2020/LDM-2020-12-14.md
+++ b/meetings/2020/LDM-2020-12-14.md
@@ -40,7 +40,7 @@ must specifically check that the collection is actually empty. The current propo
 brackets `[]` to represent a collection pattern, instead of using the curlies. We're pretty divided on this approach: C# has
 not used square brackets to represent a list or array in the past. Even C# 1.0 used the curly brackets for array initializers,
 reserving the brackets for array size or index access. This would make the proposed syntax a really big break with C# tradition.
-We could "retconn" this by enabling new types of collection literals using square brackets, but that's an issue that LDM has
+We could "retcon" this by enabling new types of collection literals using square brackets, but that's an issue that LDM has
 not intensely looked at beyond previously rejecting https://github.com/dotnet/csharplang/issues/414 and related issues. After
 some discussion, we've come to the realization that the empty collection (ie, the base case for recursive algorithms) is the
 most important pattern to design for, and the rest of the syntax falls out from that design. We've come up with a few different

--- a/proposals/variance-safety-for-static-interface-members.md
+++ b/proposals/variance-safety-for-static-interface-members.md
@@ -65,6 +65,6 @@ A type is ***output-safe*** if it is not output-unsafe, and ***input-safe*** if 
 
 We also considered whether this could potentially interfere with some of the other
 enhancements we hope to make regarding roles, type classes, and extensions. These should all be
-fine: we won't be able to retconn the existing static members to be virtual-by-default for interfaces,
+fine: we won't be able to retcon the existing static members to be virtual-by-default for interfaces,
 as that would end up being a breaking change on multiple levels, even without changing the variance
 behavior here.


### PR DESCRIPTION
'Retcon' is an abbreviation for "retroactive continuity." The word 'continuity' doesn't start 'conn.'

A second 'n' would be added as usual for 'retconned' and 'retconning.'