### PR TITLE
Clarify binding rules for `await foreach`

### DIFF
--- a/proposals/csharp-8.0/async-streams.md
+++ b/proposals/csharp-8.0/async-streams.md
@@ -230,7 +230,7 @@ is then expanded to:
 
 The body of the `finally` block is constructed according to the following steps:
 - If the type `E` has an appropriate `DisposeAsync` method:
-  - Perform member lookup on the type `E` with identifier `DisposeAsync` and no type arguments. If the member lookup does not produce a match, or it produces an ambiguity, or produces a match that is not a method group, check for the disposal  interface as described below.
+  - Perform member lookup on the type `E` with identifier `DisposeAsync` and no type arguments. If the member lookup does not produce a match, or it produces an ambiguity, or produces a match that is not a method group, check for the disposal interface as described below.
   - Perform overload resolution using the resulting method group and an empty argument list. If overload resolution results in no applicable methods, results in an ambiguity, or results in a single best method but that method is either static or not public, check for the disposal interface as described below.
   - If the return type of the `DisposeAsync` method is not awaitable, an error is produced and no further steps are taken.
   - The `finally` clause is expanded to the semantic equivalent of:

--- a/proposals/csharp-8.0/async-streams.md
+++ b/proposals/csharp-8.0/async-streams.md
@@ -189,7 +189,7 @@ No syntax would be provided that would support using either the async or the syn
 
 ### Semantics
 
