### PR TITLE
Update *Boolean expressions* section wording

### DIFF
--- a/spec/expressions.md
+++ b/spec/expressions.md
@@ -4868,7 +4868,7 @@ boolean_expression
     ;
 ```
 
-The controlling conditional expression of an *if_statement* ([The if statement](statements.md#the-if-statement)), *while_statement* ([The while statement](statements.md#the-while-statement)), *do_statement* ([The do statement](statements.md#the-do-statement)), or *for_statement* ([The for statement](statements.md#the-for-statement)) is a *boolean_expression*. The controlling conditional expression of the `?:` operator ([Conditional operator](expressions.md#conditional-operator)) follows the same rules as a *boolean_expression*, but for reasons of operator precedence is classified as a *conditional_or_expression*.
+The controlling conditional expression of an *if_statement* ([The if statement](statements.md#the-if-statement)), *while_statement* ([The while statement](statements.md#the-while-statement)), *do_statement* ([The do statement](statements.md#the-do-statement)), or *for_statement* ([The for statement](statements.md#the-for-statement)) is a *boolean_expression*. The controlling conditional expression of the `?:` operator ([Conditional operator](expressions.md#conditional-operator)) follows the same rules as a *boolean_expression*, but for reasons of operator precedence is classified as a *null_coalescing_expression*.
 
 A *boolean_expression* `E` is required to be able to produce a value of type `bool`, as follows:
 


### PR DESCRIPTION
Change: "but for reasons of operator precedence is classified as a *conditional_or_expression*" to "but for reasons of operator precedence is classified as a *null_coalescing_expression*"

Matches ANTLR definition of `conditional_expression` in *Conditional operator* section.
