### PR TITLE
Update ref field proposal

### DIFF
--- a/proposals/csharp-7.2/span-safety.md
+++ b/proposals/csharp-7.2/span-safety.md
@@ -273,7 +273,7 @@ We wish to ensure that no `ref` local variable, and no variable of `ref struct` 
   - No instance method declared in `object` or in `System.ValueType` but not overridden in a `ref struct` type may be called with a receiver of that `ref struct` type.
   - No instance method of a `ref struct` type may be captured by method conversion to a delegate type.
 
-- For a ref reassignment `ref e1 = ref e2`, the *ref-safe-to-escape* of `e2` must be at least as wide a scope as the *ref-safe-to-escape* of `e1`.
+- For a ref reassignment `e1 = ref e2`, the *ref-safe-to-escape* of `e2` must be at least as wide a scope as the *ref-safe-to-escape* of `e1`.
 
 - For a ref return statement `return ref e1`, the *ref-safe-to-escape* of `e1` must be *ref-safe-to-escape* from the entire method. (TODO: Do we also need a rule that `e1` must be *safe-to-escape* from the entire method, or is that redundant?)
 

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -143,18 +143,18 @@ The `[DoesNotEscape]` annotation is not necessary for `ref` fields but more for 
 To recognize these annotations the span safety rules for method invocation need to be updated. The first change is recognizing the impact the annotations have on arguments. For a given argument `a` that is passed to `ref` parameter `p`: 
 
 > 1. If `p` is `[RefFieldsEscape] ref` or `[RefFieldsEscape] in` and `a` is 
->     1. A `[RefFieldEscapes]` parameter it contrbutes *safe-to-escape* to *calling method*
+>     1. A `[RefFieldEscapes]` parameter it contributes *safe-to-escape* to *calling method*
 >     2. A known heap location it contributes *safe-to-escape* to *calling method*
 >     3. It contributes *safe-to-escape* to *current method*
 > 2. If `p` is `[DoesNotEscape]` then `a` does not contribute *safe-to-escape* when considering arguments.
 
-This change allows us to keep our existng rules for rvalue method invocation:
+This change allows us to keep our existing rules for rvalue method invocation:
 
 > An rvalue resulting from a method invocation e1.M(e2, ...) is *safe-to-escape* from the smallest of the following scopes:
 > * The entire enclosing method
 > * The *safe-to-escape* of all argument expressions (including the receiver)
 