-The compile-time processing of an async `foreach` statement first determines the ***collection type***, ***enumerator type*** and ***iteration type*** of the expression (very similar to https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/statements.md#1295-the-foreach-statement). This determination proceeds as follows:
+The compile-time processing of an `await foreach` statement first determines the ***collection type***, ***enumerator type*** and ***iteration type*** of the expression (very similar to https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/statements.md#1295-the-foreach-statement). This determination proceeds as follows:
 
 - If the type `X` of *expression* is `dynamic` or an array type, then an error is produced an no further steps are taken.
 - Otherwise, determine whether the type `X` has an appropriate `GetAsyncEnumerator` method:
@@ -254,7 +254,7 @@ The body of the `finally` block is constructed according to the following steps:
     }
     ```
     except that if `E` is a value type, or a type parameter instantiated to a value type, then the conversion of `e` to `System.IAsyncDisposable` shall not cause boxing to occur.
-- Otherwise, if `E` is a sealed type, the `finally` clause is expanded to an empty block:
+- Otherwise, the `finally` clause is expanded to an empty block:
   ```csharp
   finally {
   }

--- a/proposals/csharp-8.0/async-streams.md
+++ b/proposals/csharp-8.0/async-streams.md
@@ -204,7 +204,7 @@ The requirements for the enumeration pattern are:
 - The enumerator must expose a `MoveNextAsync` method that may be called with no arguments and that returns something which may be `await`ed and whose `GetResult()` returns a `bool`.
 - The enumerator must also expose `Current` property whose getter returns a `T` representing the kind of data being enumerated.
 
-For disposal, we first try to bind using pattern-based disposal, otherwise we check for the async disposal interface (`System.IDisposable`), otherwise disposal is skipped.
+For disposal, we first try to bind using pattern-based disposal, otherwise we check for the async disposal interface (`System.IAsyncDisposable`), otherwise disposal is skipped.
 
 To fulfill the disposal pattern, the enumerator must expose a `DisposeAsync` method that may be invoked with no arguments and that returns something that can be `await`ed and whose `GetResult()` returns `void`.
 

--- a/proposals/csharp-8.0/async-streams.md
+++ b/proposals/csharp-8.0/async-streams.md
@@ -204,7 +204,7 @@ The requirements for the enumeration pattern are:
 - The enumerator must expose a `MoveNextAsync` method that may be called with no arguments and that returns something which may be `await`ed and whose `GetResult()` returns a `bool`.
 - The enumerator must also expose `Current` property whose getter returns a `T` representing the kind of data being enumerated.
 
-For disposal, we first try to bind using pattern-based disposal, otherwise we check for the async disposal interface (`System.IAsyncDisposable`), otherwise disposal is skipped.
+Given that we've determined the enumerator type above, for disposal, we first try to bind using pattern-based disposal, otherwise we check for the async disposal interface (`System.IAsyncDisposable`), otherwise disposal is skipped.
 
 To fulfill the disposal pattern, the enumerator must expose a `DisposeAsync` method that may be invoked with no arguments and that returns something that can be `await`ed and whose `GetResult()` returns `void`.
 

--- a/proposals/csharp-8.0/async-streams.md
+++ b/proposals/csharp-8.0/async-streams.md
@@ -191,7 +191,7 @@ No syntax would be provided that would support using either the async or the syn
 
 The compile-time processing of an `await foreach` statement first determines the ***collection type***, ***enumerator type*** and ***iteration type*** of the expression (very similar to https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/statements.md#1295-the-foreach-statement). This determination proceeds as follows:
 
-- If the type `X` of *expression* is `dynamic` or an array type, then an error is produced an no further steps are taken.
+- If the type `X` of *expression* is `dynamic` or an array type, then an error is produced and no further steps are taken.
 - Otherwise, determine whether the type `X` has an appropriate `GetAsyncEnumerator` method:
   - Perform member lookup on the type `X` with identifier `GetAsyncEnumerator` and no type arguments. If the member lookup does not produce a match, or it produces an ambiguity, or produces a match that is not a method group, check for an enumerable interface as described below.
   - Perform overload resolution using the resulting method group and an empty argument list. If overload resolution results in no applicable methods, results in an ambiguity, or results in a single best method but that method is either static or not public, check for an enumerable interface as described below.

--- a/proposals/csharp-8.0/async-streams.md
+++ b/proposals/csharp-8.0/async-streams.md
@@ -197,13 +197,18 @@ Still to consider:
 
 ### Pattern-based Compilation
 
-The compiler will bind to the pattern-based APIs if they exist, preferring those over using the interface (the pattern may be satisfied with instance methods or extension methods).  The requirements for the pattern are:
+For enumeration, we first try to bind using pattern-based enumeration (see [`foreach` statement](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/statements.md#1295-the-foreach-statement) and details below), otherwise we check for the async enumerable interface (`System.Collections.GenericIAsyncEnumerable<T>`).
+
+The requirements for the enumeration pattern are:
 - The enumerable must expose a `GetAsyncEnumerator` method that may be called with no arguments and that returns an enumerator that meets the relevant pattern.
 - The enumerator must expose a `MoveNextAsync` method that may be called with no arguments and that returns something which may be `await`ed and whose `GetResult()` returns a `bool`.
 - The enumerator must also expose `Current` property whose getter returns a `T` representing the kind of data being enumerated.
-- The enumerator may optionally expose a `DisposeAsync` method that may be invoked with no arguments and that returns something that can be `await`ed and whose `GetResult()` returns `void`.
 
-This code:
+For disposal, we first try to bind using pattern-based disposal, otherwise we check for the async disposal interface (`System.IDisposable`), otherwise disposal is skipped.
+
+To fulfill the disposal pattern, the enumerator must expose a `DisposeAsync` method that may be invoked with no arguments and that returns something that can be `await`ed and whose `GetResult()` returns `void`.
+
+Using pattern-based enumeration and disposal, this code:
 
 ```csharp
 var enumerable = ...;
@@ -232,7 +237,7 @@ finally
 }
 ```
 
-If the iterated type doesn't expose the right pattern, the interfaces will be used.
+If the iterated type doesn't expose the right patterns, the interfaces will be used.
 
 ### ConfigureAwait
 

--- a/proposals/csharp-8.0/async-streams.md
+++ b/proposals/csharp-8.0/async-streams.md
@@ -1,4 +1,4 @@
-# Async Streams
+﻿# Async Streams
 
 ## Summary
 [summary]: #summary
@@ -187,57 +187,78 @@ await foreach (var i in enumerable)
 
 No syntax would be provided that would support using either the async or the sync APIs; the developer must choose based on the syntax used.
 
-Discarded options considered:
-- _`foreach (var i in await enumerable)`_: This is already valid syntax, and changing its meaning would be a breaking change.  This means to `await` the `enumerable`, get back something synchronously iterable from it, and then synchronously iterate through that.
-- _`foreach (var i await in enumerable)`, `foreach (var await i in enumerable)`, `foreach (await var i in enumerable)`_: These all suggest that we're awaiting the next item, but there are other awaits involved in foreach, in particular if the enumerable is an `IAsyncDisposable`, we will be `await`'ing its async disposal.  That await is as the scope of the foreach rather than for each individual element, and thus the `await` keyword deserves to be at the `foreach` level.  Further, having it associated with the `foreach` gives us a way to describe the `foreach` with a different term, e.g. a "await foreach".  But more importantly, there's value in considering `foreach` syntax at the same time as `using` syntax, so that they remain consistent with each other, and `using (await ...)` is already valid syntax.
-- _`foreach await (var i in enumerable)`_
+### Semantics
 
-Still to consider:
-- `foreach` today does not support iterating through an enumerator.  We expect it will be more common to have `IAsyncEnumerator<T>`s handed around, and thus it's tempting to support `await foreach` with both `IAsyncEnumerable<T>` and `IAsyncEnumerator<T>`.  But once we add such support, it introduces the question of whether `IAsyncEnumerator<T>` is a first-class citizen, and whether we need to have overloads of combinators that operate on enumerators in addition to enumerables?    Do we want to encourage methods to return enumerators rather than enumerables? We should continue to discuss this.  If we decide we don't want to support it, we might want to introduce an extension method `public static IAsyncEnumerable<T> AsEnumerable<T>(this IAsyncEnumerator<T> enumerator);` that would allow an enumerator to still be `foreach`'d.  If we decide we do want to support it, we'll need to also decide on whether the `await foreach` would be responsible for calling `DisposeAsync` on the enumerator, and the answer is likely "no, control over disposal should be handled by whoever called `GetEnumerator`."
+The compile-time processing of an async `foreach` statement first determines the ***collection type***, ***enumerator type*** and ***iteration type*** of the expression (very similar to https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/statements.md#1295-the-foreach-statement). This determination proceeds as follows:
 
-### Pattern-based Compilation
+- If the type `X` of *expression* is `dynamic` or an array type, then an error is produced an no further steps are taken.
+- Otherwise, determine whether the type `X` has an appropriate `GetAsyncEnumerator` method:
+  - Perform member lookup on the type `X` with identifier `GetAsyncEnumerator` and no type arguments. If the member lookup does not produce a match, or it produces an ambiguity, or produces a match that is not a method group, check for an enumerable interface as described below.
+  - Perform overload resolution using the resulting method group and an empty argument list. If overload resolution results in no applicable methods, results in an ambiguity, or results in a single best method but that method is either static or not public, check for an enumerable interface as described below.
+  - If the return type `E` of the `GetAsyncEnumerator` method is not a class, struct or interface type, an error is produced and no further steps are taken.
+  - Member lookup is performed on `E` with the identifier `Current` and no type arguments. If the member lookup produces no match, the result is an error, or the result is anything except a public instance property that permits reading, an error is produced and no further steps are taken.
+  - Member lookup is performed on `E` with the identifier `MoveNextAsync` and no type arguments. If the member lookup produces no match, the result is an error, or the result is anything except a method group, an error is produced and no further steps are taken.
+  - Overload resolution is performed on the method group with an empty argument list. If overload resolution results in no applicable methods, results in an ambiguity, or results in a single best method but that method is either static or not public, or its return type is not awaitable into `bool`, an error is produced and no further steps are taken.
+  - The collection type is `X`, the enumerator type is `E`, and the iteration type is the type of the `Current` property.
+- Otherwise, check for an enumerable interface:
+  - If among all the types `Tᵢ` for which there is an implicit conversion from `X` to `IAsyncEnumerable<ᵢ>`, there is a unique type `T` such that `T` is not dynamic and for all the other `Tᵢ` there is an implicit conversion from `IAsyncEnumerable<T>` to `IAsyncEnumerable<Tᵢ>`, then the collection type is the interface `IAsyncEnumerable<T>`, the enumerator type is the interface `IAsyncEnumerator<T>`, and the iteration type is `T`.
+  - Otherwise, if there is more than one such type `T`, then an error is produced and no further steps are taken.
+- Otherwise, an error is produced and no further steps are taken.
 
-For enumeration, we first try to bind using pattern-based enumeration (see [`foreach` statement](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/statements.md#1295-the-foreach-statement) and details below), otherwise we check for the async enumerable interface (`System.Collections.GenericIAsyncEnumerable<T>`).
-
-The requirements for the enumeration pattern are:
-- The enumerable must expose a `GetAsyncEnumerator` method that may be called with no arguments and that returns an enumerator that meets the relevant pattern.
-- The enumerator must expose a `MoveNextAsync` method that may be called with no arguments and that returns something which may be `await`ed and whose `GetResult()` returns a `bool`.
-- The enumerator must also expose `Current` property whose getter returns a `T` representing the kind of data being enumerated.
-
-Given that we've determined the enumerator type above, for disposal, we first try to bind using pattern-based disposal, otherwise we check for the async disposal interface (`System.IAsyncDisposable`), otherwise disposal is skipped.
-
-To fulfill the disposal pattern, the enumerator must expose a `DisposeAsync` method that may be invoked with no arguments and that returns something that can be `await`ed and whose `GetResult()` returns `void`.
-
-Using pattern-based enumeration and disposal, this code:
+The above steps, if successful, unambiguously produce a collection type `C`, enumerator type `E` and iteration type `T`.
 
 ```csharp
-var enumerable = ...;
-await foreach (T item in enumerable)
-{
-   ...
-}
+await foreach (V v in x) «embedded_statement»
 ```
 
-is translated to the equivalent of:
+is then expanded to:
 
 ```csharp
-var enumerable = ...;
-var enumerator = enumerable.GetAsyncEnumerator();
-try
 {
-    while (await enumerator.MoveNextAsync())
-    {
-       T item = enumerator.Current;
-       ...
+    E e = ((C)(x)).GetAsyncEnumerator();
+    try {
+        while (await e.MoveNextAsync()) {
+            V v = (V)(T)e.Current;
+            «embedded_statement»
+        }
+    }
+    finally {
+        ... // Dispose e
     }
 }
-finally
-{
-    await enumerator.DisposeAsync(); // omitted, along with the try/finally, if the enumerator doesn't expose DisposeAsync
-}
 ```
 
-If the iterated type doesn't expose the right patterns, the interfaces will be used.
+The body of the `finally` block is constructed according to the following steps:
+- If the type `E` has an appropriate `DisposeAsync` method:
+  - Perform member lookup on the type `E` with identifier `DisposeAsync` and no type arguments. If the member lookup does not produce a match, or it produces an ambiguity, or produces a match that is not a method group, check for the disposal  interface as described below.
+  - Perform overload resolution using the resulting method group and an empty argument list. If overload resolution results in no applicable methods, results in an ambiguity, or results in a single best method but that method is either static or not public, check for the disposal interface as described below.
+  - If the return type of the `DisposeAsync` method is not awaitable, an error is produced and no further steps are taken.
+  - The `finally` clause is expanded to the semantic equivalent of:
+  ```csharp
+    finally {
+        await e.DisposeAsync();
+    }
+    ```
+- Otherwise, if there is an implicit conversion from `E` to the `System.IAsyncDisposable` interface, then
+  - If `E` is a non-nullable value type then the `finally` clause is expanded to the semantic equivalent of:
+  ```csharp
+    finally {
+        await ((System.IAsyncDisposable)e).DisposeAsync();
+    }
+    ```
+  - Otherwise the `finally` clause is expanded to the semantic equivalent of:
+    ```csharp
+    finally {
+        System.IAsyncDisposable d = e as System.IAsyncDisposable;
+        if (d != null) await d.DisposeAsync();
+    }
+    ```
+    except that if `E` is a value type, or a type parameter instantiated to a value type, then the conversion of `e` to `System.IAsyncDisposable` shall not cause boxing to occur.
+- Otherwise, if `E` is a sealed type, the `finally` clause is expanded to an empty block:
+  ```csharp
+  finally {
+  }
+  ```
 
 ### ConfigureAwait
 


### PR DESCRIPTION
Relates to https://github.com/dotnet/roslyn/pull/60022