### PR TITLE
'record struct' constructor requires 'this' initializer that calls primary constructor or explicit constructor

### DIFF
--- a/proposals/csharp-10.0/parameterless-struct-constructors.md
+++ b/proposals/csharp-10.0/parameterless-struct-constructors.md
@@ -109,7 +109,7 @@ An explicit parameterless constructor in a `record struct` must have a `this` in
 ```csharp
 record struct R5(int F)
 {
-    public R5() { }                  // error: must have 'this' initializer
+    public R5() { }                  // error: must have 'this' initializer that calls explicit .ctor
     public R5(object o) : this() { } // ok
     public int F =  F;
 }

--- a/proposals/csharp-10.0/parameterless-struct-constructors.md
+++ b/proposals/csharp-10.0/parameterless-struct-constructors.md
@@ -105,11 +105,12 @@ record struct R3();                // primary .ctor: public R3() { }
 record struct R4() { int F = 42; } // primary .ctor: public R4() { F = 42; }
 ```
 
-An explicit parameterless constructor in a `record struct` must call the primary constructor.
+An explicit parameterless constructor in a `record struct` must have a `this` initializer that calls the primary constructor or an explicitly declared constructor.
 ```csharp
 record struct R5(int F)
 {
-    public R5() { } // error: must call 'this(int F)'
+    public R5() { }                  // error: must have 'this' initializer
+    public R5(object o) : this() { } // ok
     public int F =  F;
 }
 ```

--- a/proposals/csharp-10.0/record-structs.md
+++ b/proposals/csharp-10.0/record-structs.md
@@ -216,7 +216,7 @@ If there is no primary constructor, the instance initializers execute as part of
 Otherwise, at runtime the primary constructor executes the instance initializers appearing in the record-struct-body.
 
 If a record struct has a primary constructor, any user-defined constructor must have an
-explicit `this` constructor initializer.
+explicit `this` constructor initializer that calls the primary constructor or an explicitly declared constructor.
 
 Parameters of the primary constructor as well as members of the record struct are in scope within initializers of instance fields or properties. 
 Instance members would be an error in these locations (similar to how instance members are in scope in regular constructor initializers


### PR DESCRIPTION
In a `record struct` with a primary constructor, explicit constructors require a `this()` initializer that invokes the primary constructor or _another explicitly declared constructor_.
