### PR TITLE
Specify unescaping rules for interpolated strings

### DIFF
--- a/proposals/improved-interpolated-strings.md
+++ b/proposals/improved-interpolated-strings.md
@@ -361,7 +361,7 @@ lowering for `i` is performed as follows:
 of a larger expression `e`, any components of `e` that occurred before `i` will be evaluated as well, again in lexical order.
 2. `Fc` is called with the length of the interpolated string literal components, the number of _interpolation_ holes, any previously evaluated arguments, and a `bool` out argument
 (if `Fc` was resolved with one as the last parameter). The result is stored into a temporary value `ib`.
-    1. The length of the literal components is calculated after replacing replacing any _open_brace_escape_sequence_ with a single `{`, and any _close_brace_escape_sequence_
+    1. The length of the literal components is calculated after replacing any _open_brace_escape_sequence_ with a single `{`, and any _close_brace_escape_sequence_
     with a single `}`.
 3. If `Fc` ended with a `bool` out argument, a check on that `bool` value is generated. If true, the methods in `Fa` will be called. Otherwise, they will not be called.
 4. For every `Fax` in `Fa`, `Fax` is called on `ib` with either the current literal component or _interpolation_ expression, as appropriate. If `Fax` returns a `bool`, the result is

--- a/proposals/improved-interpolated-strings.md
+++ b/proposals/improved-interpolated-strings.md
@@ -361,6 +361,8 @@ lowering for `i` is performed as follows:
 of a larger expression `e`, any components of `e` that occurred before `i` will be evaluated as well, again in lexical order.
 2. `Fc` is called with the length of the interpolated string literal components, the number of _interpolation_ holes, any previously evaluated arguments, and a `bool` out argument
 (if `Fc` was resolved with one as the last parameter). The result is stored into a temporary value `ib`.
+    1. The length of the literal components is calculated after replacing replacing any _open_brace_escape_sequence_ with a single `{`, and any _close_brace_escape_sequence_
+    with a single `}`.
 3. If `Fc` ended with a `bool` out argument, a check on that `bool` value is generated. If true, the methods in `Fa` will be called. Otherwise, they will not be called.
 4. For every `Fax` in `Fa`, `Fax` is called on `ib` with either the current literal component or _interpolation_ expression, as appropriate. If `Fax` returns a `bool`, the result is
 logically anded with all preceeding `Fax` calls.

--- a/proposals/improved-interpolated-strings.md
+++ b/proposals/improved-interpolated-strings.md
@@ -364,7 +364,7 @@ of a larger expression `e`, any components of `e` that occurred before `i` will 
 3. If `Fc` ended with a `bool` out argument, a check on that `bool` value is generated. If true, the methods in `Fa` will be called. Otherwise, they will not be called.
 4. For every `Fax` in `Fa`, `Fax` is called on `ib` with either the current literal component or _interpolation_ expression, as appropriate. If `Fax` returns a `bool`, the result is
 logically anded with all preceeding `Fax` calls.
-    1. If `Fax` is a call to `AppendLiteral`, the literal component is unescaped by replacing any _open_brace_escape_sequence_ with a single `{`, and any _close_brace_escape_sequence_s
+    1. If `Fax` is a call to `AppendLiteral`, the literal component is unescaped by replacing any _open_brace_escape_sequence_ with a single `{`, and any _close_brace_escape_sequence_
     with a single `}`.
 5. The result of the conversion is `ib`.
 

--- a/proposals/improved-interpolated-strings.md
+++ b/proposals/improved-interpolated-strings.md
@@ -364,6 +364,8 @@ of a larger expression `e`, any components of `e` that occurred before `i` will 
 3. If `Fc` ended with a `bool` out argument, a check on that `bool` value is generated. If true, the methods in `Fa` will be called. Otherwise, they will not be called.
 4. For every `Fax` in `Fa`, `Fax` is called on `ib` with either the current literal component or _interpolation_ expression, as appropriate. If `Fax` returns a `bool`, the result is
 logically anded with all preceeding `Fax` calls.
+    1. If `Fax` is a call to `AppendLiteral`, the literal component is unescaped by replacing any _open_brace_escape_sequence_ with a single `{`, and any _close_brace_escape_sequence_s
+    with a single `}`.
 5. The result of the conversion is `ib`.
 
 Again, note that arguments passed to `Fc` and arguments passed to `e` are the same temp. Conversions may occur on top of the temp to convert to a form that `Fc` requires, but for example


### PR DESCRIPTION
Spec side of https://github.com/dotnet/roslyn/issues/54703.
