### PR TITLE
Fix readonly property samples

### DIFF
--- a/proposals/csharp-8.0/readonly-instance-members.md
+++ b/proposals/csharp-8.0/readonly-instance-members.md
@@ -51,9 +51,9 @@ public struct Vector2
         return tmp;
     }
 
-    public float LengthSquared
+    public readonly float LengthSquared
     {
-        readonly get
+        get
         {
             return (x * x) +
                    (y * y);
@@ -89,13 +89,13 @@ public static class MyClass
 Readonly can be applied to property accessors to indicate that `this` will not be mutated in the accessor. The following examples have readonly setters because those accessors modify the state of member field, but do not modify the value of that member field.
 
 ```csharp
-public int Prop1
+public readonly int Prop1
 {
-    readonly get
+    get
     {
         return this._store["Prop1"];
     }
-    readonly set
+    set
     {
         this._store["Prop1"] = value;
     }


### PR DESCRIPTION
The original code doesn't compile. `readonly` can be set on a getter or setter when only one of them is readonly. If all setters are readonly, `readonly` must be set on the property.

As this file is available in the documentation, I think this is better to keep it up to date.
- https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/readonly#c-language-specification
- https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/readonly-instance-members