### PR TITLE
Fix code format

### DIFF
--- a/spec/documentation-comments.md
+++ b/spec/documentation-comments.md
@@ -32,8 +32,8 @@ __Example:__
 ///
 public class Point 
 {
-    /// <summary>method <c>draw</c> renders the point.</summary>
-    void draw() {...}
+    /// <summary>method <c>Draw</c> renders the point.</summary>
+    void Draw() {...}
 }
 ```
 


### PR DESCRIPTION
See: https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md

> We use PascalCasing for all method names, including local functions.