### PR TITLE
Deleted confusing task lists from proposals

### DIFF
--- a/proposals/csharp-7.1/async-main.md
+++ b/proposals/csharp-7.1/async-main.md
@@ -1,10 +1,5 @@
 # Async Main
 
-* [x] Proposed
-* [ ] Prototype
-* [ ] Implementation
-* [ ] Specification
-
 ## Summary
 [summary]: #summary
 

--- a/proposals/csharp-7.1/generics-pattern-match.md
+++ b/proposals/csharp-7.1/generics-pattern-match.md
@@ -1,10 +1,5 @@
 # pattern-matching with generics
 
-* [x] Proposed
-* [ ] Prototype:
-* [ ] Implementation:
-* [ ] Specification:
-
 ## Summary
 [summary]: #summary
 

--- a/proposals/csharp-7.1/target-typed-default.md
+++ b/proposals/csharp-7.1/target-typed-default.md
@@ -1,10 +1,5 @@
 # Target-typed "default" literal
 
-* [x] Proposed
-* [x] Prototype
-* [x] Implementation
-* [ ] Specification
-
 ## Summary
 [summary]: #summary
 

--- a/proposals/csharp-7.2/private-protected.md
+++ b/proposals/csharp-7.2/private-protected.md
@@ -1,10 +1,5 @@
 # private protected
 
-* [x] Proposed
-* [x] Prototype: [Complete](https://github.com/dotnet/roslyn/blob/master/docs/features/private-protected.md)
-* [x] Implementation: [Complete](https://github.com/dotnet/roslyn/blob/master/docs/features/private-protected.md)
-* [x] Specification: [Complete](#detailed-design)
-
 ## Summary
 [summary]: #summary
 

--- a/proposals/csharp-7.2/readonly-ref.md
+++ b/proposals/csharp-7.2/readonly-ref.md
@@ -1,10 +1,5 @@
 # Readonly references
 
-* [x] Proposed
-* [x] Prototype
-* [x] Implementation: Started
-* [ ] Specification: Not Started
-
 ## Summary
 [summary]: #summary
 

--- a/proposals/csharp-8.0/async-streams.md
+++ b/proposals/csharp-8.0/async-streams.md
@@ -1,10 +1,5 @@
 # Async Streams
 
-* [x] Proposed
-* [x] Prototype
-* [ ] Implementation
-* [ ] Specification
-
 ## Summary
 [summary]: #summary
 

--- a/proposals/csharp-8.0/default-interface-methods.md
+++ b/proposals/csharp-8.0/default-interface-methods.md
@@ -1,10 +1,5 @@
 # default interface methods
 
-* [x] Proposed
-* [ ] Prototype: [In progress](https://github.com/dotnet/roslyn/blob/master/docs/features/DefaultInterfaceImplementation.md)
-* [ ] Implementation: None
-* [ ] Specification: In progress, below
-
 ## Summary
 [summary]: #summary
 

--- a/proposals/csharp-8.0/null-coalescing-assignment.md
+++ b/proposals/csharp-8.0/null-coalescing-assignment.md
@@ -1,10 +1,5 @@
 # null coalescing assignment
 
-* [x] Proposed
-* [x] Prototype: Completed
-* [x] Implementation: Completed
-* [x] Specification: Below
-
 ## Summary
 [summary]: #summary
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/26288.

These task lists were often outdated, I don't think they are tracking anything useful and they didn't render quite right on docs.MS, so I think it makes sense to delete them.

In a couple of cases, this also deletes links to documentation in `roslyn/docs/features`. If these should be preserved, I can add them back.

Also note that this PR only changes proposal that are shown on docs.MS (i.e. those under `proposals/csharp-x.y`). Those directly under `proposals` and those under `proposals/rejected` are left unchanged.