### PR TITLE
Low level struct updates

### DIFF
--- a/proposals/csharp-7.2/span-safety.md
+++ b/proposals/csharp-7.2/span-safety.md
@@ -147,11 +147,13 @@ The precise rules for computing the *safe-to-return* status of an expression, an
 
 The *ref-safe-to-escape* is a scope, enclosing an lvalue expression, to which it is safe for a ref to the lvalue to escape to. If that scope is the entire method, we say that a ref to the lvalue is *safe to return* from the method.
 
+The *ref-safe-to-escape* scope for an lvalue expression can never be to a greater scope than the *safe-to-escape* for the same value. That means when the spec limits the *safe-to-escape* of a value it is implicitly also limiting the *ref-safe-to-escape* as well. However *ref-safe-to-escape* scope can be to a smaller scope than *safe-to-escape*. Consider that non-ref locals have *safe-to-escape* scope outside method but *ref-safe-to-escape* inside the method.
+
 ### safe-to-escape
 
 The *safe-to-escape* is a scope, enclosing an expression, to which it is safe for the value to escape to. If that scope is the entire method, we say that the value is *safe to return* from the method.
 
-An expression whose type is not a `ref struct` type is *safe-to-return* from the entire enclosing method. Otherwise we refer to the rules below.
+An expression whose type is not a `ref struct` type is always *safe-to-return* from the entire enclosing method. Otherwise we refer to the rules below.
 
 #### Parameters
 

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -9,7 +9,7 @@ Earlier versions of C# added a number of low level performance features to the l
 
 As these features have gained traction in the .NET ecosystem developers, both internal and external, have been providing us with information on remaining friction points in the ecosystem. Places where they still need to drop to `unsafe` code to get their work, or require the runtime to special case types like `Span<T>`. 
 
-Today `Span<T>` is accomplished by using the `internal` type `ByReferenec<T>` which the runtime effectively treats as a `ref` field. This provides the benefit of `ref` fields but with the downside that the language provides no safety verification for it, as it does for other uses of `ref`. Further only dotnet/runtime can use this type as it's `internal`, so 3rd parties can not design their own primitives based on `ref` fields. Part of the [motivation for this work](https://github.com/dotnet/runtime/issues/32060) is to remove `ByReference<T>` and use proper `ref` fields in all code bases. 
+Today `Span<T>` is accomplished by using the `internal` type `ByReference<T>` which the runtime effectively treats as a `ref` field. This provides the benefit of `ref` fields but with the downside that the language provides no safety verification for it, as it does for other uses of `ref`. Further only dotnet/runtime can use this type as it's `internal`, so 3rd parties can not design their own primitives based on `ref` fields. Part of the [motivation for this work](https://github.com/dotnet/runtime/issues/32060) is to remove `ByReference<T>` and use proper `ref` fields in all code bases. 
 
 This proposal plans to address these issues by building on top of our existing low level features. Specifically it aims to:
 
@@ -143,7 +143,7 @@ Next the rules for method invocation will change as follows when the target meth
     - The existing *safe-to-escape* calculation for method invocation
     - All of the *ref-safe-to-escape* values of `ref` and `in` arguments
 
