### PR TITLE
De-duplicate titles

### DIFF
--- a/spec/attributes.md
+++ b/spec/attributes.md
@@ -1,4 +1,4 @@
-﻿# Attributes
+﻿# Attributes in C#
 
 Much of the C# language enables the programmer to specify declarative information about the entities defined in the program. For example, the accessibility of a method in a class is specified by decorating it with the *method_modifier*s `public`, `protected`, `internal`, and `private`.
 

--- a/spec/attributes.md
+++ b/spec/attributes.md
@@ -1,4 +1,4 @@
-﻿# Attributes in C#
+﻿# Attributes in C\#
 
 Much of the C# language enables the programmer to specify declarative information about the entities defined in the program. For example, the accessibility of a method in a class is specified by decorating it with the *method_modifier*s `public`, `protected`, `internal`, and `private`.
 

--- a/spec/conversions.md
+++ b/spec/conversions.md
@@ -1,4 +1,4 @@
-﻿# Conversions
+﻿# Conversions in C#
 
 A ***conversion*** enables an expression to be treated as being of a particular type. A conversion may cause an expression of a given type to be treated as having a different type, or it may cause an expression without a type to get a type. Conversions can be ***implicit*** or ***explicit***, and this determines whether an explicit cast is required. For instance, the conversion from type `int` to type `long` is implicit, so expressions of type `int` can implicitly be treated as type `long`. The opposite conversion, from type `long` to type `int`, is explicit and so an explicit cast is required.
 

--- a/spec/conversions.md
+++ b/spec/conversions.md
@@ -1,4 +1,4 @@
-﻿# Conversions in C#
+﻿# Conversions in C\#
 
 A ***conversion*** enables an expression to be treated as being of a particular type. A conversion may cause an expression of a given type to be treated as having a different type, or it may cause an expression without a type to get a type. Conversions can be ***implicit*** or ***explicit***, and this determines whether an explicit cast is required. For instance, the conversion from type `int` to type `long` is implicit, so expressions of type `int` can implicitly be treated as type `long`. The opposite conversion, from type `long` to type `int`, is explicit and so an explicit cast is required.
 

--- a/spec/expressions.md
+++ b/spec/expressions.md
@@ -1,4 +1,4 @@
-﻿# Expressions
+﻿# Expressions in C\#
 
 An expression is a sequence of operators and operands. This chapter defines the syntax, order of evaluation of operands and operators, and meaning of expressions.
 

--- a/spec/introduction.md
+++ b/spec/introduction.md
@@ -1,4 +1,4 @@
-﻿# Introduction
+﻿# Introduction to C\#
 
 C# (pronounced "See Sharp") is a simple, modern, object-oriented, and type-safe programming language. C# has its roots in the C family of languages and will be immediately familiar to C, C++, and Java programmers. C# is standardized by ECMA International as the ***ECMA-334*** standard and by ISO/IEC as the ***ISO/IEC 23270*** standard. Microsoft's C# compiler for the .NET Framework is a conforming implementation of both of these standards.
 

--- a/spec/statements.md
+++ b/spec/statements.md
@@ -1,4 +1,4 @@
-﻿# Statements
+﻿# Statements in C\#
 
 C# provides a variety of statements. Most of these statements will be familiar to developers who have programmed in C and C++.
 

--- a/spec/types.md
+++ b/spec/types.md
@@ -1,4 +1,4 @@
-﻿# Types
+﻿# Types in C/#
 
 The types of the C# language are divided into two main categories: ***value types*** and ***reference types***. Both value types and reference types may be ***generic types***, which take one or more ***type parameters***. Type parameters can designate both value types and reference types.
 

--- a/spec/types.md
+++ b/spec/types.md
@@ -1,4 +1,4 @@
-﻿# Types in C/#
+﻿# Types in C\#
 
 The types of the C# language are divided into two main categories: ***value types*** and ***reference types***. Both value types and reference types may be ***generic types***, which take one or more ***type parameters***. Type parameters can designate both value types and reference types.
 


### PR DESCRIPTION
The dotnet/csharplang and dotnet/vblang repos both publish to the docs.microsoft.com/dotnet URL/docset. Because there are articles in these two repos that have the same titles, e.g. "Attributes" and "Types", it's causing [build warnings in the dotnet/docs repo](https://opbuilduserstoragepublic.blob.core.windows.net/report/2021%5C7%5C26%5Ca3bda507-3390-de91-8f7f-26f90f4e5fc8%5CCommit%5C202107261737163177-main%5Cworkflow_report.html?skoid=280a3845-ef4c-4943-95ab-56a392a37cc8&sktid=975f013f-7f24-47e8-a7d3-abc4752bf346&skt=2021-07-26T01%3A27%3A30Z&ske=2021-08-02T01%3A32%3A30Z&sks=b&skv=2020-04-08&sv=2020-04-08&st=2021-07-26T18%3A59%3A51Z&se=2021-08-26T19%3A04%3A51Z&sr=b&sp=r&sig=Z70ptwFOGeD0qauKiNfgYVNfJzrgOzr5Ox7ANtnZnwI%3D). This PR resolves those build warnings.

Contributes to dotnet/docs#25322