### PR TITLE
fix build warnings in docs

### DIFF
--- a/proposals/csharp-10.0/GlobalUsingDirective.md
+++ b/proposals/csharp-10.0/GlobalUsingDirective.md
@@ -34,22 +34,22 @@ The scope of a *global_using_directive* specifically does not include *using_dir
 
 The effect of adding a *global_using_directive* to a program can be thought of as the effect of adding a similar *using_directive* that resolves to the same target namespace or type to every compilation unit of the program. However, the target of a *global_using_directive* is resolved in context of the compilation unit that contains it. 
 
-# Scopes 
+## Scopes 
 https://github.com/dotnet/csharplang/blob/master/spec/basic-concepts.md#scopes
 
 These are the relevant bullet points with proposed additions (which are **in bold**):
 *  The scope of name defined by an *extern_alias_directive* extends over the ***global_using_directive*s,** *using_directive*s, *global_attributes* and *namespace_member_declaration*s of its immediately containing compilation unit or namespace body. An *extern_alias_directive* does not contribute any new members to the underlying declaration space. In other words, an *extern_alias_directive* is not transitive, but, rather, affects only the compilation unit or namespace body in which it occurs.
 *  **The scope of a name defined or imported by a *global_using_directive* extends over the *global_attributes* and *namespace_member_declaration*s of all the *compilation_unit*s in the program.**
 
-# Namespace and type names
+## Namespace and type names
 https://github.com/dotnet/csharplang/blob/master/spec/basic-concepts.md#namespace-and-type-names
 
 Changes are made to the algorithm determining the meaning of a *namespace_or_type_name* as follows.
 
 This is the relevant bullet point with proposed additions (which are **in bold**):
 *   If the *namespace_or_type_name* is of the form `I` or of the form `I<A1, ..., Ak>`:
