### PR TITLE
Move CODEOWNERS file to correct folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @dotnet/roslyn-compiler

--- a/.github/ISSUE_TEMPLATE/CODEOWNERS
+++ b/.github/ISSUE_TEMPLATE/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @dotnet/roslyn-compiler

--- a/.github/ISSUE_TEMPLATE/CODEOWNERS
+++ b/.github/ISSUE_TEMPLATE/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @dotnet/roslyn-compiler


### PR DESCRIPTION
I'd accidentally placed the file in a sub-folder.