### PR TITLE
Mention async methods in param-nullchecking spec

### DIFF
--- a/proposals/param-nullchecking.md
+++ b/proposals/param-nullchecking.md
@@ -135,6 +135,8 @@ void G() {
 }
 ```
 
+`async` methods can have null-checked parameters. The null check occurs when the method is invoked.
+
 The syntax is also valid on parameters to iterator methods. Unlike other code in the iterator the `null` validation will
 occur when the iterator method is invoked, not when the underlying enumerator is walked. This is true for traditional
 or `async` iterators.


### PR DESCRIPTION
Related to dotnet/roslyn#36024