-    * If `K` is zero and the *namespace_or_type_name* appears within a generic method declaration ([Methods](classes.md#methods)) and if that declaration includes a type parameter ([Type parameters](classes.md#type-parameters)) with name `I`, then the *namespace_or_type_name* refers to that type parameter.
-    * Otherwise, if the *namespace_or_type_name* appears within a type declaration, then for each instance type `T` ([The instance type](classes.md#the-instance-type)), starting with the instance type of that type declaration and continuing with the instance type of each enclosing class or struct declaration (if any):
+    * If `K` is zero and the *namespace_or_type_name* appears within a generic method declaration ([Methods](../../spec/classes.md#methods)) and if that declaration includes a type parameter ([Type parameters](../../spec/classes.md#type-parameters)) with name `I`, then the *namespace_or_type_name* refers to that type parameter.
+    * Otherwise, if the *namespace_or_type_name* appears within a type declaration, then for each instance type `T` ([The instance type](../../spec/classes.md#the-instance-type)), starting with the instance type of that type declaration and continuing with the instance type of each enclosing class or struct declaration (if any):
         * If `K` is zero and the declaration of `T` includes a type parameter with name `I`, then the *namespace_or_type_name* refers to that type parameter.
         * Otherwise, if the *namespace_or_type_name* appears within the body of the type declaration, and `T` or any of its base types contain a nested accessible type having name `I` and `K` type parameters, then the *namespace_or_type_name* refers to that type constructed with the given type arguments. If there is more than one such type, the type declared within the more derived type is selected. Note that non-type members (constants, fields, methods, properties, indexers, operators, instance constructors, destructors, and static constructors) and type members with a different number of type parameters are ignored when determining the meaning of the *namespace_or_type_name*.
     * If the previous steps were unsuccessful then, for each namespace `N`, starting with the namespace in which the *namespace_or_type_name* occurs, continuing with each enclosing namespace (if any), and ending with the global namespace, the following steps are evaluated until an entity is located:
@@ -65,7 +65,7 @@ This is the relevant bullet point with proposed additions (which are **in bold**
             * Otherwise, if the namespaces and type declarations imported by the *using_namespace_directive*s and *using_alias_directive*s of the namespace declaration **and the namespaces and type declarations imported by the *global_using_namespace_directive*s and *global_using_static_directive*s of any namespace declaration for `N` in the program** contain more than one accessible type having name `I` and `K` type parameters, then the *namespace_or_type_name* is ambiguous and an error occurs.
     * Otherwise, the *namespace_or_type_name* is undefined and a compile-time error occurs.
 
-# Simple names
+## Simple names
 https://github.com/dotnet/csharplang/blob/master/spec/expressions.md#simple-names
 
 Changes are made to the *simple_name* evaluation rules as follows.
@@ -83,7 +83,7 @@ This is the relevant bullet point with proposed additions (which are **in bold**
       * Otherwise, if the namespaces and type declarations imported by the *using_namespace_directive*s and *using_static_directive*s of the namespace declaration **and the namespaces and type declarations imported by the *global_using_namespace_directive*s and *global_using_static_directive*s of any namespace declaration for `N` in the program** contain exactly one accessible type or non-extension static member having name `I` and `K` type parameters, then the *simple_name* refers to that type or member constructed with the given type arguments.
       * Otherwise, if the namespaces and types imported by the *using_namespace_directive*s of the namespace declaration **and the namespaces and type declarations imported by the *global_using_namespace_directive*s and *global_using_static_directive*s of any namespace declaration for `N` in the program** contain more than one accessible type or non-extension-method static member having name `I` and `K` type parameters, then the *simple_name* is ambiguous and an error occurs.
 
-# Extension method invocations
+## Extension method invocations
 https://github.com/dotnet/csharplang/blob/master/spec/expressions.md#extension-method-invocations
 
 Changes are made to the algorithm to find the best *type_name* `C` as follows.
@@ -92,7 +92,7 @@ This is the relevant bullet point with proposed additions (which are **in bold**
    * If the given namespace or compilation unit directly contains non-generic type declarations `Ci` with eligible extension methods `Mj`, then the set of those extension methods is the candidate set.
    * If types `Ci` imported by *using_static_declarations* and directly declared in namespaces imported by *using_namespace_directive*s in the given namespace or compilation unit **and, if containing compilation unit is reached, imported by *global_using_static_declarations* and directly declared in namespaces imported by *global_using_namespace_directive*s in the program** directly contain eligible extension methods `Mj`, then the set of those extension methods is the candidate set.
 
-# Compilation units
+## Compilation units
 https://github.com/dotnet/csharplang/blob/master/spec/namespaces.md#compilation-units
 
 A *compilation_unit* defines the overall structure of a source file. A compilation unit consists of **zero or more *global_using_directive*s followed by** zero or more *using_directive*s followed by zero or more *global_attributes* followed by zero or more *namespace_member_declaration*s.
@@ -107,17 +107,17 @@ A C# program consists of one or more compilation units, each contained in a sepa
 
 The *global_using_directive*s of a compilation unit affect the *global_attributes* and *namespace_member_declaration*s of all compilation units in the program.
 
-# Extern aliases
+## Extern aliases
 https://github.com/dotnet/csharplang/blob/master/spec/namespaces.md#extern-aliases
 
 The scope of an *extern_alias_directive* extends over the ***global_using_directive*s,** *using_directive*s, *global_attributes* and *namespace_member_declaration*s of its immediately containing compilation unit or namespace body.
 
-# Using alias directives
+## Using alias directives
 https://github.com/dotnet/csharplang/blob/main/spec/namespaces.md#using-alias-directives
 
 The order in which *using_alias_directive*s are written has no significance, and resolution of the *namespace_or_type_name* referenced by a *using_alias_directive* is not affected by the *using_alias_directive* itself or by other *using_directive*s in the immediately containing compilation unit or namespace body, **and, if the *using_alias_directive* is immediately contained in a compilation unit, is not affected by the *global_using_directive*s in the program**. In other words, the *namespace_or_type_name* of a *using_alias_directive* is resolved as if the immediately containing compilation unit or namespace body had no *using_directive*s **and, if the *using_alias_directive* is immediately contained in a compilation unit, the program had no *global_using_directive*s**. A *using_alias_directive* may however be affected by *extern_alias_directive*s in the immediately containing compilation unit or namespace body.
 
-# Global Using alias directives
+## Global Using alias directives
 
 A *global_using_alias_directive* introduces an identifier that serves as an alias for a namespace or type within the program.
 
@@ -141,7 +141,7 @@ Accessing a namespace or type through an alias yields exactly the same result as
 
 Using aliases can name a closed constructed type, but cannot name an unbound generic type declaration without supplying type arguments.
 
-# Global Using namespace directives
+## Global Using namespace directives
 
 A *global_using_namespace_directive* imports the types contained in a namespace into the program, enabling the identifier of each type to be used without qualification.
 
@@ -163,8 +163,7 @@ Furthermore, when more than one namespace or type imported by *global_using_name
 
 The *namespace_name* referenced by a *global_using_namespace_directive* is resolved in the same way as the *namespace_or_type_name* referenced by a *global_using_alias_directive*. Thus, *global_using_namespace_directive*s in the same program do not affect each other and can be written in any order.
 
-
-# Global Using static directives
+## Global Using static directives
 
 A *global_using_static_directive* imports the nested types and static members contained directly in a type declaration into the containing program, enabling the identifier of each member and type to be used without qualification.
 
@@ -182,13 +181,13 @@ A *global_using_static_directive* only imports members and types declared direct
 
 Ambiguities between multiple *global_using_namespace_directive*s and *global_using_static_directives* are discussed in the section for *global_using_namespace_directive*s (above).
 
-# Namespace alias qualifiers
+## Namespace alias qualifiers
 https://github.com/dotnet/csharplang/blob/master/spec/namespaces.md#namespace-alias-qualifiers
 
 Changes are made to the algorithm determining the meaning of a *qualified_alias_member* as follows.
 
 This is the relevant bullet point with proposed additions (which are **in bold**):
-*  Otherwise, starting with the namespace declaration ([Namespace declarations](namespaces.md#namespace-declarations)) immediately containing the *qualified_alias_member* (if any), continuing with each enclosing namespace declaration (if any), and ending with the compilation unit containing the *qualified_alias_member*, the following steps are evaluated until an entity is located:
+*  Otherwise, starting with the namespace declaration ([Namespace declarations](../../spec/namespaces.md#namespace-declarations)) immediately containing the *qualified_alias_member* (if any), continuing with each enclosing namespace declaration (if any), and ending with the compilation unit containing the *qualified_alias_member*, the following steps are evaluated until an entity is located:
 
    * If the namespace declaration or compilation unit contains a *using_alias_directive* that associates `N` with a type, **or, when a compilation unit is reached, the program contains a *global_using_alias_directive* that associates `N` with a type,** then the *qualified_alias_member* is undefined and a compile-time error occurs.
    * Otherwise, if the namespace declaration or compilation unit contains an *extern_alias_directive* or *using_alias_directive* that associates `N` with a namespace, ***or, when a compilation unit is reached, the program contains a *global_using_alias_directive* that associates `N` with a namespace,** then:

--- a/proposals/csharp-10.0/constant_interpolated_strings.md
+++ b/proposals/csharp-10.0/constant_interpolated_strings.md
@@ -81,17 +81,17 @@ Whenever an expression fulfills the requirements listed above, the expression is
 
 The compile-time evaluation of constant expressions uses the same rules as run-time evaluation of non-constant expressions, except that where run-time evaluation would have thrown an exception, compile-time evaluation causes a compile-time error to occur.
 
-Unless a constant expression is explicitly placed in an `unchecked` context, overflows that occur in integral-type arithmetic operations and conversions during the compile-time evaluation of the expression always cause compile-time errors ([Constant expressions](../spec/expressions.md#constant-expressions)).
+Unless a constant expression is explicitly placed in an `unchecked` context, overflows that occur in integral-type arithmetic operations and conversions during the compile-time evaluation of the expression always cause compile-time errors ([Constant expressions](../../spec/expressions.md#constant-expressions)).
 
 Constant expressions occur in the contexts listed below. In these contexts, a compile-time error occurs if an expression cannot be fully evaluated at compile-time.
 
-*  Constant declarations ([Constants](../spec/classes.md#constants)).
-*  Enumeration member declarations ([Enum members](../spec/enums.md#enum-members)).
-*  Default arguments of formal parameter lists ([Method parameters](../spec/classes.md#method-parameters))
-*  `case` labels of a `switch` statement ([The switch statement](../spec/statements.md#the-switch-statement)).
-*  `goto case` statements ([The goto statement](../spec/statements.md#the-goto-statement)).
-*  Dimension lengths in an array creation expression ([Array creation expressions](../spec/expressions.md#array-creation-expressions)) that includes an initializer.
-*  Attributes ([Attributes](../spec/attributes.md)).
+*  Constant declarations ([Constants](../../spec/classes.md#constants)).
+*  Enumeration member declarations ([Enum members](../../spec/enums.md#enum-members)).
+*  Default arguments of formal parameter lists ([Method parameters](../../spec/classes.md#method-parameters))
+*  `case` labels of a `switch` statement ([The switch statement](../../spec/statements.md#the-switch-statement)).
+*  `goto case` statements ([The goto statement](../../spec/statements.md#the-goto-statement)).
+*  Dimension lengths in an array creation expression ([Array creation expressions](../../spec/expressions.md#array-creation-expressions)) that includes an initializer.
+*  Attributes ([Attributes](../../spec/attributes.md)).
 
 An implicit constant expression conversion ([Implicit constant expression conversions](conversions.md#implicit-constant-expression-conversions)) permits a constant expression of type `int` to be converted to `sbyte`, `byte`, `short`, `ushort`, `uint`, or `ulong`, provided the value of the constant expression is within the range of the destination type.
 

--- a/proposals/csharp-10.0/file-scoped-namespaces.md
+++ b/proposals/csharp-10.0/file-scoped-namespaces.md
@@ -1,6 +1,6 @@
-## File Scoped Namespaces
+# File Scoped Namespaces
 
-### Summary
+## Summary
 
 Allow a simpler format for the common case of file containing only one namespace in it.  This format is `namespace X.Y.Z;` (note the semicolon and lack of braces).  This allows for files like so:
 
@@ -16,7 +16,7 @@ class X
 
 The semantics are that using the `namespace X.Y.Z;` form is equivalent to writing `namespace X.Y.Z { ... }` where the remainder of the file following the file-scoped namespace is in the `...` section of a standard namespace declaration.
 
-### Motivation
+## Motivation
 
 Analysis of the C# ecosystem shows that around 99.7% (or more) files are all of either one of these forms:
 
@@ -44,11 +44,11 @@ However, both these forms force the user to indent the majority of their code an
 
 The primary goal of the feature therefore is to meet the needs of the majority of the ecosystem with less unnecessary boilerplate.
 
-### Detailed design
+## Detailed design
 
 This proposal takes the form of a diff to the existing https://github.com/dotnet/csharplang/blob/main/spec/namespaces.md#compilation-units section of the specification.
 
-#### Diff
+### Diff
 
 ~~A *compilation_unit* defines the overall structure of a source file. A compilation unit consists of zero or more *using_directive*s followed by zero or more *global_attributes* followed by zero or more *namespace_member_declaration*s.~~
 

--- a/proposals/csharp-10.0/improved-definite-assignment.md
+++ b/proposals/csharp-10.0/improved-definite-assignment.md
@@ -1,7 +1,7 @@
 # Improved Definite Assignment Analysis
 
 ## Summary
-[Definite assignment analysis](../spec/variables.md#definite-assignment) as specified has a few gaps which have caused users inconvenience. In particular, scenarios involving comparison to boolean constants, conditional-access, and null coalescing.
+[Definite assignment analysis](../../spec/variables.md#definite-assignment) as specified has a few gaps which have caused users inconvenience. In particular, scenarios involving comparison to boolean constants, conditional-access, and null coalescing.
 
 ## Related discussions and issues
 csharplang discussion of this proposal: https://github.com/dotnet/csharplang/discussions/4240
@@ -97,11 +97,11 @@ if (c != null ? c.M(out object obj4) : false)
 # Specification
 
 ## ?. (null-conditional operator) expressions
-We introduce a new section **?. (null-conditional operator) expressions**. See the [null-conditional operator](../spec/expressions.md#null-conditional-operator) specification and [definite assignment rules](../spec/variables.md#precise-rules-for-determining-definite-assignment) for context.
+We introduce a new section **?. (null-conditional operator) expressions**. See the [null-conditional operator](../../spec/expressions.md#null-conditional-operator) specification and [definite assignment rules](../../spec/variables.md#precise-rules-for-determining-definite-assignment) for context.
 
 As in the definite assignment rules linked above, we refer to a given initially unassigned variable as *v*.
 
-We introduce the concept of "directly contains". An expression *E* is said to "directly contain" a subexpression *E<sub>1</sub>* if it is not subject to a [user-defined conversion](../spec/conversions.md#user-defined-conversions) whose parameter is not of a non-nullable value type, and one of the following conditions holds:
+We introduce the concept of "directly contains". An expression *E* is said to "directly contain" a subexpression *E<sub>1</sub>* if it is not subject to a [user-defined conversion](../../spec/conversions.md#user-defined-conversions) whose parameter is not of a non-nullable value type, and one of the following conditions holds:
 - *E* is *E<sub>1</sub>*. For example, `a?.b()` directly contains the expression `a?.b()`.
 - If *E* is a parenthesized expression `(E2)`, and *E<sub>2</sub>* directly contains *E<sub>1</sub>*.
 - If *E* is a null-forgiving operator expression `E2!`, and *E<sub>2</sub>* directly contains *E<sub>1</sub>*.
@@ -162,7 +162,7 @@ We assume that if an expression has a constant value bool `false`, for example, 
 It's also worth noting that we never expect to be in a conditional state *before* visiting a constant expression. That's why we do not account for scenarios such as "*expr* is a constant expression with value *true*, and the state of *v* before *expr* is "definitely assigned when true".
 
 ## ?? (null-coalescing expressions) augment
-We augment the section [?? (null coalescing) expressions](../spec/variables.md#-null-coalescing-expressions) as follows:
+We augment the section [?? (null coalescing) expressions](../../spec/variables.md#-null-coalescing-expressions) as follows:
 
 For an expression *expr* of the form `expr_first ?? expr_second`:
 - ...
@@ -180,7 +180,7 @@ The more general formulation also allows us to handle some more unusual scenario
 - `if (x?.M(out y) ?? z?.M(out y) ?? false) y.ToString();`
 
 ## ?: (conditional) expressions
-We augment the section [**?: (conditional) expressions**](../spec/variables.md#-conditional-expressions) as follows:
+We augment the section [**?: (conditional) expressions**](../../spec/variables.md#-conditional-expressions) as follows:
 
 For an expression *expr* of the form `expr_cond ? expr_true : expr_false`:
 - ...
@@ -210,15 +210,15 @@ This is an admittedly niche scenario, that compiles without error in the native 
 ## ==/!= (relational equality operator) expressions
 We introduce a new section **==/!= (relational equality operator) expressions**.
 
-The [general rules for expressions with embedded expressions](../spec/variables.md#general-rules-for-expressions-with-embedded-expressions) apply, except for the scenarios described below.
+The [general rules for expressions with embedded expressions](../../spec/variables.md#general-rules-for-expressions-with-embedded-expressions) apply, except for the scenarios described below.
 
-For an expression *expr* of the form `expr_first == expr_second`, where `==` is a [predefined comparison operator](../spec/expressions.md#relational-and-type-testing-operators) or a [lifted operator](../spec/expressions.md#lifted-operators), the definite assignment state of *v* after *expr* is determined by:
+For an expression *expr* of the form `expr_first == expr_second`, where `==` is a [predefined comparison operator](../../spec/expressions.md#relational-and-type-testing-operators) or a [lifted operator](../../spec/expressions.md#lifted-operators), the definite assignment state of *v* after *expr* is determined by:
   - If *expr_first* directly contains a null-conditional expression *E* and *expr_second* is a constant expression with value *null*, and the state of *v* after the non-conditional counterpart *E<sub>0</sub>* is "definitely assigned", then the state of *v* after *expr* is "definitely assigned when false".
   - If *expr_first* directly contains a null-conditional expression *E* and *expr_second* is an expression of a non-nullable value type, or a constant expression with a non-null value, and the state of *v* after the non-conditional counterpart *E<sub>0</sub>* is "definitely assigned", then the state of *v* after *expr* is "definitely assigned when true".
   - If *expr_first* is of type *boolean*, and *expr_second* is a constant expression with value *true*, then the definite assignment state after *expr* is the same as the definite assignment state after *expr_first*.
   - If *expr_first* is of type *boolean*, and *expr_second* is a constant expression with value *false*, then the definite assignment state after *expr* is the same as the definite assignment state of *v* after the logical negation expression `!expr_first`.
 
-For an expression *expr* of the form `expr_first != expr_second`, where `!=` is a [predefined comparison operator](../spec/expressions.md#relational-and-type-testing-operators) or a [lifted operator](../spec/expressions.md#lifted-operators), the definite assignment state of *v* after *expr* is determined by:
+For an expression *expr* of the form `expr_first != expr_second`, where `!=` is a [predefined comparison operator](../../spec/expressions.md#relational-and-type-testing-operators) or a [lifted operator](../../spec/expressions.md#lifted-operators), the definite assignment state of *v* after *expr* is determined by:
   - If *expr_first* directly contains a null-conditional expression *E* and *expr_second* is a constant expression with value *null*, and the state of *v* after the non-conditional counterpart *E<sub>0</sub>* is "definitely assigned", then the state of *v* after *expr* is "definitely assigned when true".
   - If *expr_first* directly contains a null-conditional expression *E* and *expr_second* is an expression of a non-nullable value type, or a constant expression with a non-null value, and the state of *v* after the non-conditional counterpart *E<sub>0</sub>* is "definitely assigned", then the state of *v* after *expr* is "definitely assigned when false".
   - If *expr_first* is of type *boolean*, and *expr_second* is a constant expression with value *true*, then the definite assignment state after *expr* is the same as the definite assignment state of *v* after the logical negation expression `!expr_first`.
@@ -261,7 +261,7 @@ For an expression *expr* of the form `E is T`, where *T* is any type or pattern
 This section is meant to address similar scenarios as in the `==`/`!=` section above.
 This specification does not address recursive patterns, e.g. `(a?.b(out x), c?.d(out y)) is (object, object)`. Such support may come later if time permits.
 
-# Additional scenarios
+## Additional scenarios
 
 This specification doesn't currently address scenarios involving pattern switch expressions and switch statements. For example:
 

--- a/proposals/csharp-10.0/record-structs.md
+++ b/proposals/csharp-10.0/record-structs.md
@@ -260,7 +260,7 @@ to the value from an instance member access to a member of the same name.
 The method can be declared explicitly. It is an error if the explicit declaration does not match
 the expected signature or accessibility, or is static.
 
-# Allow `with` expression on structs
+## Allow `with` expression on structs
 
 It is now valid for the receiver in a `with` expression to have a struct type.
 
@@ -272,9 +272,9 @@ For a receiver with struct type, the receiver is first copied, then each `member
 the same way as an assignment to a field or property access of the result of the conversion. 
 Assignments are processed in lexical order.
 
-# Improvements on records
+## Improvements on records
 
-## Allow `record class`
+### Allow `record class`
 
 The existing syntax for record types allows `record class` with the same meaning as `record`:
 
@@ -285,13 +285,13 @@ record_declaration
     ;
 ```
 
-## Allow user-defined positional members to be fields
+### Allow user-defined positional members to be fields
 
 See https://github.com/dotnet/csharplang/blob/master/meetings/2020/LDM-2020-10-05.md#changing-the-member-type-of-a-primary-constructor-parameter
 
 No auto-property is created if the record has or inherits an instance field with expected name and type.
 
-# Allow parameterless constructors and member initializers in structs
+## Allow parameterless constructors and member initializers in structs
 
 We are going to support both parameterless constructors and member initializers in structs.
 This will be specified in more details.
@@ -301,7 +301,7 @@ Allow parameterless ctors on structs and also field initializers (no runtime det
 We will enumerate scenarios where initializers aren't evaluated: arrays, generics, default, ...  
 Consider diagnostics for using struct with parameterless ctor in some of those cases?  
 
-# Open questions
+## Open questions
 
 - should we disallow a user-defined constructor with a copy constructor signature?
 - confirm that we want to disallow members named "Clone".
@@ -312,7 +312,7 @@ Consider diagnostics for using struct with parameterless ctor in some of those c
 - could field- or property-targeting attributes be placed in the positional parameter list?
 - how to place attributes on the properties of a record struct?  IDE has serialization types that would work nicely as record structs, but which need attributes on the members. Supporting `[property: DataMember(Order = 1)]` would solve this.
 
-## Answered
+### Answered
 
 - confirm that we want to keep PrintMembers design (separate method returning `bool`) (answer: yes)
 - confirm we won't allow `record ref struct` (issue with `IEquatable<RefStruct>` and ref fields) (answer: yes)

--- a/proposals/csharp-7.0/task-types.md
+++ b/proposals/csharp-7.0/task-types.md
@@ -1,5 +1,5 @@
-Async Task Types in C#
-======================
+# Async Task Types in C# #
+
 Extend `async` to support _task types_ that match a specific pattern, in addition to the well known types
 `System.Threading.Tasks.Task` and `System.Threading.Tasks.Task<T>`.
 

--- a/proposals/csharp-9.0/extending-partial-methods.md
+++ b/proposals/csharp-9.0/extending-partial-methods.md
@@ -1,5 +1,4 @@
-Extending Partial Methods
-=====
+# Extending Partial Methods
 
 ## Summary
 This proposal aims to remove all restrictions around the signatures of `partial`


### PR DESCRIPTION
Most of the fixes are updating links to sections of the spec so that they work correctly.

Other fixes include semantic markdown:
- exactly 1 H1 heading in each file.
- ATX style headers.

Discovered while working on dotnet/docs#25504