-The rules for `ref` field assignment will be discussed in detail [later on](#ref-field-reassignment) the doc. For now readers only need to know constructors can initialize `ref` fields with parameters marked as `[RefFieldEscape]` or known heap locations.
+The rules for `ref` field assignment will be discussed in detail [later on](#ref-field-reassignment) the doc. For now readers only need to know constructors can initialize `ref` fields with parameters marked as `[RefFieldEscapes]` or known heap locations.
 
 Let's examine these rules in the context of samples to better understand their impact and how they maintain the required compat considerations.
 

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -144,7 +144,7 @@ To recognize these annotations the span safety rules for method invocation need 
 
 > 1. If `p` is `[RefFieldsEscape] ref` or `[RefFieldsEscape] in` and `a` is 
 >     1. A `[RefFieldEscapes]` parameter it contrbutes *safe-to-escape* to *calling method*
->     2. A known heap location it contrbutes *safe-to-escape* to *calling method*
+>     2. A known heap location it contributes *safe-to-escape* to *calling method*
 >     3. It contributes *safe-to-escape* to *current method*
 > 2. If `p` is `[DoesNotEscape]` then `a` does not contribute *safe-to-escape* when considering arguments.
 
@@ -878,7 +878,7 @@ Span<int> CreateAndCapture(ref int value)
 {
     // Okay: RValue Rule 3 specifies that the safe-to-escape be limited to the ref-safe-to-escape
     // of the ref argument. That is the calling method for value hence this is not allowed.
-    return new Span<int>(value)
+    return new Span<int>(ref value)
 }
 
 Span<int> ComplexScopedRefExample(scoped ref Span<int> span)
@@ -956,7 +956,7 @@ ref T StrangeIdentity<T>(out T value)
 
 This is an unlikely combination and the language could benefit strongly by considering `out` parameters as not returnable by `ref`. 
 
-Consideration was given in this section to also taking a breaking change for *ref-safe-to-escape* defaults for `this` on a `struct`. Specifically considering changing it to be `ref T` vs. `scoped ref T`. That has the advantage that there is no need for the `escapes` keyword anymore as every has maximum return as the default hence only `scoped` is needed to restrict the behavior. The impact of this change is far more significant. It impacts all `struct` instances that have a `ref` returning method which is likely too big of a surface area to take a casual break to.
+Consideration was given in this section to also taking a breaking change for *ref-safe-to-escape* defaults for `this` on a `struct`. Specifically considering changing it to be `ref T` vs. `scoped ref T`. That has the advantage that there is no need for the `escapes` keyword anymore as every value already has maximum return as the default hence only `scoped` is needed to restrict the behavior. The impact of this change is far more significant. It impacts all `struct` instances that have a `ref` returning method which is likely too big of a surface area to take a casual break to.
 
 ### Allow fixed buffer locals
 This design allows for safe `fixed` buffers that can support any type. One possible extension here is allowing such `fixed` buffers to be declared as local variables. This would allow a number of existing `stackalloc` operations to be replaced with a `fixed` buffer. It would also expand the set of scenarios we could have stack style allocations as `stackalloc` is limited to unmanaged element types while `fixed` buffers are not. 

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -840,7 +840,7 @@ ref int Sneaky(out int i)
 }
 ```
 
-This small compat change reduces the overall compat impact of this change. The ability to return `out` by reference is effectively compiler trivia. However it negatively impacts analysis because the rules must consider the case that it is returned by `ref`. Hence `out` arguments, even though 99% of the time are not returned by ref must be considered as such and that conflates lifetime issues.
+This change to `out` reduces the overall compat impact of this change. The ability to return `out` by reference is effectively compiler trivia. However it negatively impacts analysis because the rules must consider the case that it is returned by `ref`. Hence `out` arguments, even though 99% of the time are not returned by ref must be considered as such and that conflates lifetime issues.
 
 The span safety rules for method invocation will be updated in several ways. The first is by recognizing the impact that `scoped` has on arguments. For a given argument `a` that is passed to parameter `p`:
 

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -886,9 +886,11 @@ Span<int> ComplexScopedRefExample(scoped ref Span<int> span)
     // Okay: the safe-to-escape of `span` is *calling method* hence this is legal.
     return span;
 
-    // Okay: the parameter here is `scoped ref` hence `refLocal` does not contribute /
-    // ref-safe-to-escape, it only contributes safe-to-escape. That is *calling method* 
-    // hence this is legal.
+    // Okay: the local `refLocal` has a ref-safe-to-escape of *current method* and a 
+    // safe-to-escape of *calling method*. In the call below it is passed to a 
+    // parameter that is `scoped ref` which means it does not contribute 
+    // ref-safe-to-escape. It only contributes its safe-to-escape hence the returned
+    // rvalue ends up as safe-to-escape of *calling method*
     Span<int> local = default;
     ref Span<int> refLocal = ref local;
     return ComplexScopedRefExample(ref refLocal);

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -134,7 +134,7 @@ The [new Span<T> definition](#new-span) also reveals several [challenges](#new-s
 
 The rules we define for `ref` fields must ensure the `Span<T>` constructor properly restricts the *safe-to-escape* scope of constructed objects in the cases it captures `ref` state. At the same time it must ensure that we don't break the existing consumption rules for methods like `CreateSpan<T>`. 
 
-<a name="ref-fields-escape"></a>
+<a name="ref-field-escapes"></a>
 
 To accomplish this two new annotations will be introduced to help control how arguments influence lifetime of method calls: `[RefFieldEscapes]` and `[DoesNotEscape]`. The annotation `[RefFieldEscapes]` when applied to a `ref` parameter signifies that it can be captured as a `ref` field in a returned `ref struct`.
 
@@ -525,7 +525,7 @@ Methods that return `ref struct` that capture `ref` parameters as fields must de
 
 This attribute can be applied to methods, constructors and operators. Applying to any other member will be an error. 
 
-The semantics of this attribute, and how it impacts span safety rules, are described [above](#ref-fields-escape)
+The semantics of this attribute, and how it impacts span safety rules, are described [above](#ref-field-escapes)
 
 #### DoesNotEscape
 <a name="does-not-escape">

--- a/proposals/todo.txt
+++ b/proposals/todo.txt
@@ -1,2 +1,0 @@
-* change the ref field assignment rules to account for changes
-* note that Rikki's proposal is going to need adjustment with this change.

--- a/proposals/todo.txt
+++ b/proposals/todo.txt
@@ -1,0 +1,2 @@
+* change the ref field assignment rules to account for changes
+* note that Rikki's proposal is going to need adjustment with this change.


### PR DESCRIPTION
This update has two main parts:

- Move `[RefFieldsEscape]` from annotating methods to annotating the actual `ref` parameter that escapes. Initially this was done at the method level to remove some complexity from the rules. In reality though it's the individual parameters that matter and the correct decision is to annotate them. That gives the maximum flexibility to API designers.
- Significantly expand on the **Breaking Compatibility** section. In several one off discussions and [C# LDM meetings](https://github.com/dotnet/csharplang/blob/main/meetings/2022/LDM-2022-02-28.md#conclusion-2) there was significant support for limited compat breaks to simplify this feature. Correspondingly this section was updated to have a more detailed design of what a compat break would look like and how it would impact the ref safety rules.