### PR TITLE
Update LDM-2021-05-10.md

### DIFF
--- a/meetings/2021/LDM-2021-05-10.md
+++ b/meetings/2021/LDM-2021-05-10.md
@@ -31,7 +31,7 @@ These scenarios are all related to how much we want to define a "default" functi
 stifle later development around value delegates (if we even do such a feature). In C# today, we have 3 function types:
 
 * Delegate types that inherit from `System.Delegate`.
-* Expression tree types that inherit from `System.Linq.Expressions.**Expression`.
+* Expression tree types that inherit from `System.Linq.Expressions.Expression`.
 * Function pointer types.
 
 All of these types support conversions from some subset of method groups or lambdas, and none is currently privileged above another.


### PR DESCRIPTION
Fix typo in Expressions namespace.

To 
      `System.Linq.Expressions.Expression`
    
From 
     `System.Linq.Expressions.**Expression`