### PR TITLE
Correct formatting of generic type name in LDM notes

### DIFF
--- a/meetings/2021/LDM-2021-09-20.md
+++ b/meetings/2021/LDM-2021-09-20.md
@@ -36,10 +36,10 @@ the issue. These options where:
 3. Change “better function member” to treat delegate types with identical signatures as equivalent, allowing tie-breaking rules to apply.
 4. Change “better function member” to prefer overloads where method type inference did not infer type arguments from the natural types
 of lambdas or method groups.
-5. Change “better function member” to prefer parameter types that are delegate types other than those used for natural type. (Prefer D
-over Action.)
+5. Change “better function member” to prefer parameter types that are delegate types other than those used for natural type. (Prefer `D`
+over `Action`.)
 6. Change “better function member” to prefer argument conversions other than “function type” conversions.
-7. Change “better function member” to prefer parameter types D or Expression<D> over Delegate or Expression, where D is a delegate type.
+7. Change “better function member” to prefer parameter types `D` or `Expression<D>` over `Delegate` or `Expression`, where `D` is a delegate type.
 
 Discussion further narrowed our focus to two combinations of the above options: 3+7 or 4+6. 3+7 results in a more aggressive break, while
 4+6 is more compatible with previous versions of C#. Given the extent of some of the breaks we're seeing, we think the more compatible


### PR DESCRIPTION
`Expression<D>` was not displayed correctly without back quotes.