### PR TITLE
Rename record equality parameters to 'left' and 'right'

### DIFF
--- a/proposals/csharp-9.0/records.md
+++ b/proposals/csharp-9.0/records.md
@@ -81,10 +81,10 @@ the value of `EqualityContract == other.EqualityContract`.
 
 The record type includes synthesized `==` and `!=` operators equivalent to operators declared as follows:
 ```C#
-public static bool operator==(R? r1, R? r2)
-    => (object)r1 == r2 || (r1?.Equals(r2) ?? false);
-public static bool operator!=(R? r1, R? r2)
-    => !(r1 == r2);
+public static bool operator==(R? left, R? right)
+    => (object)left == right || (left?.Equals(right) ?? false);
+public static bool operator!=(R? left, R? right)
+    => !(left == right);
 ```
 The `Equals` method called by the `==` operator is the `Equals(R? other)` method specified above. The `!=` operator delegates to the `==` operator. It is an error if the operators are declared explicitly.
     
@@ -137,10 +137,10 @@ class R1 : IEquatable<R1>
             EqualityContract == other.EqualityContract &&
             EqualityComparer<T1>.Default.Equals(P1, other.P1);
     }
-    public static bool operator==(R1? r1, R1? r2)
-        => (object)r1 == r2 || (r1?.Equals(r2) ?? false);
-    public static bool operator!=(R1? r1, R1? r2)
-        => !(r1 == r2);    
+    public static bool operator==(R1? left, R1? right)
+        => (object)left == right || (left?.Equals(right) ?? false);
+    public static bool operator!=(R1? left, R1? right)
+        => !(left == right);
     public override int GetHashCode()
     {
         return Combine(EqualityComparer<Type>.Default.GetHashCode(EqualityContract),
@@ -159,10 +159,10 @@ class R2 : R1, IEquatable<R2>
         return base.Equals((R1?)other) &&
             EqualityComparer<T2>.Default.Equals(P2, other.P2);
     }
-    public static bool operator==(R2? r1, R2? r2)
-        => (object)r1 == r2 || (r1?.Equals(r2) ?? false);
-    public static bool operator!=(R2? r1, R2? r2)
-        => !(r1 == r2);    
+    public static bool operator==(R2? left, R2? right)
+        => (object)left == right || (left?.Equals(right) ?? false);
+    public static bool operator!=(R2? left, R2? right)
+        => !(left == right);
     public override int GetHashCode()
     {
         return Combine(base.GetHashCode(),
@@ -181,10 +181,10 @@ class R3 : R2, IEquatable<R3>
         return base.Equals((R2?)other) &&
             EqualityComparer<T3>.Default.Equals(P3, other.P3);
     }
-    public static bool operator==(R3? r1, R3? r2)
-        => (object)r1 == r2 || (r1?.Equals(r2) ?? false);
-    public static bool operator!=(R3? r1, R3? r2)
-        => !(r1 == r2);    
+    public static bool operator==(R3? left, R3? right)
+        => (object)left == right || (left?.Equals(right) ?? false);
+    public static bool operator!=(R3? left, R3? right)
+        => !(left == right);
     public override int GetHashCode()
     {
         return Combine(base.GetHashCode(),


### PR DESCRIPTION
In accordance with https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/naming-parameters#naming-operator-overload-parameters

Related to https://github.com/dotnet/roslyn/issues/49300