### PR TITLE
Leave type parameters untouched by 'nameof(parameter)' feature

### DIFF
--- a/proposals/extended-nameof-scope.md
+++ b/proposals/extended-nameof-scope.md
@@ -14,14 +14,10 @@ Attributes like `NotNullWhen` or `CallerExpression` need to refer to parameters,
 
 ## Detailed design
 
-[Methods](https://github.com/dotnet/csharplang/blob/master/spec/classes.md#methods)
-
-The method's *type_parameters* are in scope throughout the *method_declaration*, and can be used to form types throughout that scope in *return_type*, *method_body*, and *type_parameter_constraints_clauses* but not in *attributes*, **except within a `nameof` expression in *attributes*.**
-
 [Method parameters](https://github.com/dotnet/csharplang/blob/master/spec/classes.md#method-parameters)
 
 A method declaration creates a separate declaration space for parameters, type parameters and local variables. Names are introduced into this declaration space by the type parameter list and the formal parameter list of the method and by local variable declarations in the block of the method.
-**Names are introduced into this declaration space by the type parameter list and the formal parameter list of the method in `nameof` expressions in attributes placed on the method or its parameters.**
+**Names are introduced into this declaration space by the formal parameter list of the method in `nameof` expressions in attributes placed on the method or its parameters.**
 
 \[...]   
 Within the block of a method, formal parameters can be referenced by their identifiers in simple_name expressions (Simple names).
@@ -33,7 +29,7 @@ A *simple_name* is either of the form `I` or of the form `I<A1,...,Ak>`, where `
 
 - If `K` is zero and the *simple_name* appears within a block and if the block's (or an enclosing block's) local variable declaration space (Declarations) contains a local variable, parameter or constant with name `I`, then the *simple_name* refers to that local variable, parameter or constant and is classified as a variable or value.
 - If `K` is zero and the *simple_name* appears within the body of a generic method declaration and if that declaration includes a type parameter with name `I`, then the *simple_name* refers to that type parameter.
-- **If `K` is zero and the *simple_name* appears within a `nameof` expression in an attribute on the method declaration or its parameters and if that declaration includes a parameter or type parameter with name `I`, then the *simple_name* refers to that parameter or type parameter.**
+- **If `K` is zero and the *simple_name* appears within a `nameof` expression in an attribute on the method declaration or its parameters and if that declaration includes a parameter with name `I`, then the *simple_name* refers to that parameter.**
 - Otherwise, for each instance type `T` (The instance type), starting with the instance type of the immediately enclosing type declaration and continuing with the instance type of each enclosing class or struct declaration (if any):  
 \[...]
 - Otherwise, for each namespace `N`, starting with the namespace in which the *simple_name* occurs, continuing with each enclosing namespace (if any), and ending with the global namespace, the following steps are evaluated until an entity is located:  


### PR DESCRIPTION
FYI @333fred 
I don't see benefit of allowing `[Attribute(nameof(TypeParameter))] void M<TypeParameter>() { }` so removing from the spec, since that's not the point of the feature. Will confirm with LDM when we review this speclet.

Relates to https://github.com/dotnet/roslyn/issues/40524