### PR TITLE
Help to set expectations for issues up front

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Propose a language idea or ask a question
     url: https://github.com/dotnet/csharplang/discussions/new
-    about: Starting with discussion is the way to get traction on a new proposal.
+    about: Starting with discussion is the way to create a new proposal.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Open a Discussion
+  - name: Propose a language idea or ask a question
     url: https://github.com/dotnet/csharplang/discussions/new
-    about: Please open new proposals as discussions if they are not fully specified.
+    about: Starting with discussion is the way to get traction on a new proposal.

--- a/.github/ISSUE_TEMPLATE/proposal_template.md
+++ b/.github/ISSUE_TEMPLATE/proposal_template.md
@@ -1,10 +1,12 @@
 ---
-name: Language Proposal
-about: Fully specified language proposal
+name: Create a language specification
+about: For proposals that already have support in community discussions or from a team member.
 title: "[Proposal]: [FEATURE_NAME]"
 ---
 <!--
-New language feature proposals should fully fill out this template. This should include a complete detailed design, which describes the syntax of the feature, what that syntax means, and how it affects current parts of the spec. Please make sure to point out specific spec sections that need to be updated for this feature. If you do not have the knowledge or experience to fill this out completely, that's perfectly alright: please open this proposal as a Discussion instead (https://github.com/dotnet/csharplang/discussions/new) and the community can generally discuss the proposal in less formal terms.
+Hi! Without existing community discussions or invitation from a team member, we will likely convert this issue into a discussion. If this is your first time opening an issue, please open a discussion marked [draft issue] at https://github.com/dotnet/csharplang/discussions/new and we'll try to give you feedback on how to get to an issue-ready proposal.
+
+New language feature proposals should fully fill out this template. This should include a complete detailed design, which describes the syntax of the feature, what that syntax means, and how it affects current parts of the spec. Please make sure to point out specific spec sections that need to be updated for this feature.
 -->
 # FEATURE_NAME
 

--- a/.github/ISSUE_TEMPLATE/proposal_template.md
+++ b/.github/ISSUE_TEMPLATE/proposal_template.md
@@ -1,10 +1,10 @@
 ---
 name: Create a language specification
-about: For proposals that already have support in community discussions or from a team member.
+about: For proposals that have been invited by a team member.
 title: "[Proposal]: [FEATURE_NAME]"
 ---
 <!--
-Hello, and thanks for your interest in contributing to C#! If this is your first time opening an issue, please open a discussion marked [draft issue] at https://github.com/dotnet/csharplang/discussions/new and we'll try to give you feedback on how to get to an issue-ready proposal. Without existing community discussions or invitation from a team member, we will likely convert this issue into a discussion.
+Hello, and thanks for your interest in contributing to C#! If you haven't been invited by a team member to open an issue, please instead open a discussion marked [draft issue] at https://github.com/dotnet/csharplang/discussions/new and we'll try to give you feedback on how to get to an issue-ready proposal.
 
 New language feature proposals should fully fill out this template. This should include a complete detailed design, which describes the syntax of the feature, what that syntax means, and how it affects current parts of the spec. Please make sure to point out specific spec sections that need to be updated for this feature.
 -->

--- a/.github/ISSUE_TEMPLATE/proposal_template.md
+++ b/.github/ISSUE_TEMPLATE/proposal_template.md
@@ -4,7 +4,7 @@ about: For proposals that already have support in community discussions or from 
 title: "[Proposal]: [FEATURE_NAME]"
 ---
 <!--
-Hi! Without existing community discussions or invitation from a team member, we will likely convert this issue into a discussion. If this is your first time opening an issue, please open a discussion marked [draft issue] at https://github.com/dotnet/csharplang/discussions/new and we'll try to give you feedback on how to get to an issue-ready proposal.
+Hello, and thanks for your interest in contributing to C#! If this is your first time opening an issue, please open a discussion marked [draft issue] at https://github.com/dotnet/csharplang/discussions/new and we'll try to give you feedback on how to get to an issue-ready proposal. Without existing community discussions or invitation from a team member, we will likely convert this issue into a discussion.
 
 New language feature proposals should fully fill out this template. This should include a complete detailed design, which describes the syntax of the feature, what that syntax means, and how it affects current parts of the spec. Please make sure to point out specific spec sections that need to be updated for this feature.
 -->


### PR DESCRIPTION
From a discussion with @333fred, @CyrusNajmabadi, @MadsTorgersen, @YairHalberstadt, incorporating suggestions by Yair and Fred

The motivation is to close any gap between how the language design team already effectively works, and expectations of community members who want to create a new issue:

- Avoiding a contributor feeling that moving to a discussion is a rejection of the time and level of quality put into their proposal. (The comprehensiveness is what the current directions emphasize.)
- Directing contributors to the right spot in the first place.
- Showing contributors that community discussions are the normal path to get a proposal that would be considered by the LDM, as opposed to thinking chances are increased by doing a big walk-up proposal, or thinking chances are lessened by being a "just" a discussion.

Wording suggestions welcome!

The changes to the titles and tag lines look like this:
![image](https://user-images.githubusercontent.com/8040367/110544917-7222e180-80fa-11eb-9c13-bea57e1a25ba.png)