-The design of `[RefFieldEscape]` will be discussed in detail [later in the propsal](#reffieldescapes).
+The design of `[RefFieldEscape]` will be discussed in detail [later in the proposal](#reffieldescapes).
 
 Let's examine these rules in the context of samples to better understand their impact and how they maintain the required compat considerations.
 
@@ -236,7 +236,7 @@ ref struct RS
 
 The samples here have the same patterns as the [compat considerations](#compat-considerations) above. This means it will allow the introduction of `ref` fields without breaking existing code.
 
-Constructor chaining needs to consider these new rules as well. When the original constructor calls a chained constructor via `:this(...)` the chained constructor effectively escapes from the original. That means a chained constructor call is olny legal if the *safe-to-escape* value is not smaller than the original constructor one. This will be accomplished with the following rules:
+Constructor chaining needs to consider these new rules as well. When the original constructor calls a chained constructor via `:this(...)` the chained constructor effectively escapes from the original. That means a chained constructor call is only legal if the *safe-to-escape* value is not smaller than the original constructor one. This will be accomplished with the following rules:
 
 - If the chained constructor has `[RefFieldEscapes]` 
     - If the original constructor has `[RefFieldEscapes]` then no additional checking is needed 

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -394,7 +394,7 @@ The rules for `ref` assignment also need to be adjusted to account for `ref` fie
 - `init` accessors:  The value limited to values that are known to refer to the heap as accessors can't have `ref` parameters
 - object initializers: The value can have any *ref-safe-to-escape* value as this will feed into the calculation of the *safe-to-escape* of the constructed object by existing rules.
 
-A `ref` field can only be `ref` assigned outside a constructor when the value is known to have a lifetime greater than the reciever. Specifically: 
+A `ref` field can only be `ref` assigned outside a constructor when the value is known to have a lifetime greater than or equal to the receiver. Specifically: 
 - A value that is known to refer to the heap is always allowed 
 - A value which is *safe-to-escape* to the *calling method* can be assigned to a `ref` field where the receiver is *safe-to-escape* within the *current method*
 - A value which is *safe-to-escape* to the *calling method* **cannot** be assigned to a `ref` field where the receiver is *safe-to-escape* to the *calling method*. In that situation it cannot be asserted that the field outlives the receiver.

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -4,23 +4,23 @@ Low Level Struct Improvements
 ***
 TODO
 types of lifetime capture we need to solve with annotations
-    - methods that capture a `ref` into a `ref` field (true for `ref` parameter or `ref`
-      field of an argument) and that is returned to the caller. Do we annotate the value
-      or the method
-    - `[RefEscapes]` `this` of a `struct` being ref-safe-to-escape (maybe this is a generalized `ref`
-      escape that could be applied to existing `ref` parameter)
-    - `[DoesNotRefEscape]` valuable once we have `ref` fields and we need to distinguish
-      which of the parameters is the captured ones 
-    - `[DoesNotEscape]` used to indicate that a `ref struct` can't escape from a method 
-      and that helps infer lifetime issues
+- methods that capture a `ref` into a `ref` field (true for `ref` parameter or `ref`
+    field of an argument) and that is returned to the caller. Do we annotate the value
+    or the method
+- `[RefEscapes]` `this` of a `struct` being ref-safe-to-escape (maybe this is a generalized `ref`
+    escape that could be applied to existing `ref` parameter)
+- `[DoesNotRefEscape]` valuable once we have `ref` fields and we need to distinguish
+    which of the parameters is the captured ones 
+- `[DoesNotEscape]` used to indicate that a `ref struct` can't escape from a method 
+    and that helps infer lifetime issues
 
 types of lifetime annotations that are not needed
-    - `[Escapes]` this is always true for non `ref struct` values and for a `ref struct`
-      it is the natural default. Can't think of a case where it would be needed
-    - `[DoesNotInput]` today `out` is treated no differently than `ref` and that can cause
-      confusion in places. This could be fixed by an annotation where we don't consider
-      the input of a `out` in lifetime calculation. This is narrow though and don't 
-      see the need to do it.
+- `[Escapes]` this is always true for non `ref struct` values and for a `ref struct`
+    it is the natural default. Can't think of a case where it would be needed
+- `[DoesNotInput]` today `out` is treated no differently than `ref` and that can cause
+    confusion in places. This could be fixed by an annotation where we don't consider
+    the input of a `out` in lifetime calculation. This is narrow though and don't 
+    see the need to do it.
 
 annotations need to be subject to verification. Consider marking a normal parameter
 as `[RefEscapes]` is non-sense and must be a compilation error. Likely need an allow

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -583,7 +583,7 @@ This attribute can be applied to methods, constructors and operators. Applying t
 The semantics of this attribute, and how it impacts span safety rules, are described [above](#ref-fields-escape)
 
 #### DoesNotEscape
-One source of repeated friction in low level code is the default escape for parameters is permissive. They are *safe-to-escape* to the *calling method*. This is a sensible defaults because it lines up with the coding patterns of .NET as a whole. In low level code though there is a larger use of  and `ref struct` and this default can cause friction with other parts of the span safety rules.
+One source of repeated friction in low level code is the default escape for parameters is permissive. They are *safe-to-escape* to the *calling method*. This is a sensible default because it lines up with the coding patterns of .NET as a whole. In low level code though there is a larger use of  `ref struct` and this default can cause friction with other parts of the span safety rules.
 
 The main friction point occurs because of the following constraint around method invocations:
 
@@ -693,7 +693,7 @@ class C
         // Error: `local` has the same safe-to-escape as `p2` hence it cannot
         // be returned.
         Span<int> local = p2;
-        return p2; 
+        return local; 
     }
 }
 ```
@@ -702,7 +702,7 @@ This attribute cannot be used on `ref` or `out` parameters. Those always implici
 
 To account for this change the "Parameters" section of the span safety document will be updated to include the following bullet:
 
-- If the parameter is marked with `[DoesNotEscape]`it is *safe-to-escape* is to the *current method*
+- If the parameter is marked with `[DoesNotEscape]` it is *safe-to-escape* to the *current method*
 
 It's important to note that this will naturally block the ability for such parameters to escape by being stored as fields. Receivers that are passed by `ref`, or `this` on `ref struct`, have a *safe-to-escape* scope outside the current method. Hence assignment from a `[DoesNotEscape]` parameter to a field on such a value fails by existing field assignment rules: the scope of the receiver is greater than the value being assigned.
 
@@ -734,7 +734,7 @@ For example the last line of calculating *safe-to-escape* of returns will change
 
 Detailed Notes:
 - The `[DoesNotEscape]` and `[RefThisEscapes]` cannot be combined on the same method 
-- The `[DoesNotEsacpe]` attribute cannot be used on parameters that are `ref`, `out` or `in`.
+- The `[DoesNotEscape]` attribute cannot be used on parameters that are `ref`, `out` or `in`.
 
 ### Safe fixed size buffers
 The language will relax the restrictions on fixed sized arrays such that they can be declared in safe code and the element type can be managed or unmanaged.  This will make types like the following legal:

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -793,9 +793,9 @@ These implicit opt-in strategies all have significant holes while an explicit op
 ### Reference Assemblies
 A reference assembly for a compilation using features described in this proposal must maintain the elements that convey span safety information. That means all lifetime annotation attributes and `[RefFieldEscapes]` must be preserved in their original position. Any attempt to replace or omit them can lead to invalid reference assemblies.
 
-Representing `ref` fields is more nuanaced. Ideally a `ref` field would appear in a reference assembly as would any other field. However a `ref` field represents a change to the metadata format and that can cause issues with tool chains that are not updated to understand this metadata change. A concrete example is C++/CLI which will likely error if it consumes a `ref` field. Hence it's advantageous if `ref` fields can be omitted from reference assemblies in our core libraries. 
+Representing `ref` fields is more nuanced. Ideally a `ref` field would appear in a reference assembly as would any other field. However a `ref` field represents a change to the metadata format and that can cause issues with tool chains that are not updated to understand this metadata change. A concrete example is C++/CLI which will likely error if it consumes a `ref` field. Hence it's advantageous if `ref` fields can be omitted from reference assemblies in our core libraries. 
 
-A `ref` field by itself has no impact on span safety rules. As a conecrete example consider that flipping the existing `Span<T>` defintion to use a `ref` field has no impact on consumption. Hence the `ref` itself can be omitted safely. However a `ref` field does have other impacts to consumption that must be preserved: 
+A `ref` field by itself has no impact on span safety rules. As a concrete example consider that flipping the existing `Span<T>` definition to use a `ref` field has no impact on consumption. Hence the `ref` itself can be omitted safely. However a `ref` field does have other impacts to consumption that must be preserved: 
 
 - A `ref struct` which has a `ref` field is never considered `unmanaged` 
 - The type of the `ref` field impacts infinite generic expansion rules. Hence if the type of a `ref` field contains a type parameter that must be preserved 

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -84,6 +84,19 @@ Further the design must ensure that once `ref` fields exist that implementations
 <a name="new-span-challenges"></a>
 
 ```c#
+Span<int> UseSpan()
+{
+    // This code is 100% legal and safe in C# today. The span safety rules and .NET runtime 
+    // ensure that CreateSpan **cannot** capture the parameter in the returned Span<T>. Hence
+    // the result is always returnable. 
+    // 
+    // The rules created for ref fields must ensure this remains legal else it becomes a 
+    // breaking change when moving to the new compiler.
+    int local = 42;
+    Span<int> span = CreateSpan(ref local);
+    return span;
+}
+
 Span<T> CreateSpan<T>(ref T parameter)
 {
     // This will create a length one Span<T> over the value referred to by `parameter`.
@@ -99,13 +112,6 @@ Span<T> CreateSpan<T>(ref T parameter)
     // returning references to values that live beyond this method call. But our existing
     // rules hide that this could be happening and callers do not account for it.
     return span;
-
-    int local = 42;
-
-    // Error: this is fundamentally unsafe because the created Span<T> is referring to 
-    // locals in the current stack from. This is a dangling reference. No rule change 
-    // is going to make this legal.
-    return new Span<int>(ref local);
 }
 ```
 

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -790,6 +790,31 @@ Several ideas for having implicit opt-in to `ref` capture were explored and disc
 
 These implicit opt-in strategies all have significant holes while an explicit opt-in is fully generalizable and makes the span safety rule different explicit in the code.
 
+### Reference Assemblies
+A reference assembly for a compilation using features described in this proposal must maintain the elements that convey span safety information. That means all lifetime annotation attributes and `[RefFieldEscapes]` must be preserved in their original position. Any attempt to replace or omit them can lead to invalid reference assemblies.
+
+Representing `ref` fields is more nuanaced. Ideally a `ref` field would appear in a reference assembly as would any other field. However a `ref` field represents a change to the metadata format and that can cause issues with tool chains that are not updated to understand this metadata change. A concrete example is C++/CLI which will likely error if it consumes a `ref` field. Hence it's advantageous if `ref` fields can be omitted from reference assemblies in our core libraries. 
+
+A `ref` field by itself has no impact on span safety rules. As a conecrete example consider that flipping the existing `Span<T>` defintion to use a `ref` field has no impact on consumption. Hence the `ref` itself can be omitted safely. However a `ref` field does have other impacts to consumption that must be preserved: 
+
+- A `ref struct` which has a `ref` field is never considered `unmanaged` 
+- The type of the `ref` field impacts infinite generic expansion rules. Hence if the type of a `ref` field contains a type parameter that must be preserved 
+
+Given those rules here is a valid reference assembly transformation for a `ref struct`: 
+
+```c#
+// Impl assembly 
+ref struct S<T> {
+    ref T _field;
+}
+
+// Ref assembly 
+ref struct S<T> {
+    object _o; // force unmanaged 
+    T _f; // mantain generic expansion protections
+}
+```
+
 ### Why isn't assignability to ref field a scope?
 It may seem attractive to think of the ability to assign to a `ref` field as just another scope concept instead of an orthogonal concept. Essentially *assignable to field* as an escape scope between *heap* and *calling method*. This falls a part though when looking at practical examples. Consider for example the following: 
 

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -60,6 +60,9 @@ Span<T> CreateSpan<T>(ref T parameter)
 
 By the existing span safety rules the return of an invocation of this method always has a //*safe-to-escape* value of *calling method*. That is because in the span safety document `ref` fields do not exist and hence there is no way for the return to capture `parameter` hence there is no constraint on the return.  The implementation of the method is completely irrelevant here, which is why it's omitted from the sample, because there is simply no way for the `ref` to be captured. This means no matter how this method is called the return is *safe-to-escape* to the *calling method*.
 
+This is not a hypothetical pattern, there are APIs today in .NET which have this basic structure. Very likely in customer code as well. One such example is [AsnDecoder.ReadEnumeratedBytes](https://github.com/dotnet/runtime/blob/3580ba795d92444e99fe5a5bfa4883458a0d4ac5/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Enumerated.cs#L48-L52). 
+
+
 ```c#
 Span<T> CompatExample(ref int p)
 {
@@ -145,7 +148,7 @@ Next the rules for method invocation will change as follows when the target meth
     - Else the *safe-to-escape* scope is to the *current method*
 - Else the *safe-to-escape* scope of the return is the minimum of 
     - The existing *safe-to-escape* calculation for method invocation
-    - All of the *ref-safe-to-escape* values of `ref` and `in` arguments
+    - All of the *ref-safe-to-escape* values of `ref`, `in` and `out` arguments
 
 The design of `[RefFieldEscape]` will be discussed in detail [later in the proposal](#reffieldescapes).
 
@@ -811,7 +814,7 @@ This would be a breaking change and it's easy to construct code samples that tri
 - Have a `Span<T>` or `ref struct` which has a `Span<T>` as
     - The return type 
     - A `ref` or `out` parameter
-- Take a `ref` or `in` parameter 
+- Take a `ref`, `in` or `out` parameter 
 
 If this is very low then it's possible that a breaking change could be acceptable here. 
 

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -501,7 +501,7 @@ The lifetime defaults for these locations is not fundamental to correctness. For
 This, and several other friction points, can be removed if the language provides developers a way to invert the defaults by applying attributes to specific locations. The language can recognize these attributes and simply adjust the lifetime calculation for locations when evaluating span safety.
 
 #### RefThisEscapes
-One of the most notable friction points in the inability to return fields by `ref` in instance members of a `struct`. This means developers can't create `ref` returning methods / properties and have to resort to exposing fields directly. This reduces the usefulness of `ref` returns in `struct` where it is often the most desired. 
+One of the most notable friction points is the inability to return fields by `ref` in instance members of a `struct`. This means developers can't create `ref` returning methods / properties and have to resort to exposing fields directly. This reduces the usefulness of `ref` returns in `struct` where it is often the most desired. 
 
 ```c#
 struct S
@@ -717,7 +717,7 @@ ref struct S
 
         // Error: the [DoesNotEscape] attribute changes the *safe-to-escape* 
         // to be limited to the current method scope. Hence it cannot be 
-        // assigned to a receiver than has a *safe-to-escape* scope outside the 
+        // assigned to a receiver that has a *safe-to-escape* scope outside the 
         // current method.
         _field = p2;
     }
@@ -768,7 +768,7 @@ This also has the added benefit that it will make `fixed` buffers easier to cons
 
 There will also be a by value `get` and `set` accessor generated for every 
 
-The backing storage for the buffer will be generated using the `[InlineArray]` attribute. This is a mechanism discussed in [isuse 12320](https://github.com/dotnet/runtime/issues/12320) which allows specifically for the case of efficiently declaring sequence of fields of the same type. This particular issue is still under active discussion and the expectation is that the implementation of this feature will follow however that discussion goes.
+The backing storage for the buffer will be generated using the `[InlineArray]` attribute. This is a mechanism discussed in [issue 12320](https://github.com/dotnet/runtime/issues/12320) which allows specifically for the case of efficiently declaring sequence of fields of the same type. This particular issue is still under active discussion and the expectation is that the implementation of this feature will follow however that discussion goes.
 
 ## Considerations
 

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -663,7 +663,7 @@ void WriteData(ReadOnlySpan<char> data)
         Escape(data, buffer, out var length);
 
         // Error: Cannot assign `buffer` to `data` here as the safe-to-escape
-        // scope of `buffer` is to the current method scope while `buffer` is
+        // scope of `buffer` is to the current method scope while `data` is
         // outside the current method scope
         data = buffer.Slice(0, length);
     }

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -201,7 +201,7 @@ ref struct RS
     static RS CreateRS2(ref int parameter)
     {
         // Okay: Both CreateRS2 and RS(ref int) are annotated as [RefFieldEscapes] hence the 
-        // safe-to-escape scope of the return is is the min of the ref-safe-to-escape scope of 
+        // safe-to-escape scope of the return is the min of the ref-safe-to-escape scope of 
         // the ref / in arguments. In that case this is simply `parameter` which has a
         // ref-safe-to-escape scope of the calling method
         RS rs = new RS(ref parameter);

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -1,6 +1,38 @@
 Low Level Struct Improvements
 =====
 
+***
+TODO
+types of lifetime capture we need to solve with annotations
+    - methods that capture a `ref` into a `ref` field (true for `ref` parameter or `ref`
+      field of an argument) and that is returned to the caller. Do we annotate the value
+      or the method
+    - `[RefEscapes]` `this` of a `struct` being ref-safe-to-escape (maybe this is a generalized `ref`
+      escape that could be applied to existing `ref` parameter)
+    - `[DoesNotRefEscape]` valuable once we have `ref` fields and we need to distinguish
+      which of the parameters is the captured ones 
+    - `[DoesNotEscape]` used to indicate that a `ref struct` can't escape from a method 
+      and that helps infer lifetime issues
+
+types of lifetime annotations that are not needed
+    - `[Escapes]` this is always true for non `ref struct` values and for a `ref struct`
+      it is the natural default. Can't think of a case where it would be needed
+    - `[DoesNotInput]` today `out` is treated no differently than `ref` and that can cause
+      confusion in places. This could be fixed by an annotation where we don't consider
+      the input of a `out` in lifetime calculation. This is narrow though and don't 
+      see the need to do it.
+
+annotations need to be subject to verification. Consider marking a normal parameter
+as `[RefEscapes]` is non-sense and must be a compilation error. Likely need an allow
+list for when these can be added
+
+what is the default escape rules of `ref` fields?
+
+intersection of annotations and the `[InlineArray]` attribute. Maybe it implies and 
+/ or requires `[RefEscapes]`
+
+***
+
 ## Summary
 This proposal is an aggregation of several different proposals for `struct` performance improvements: ref fields and attributes to override lifetime defaults.  The goal being a design which takes into account the various proposals to create a single overarching feature set for `struct` improvements.
 

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -118,7 +118,7 @@ Span<T> CreateSpan<T>(ref T parameter)
 }
 ```
 
-It will be possible for such methods to exist. Specifically methods which take `ref` parameters, capture them in `ref` fields and return them. But they require a declarative opt-in to let the compiler, and developer, know that it is happening and to adjust the span spafety rules accordingly.
+It will be possible for such methods to exist. Specifically methods which take `ref` parameters, capture them in `ref` fields and return them. But they require a declarative opt-in to let the compiler, and developer, know that it is happening and to adjust the span safety rules accordingly.
 
 It is important to understand these compat considerations before diving too far into the proposal here as they are central to parts of the design.
 


### PR DESCRIPTION
Updates to the low level struct improvements document. Changes:

1. Tried to put the compat issue up front. Want readers to understand that as a separate concept as it comes up many times in the feature design
2. Solved the issue of how non-constructors could return `ref struct` which had `ref` fields
3. Have firm rules now about which life time annotations we will support and how they interact with the existing rules