### PR TITLE
Fix PrintMembers return type

### DIFF
--- a/proposals/csharp-9.0/records.md
+++ b/proposals/csharp-9.0/records.md
@@ -309,7 +309,7 @@ class R2 : R1, IEquatable<R2>
     public T2 P2 { get; init; }
     public T3 P3 { get; init; }
     
-    protected override void PrintMembers(StringBuilder builder)
+    protected override bool PrintMembers(StringBuilder builder)
     {
         if (base.PrintMembers(builder))
             builder.Append(", ");


### PR DESCRIPTION
Fixes dotnet/docs#22991