### PR TITLE
A meeting with lambda improvements mentioned

### DIFF
--- a/proposals/lambda-improvements.md
+++ b/proposals/lambda-improvements.md
@@ -216,5 +216,6 @@ lambda_parameter
 
 ## Design meetings
 
-- https://github.com/dotnet/csharplang/blob/master/meetings/2021/LDM-2021-03-03.md
-- https://github.com/dotnet/csharplang/blob/master/meetings/2021/LDM-2021-04-12.md
+- https://github.com/dotnet/csharplang/blob/main/meetings/2021/LDM-2021-03-03.md
+- https://github.com/dotnet/csharplang/blob/main/meetings/2021/LDM-2021-04-12.md
+- https://github.com/dotnet/csharplang/blob/main/meetings/2021/LDM-2021-07-12.md


### PR DESCRIPTION
I was looking for the status of naturally typed lambdas and couldn't find. Then Fred gave me a link to a meeting which, I assume, should be mentioned in the lambda improvements proposal too, since it touches them.