### PR TITLE
Document native integers not supported as 'enum' base type

### DIFF
--- a/proposals/csharp-9.0/native-integers.md
+++ b/proposals/csharp-9.0/native-integers.md
@@ -279,9 +279,9 @@ static object GetItem(object[] array, nint index)
 }
 ```
 
-`nint` and `nuint` can be used as an `enum` base type.
+`nint` and `nuint` cannot be used as an `enum` base type from C#.
 ```C#
-enum E : nint // ok
+enum E : nint // error: byte, sbyte, short, ushort, int, uint, long, or ulong expected
 {
 }
 ```


### PR DESCRIPTION
Update proposals/csharp-9.0/native-integers.md to indicate that native integers are not supported as `enum` base types.

Allowing native integer base types is tracked by https://github.com/dotnet/roslyn/issues/44110.
Relates to test plan https://github.com/dotnet/roslyn/issues/38821