### PR TITLE
fix typo in improved-interpolated-strings.md

### DIFF
--- a/proposals/csharp-10.0/improved-interpolated-strings.md
+++ b/proposals/csharp-10.0/improved-interpolated-strings.md
@@ -424,7 +424,7 @@ of a larger expression `e`, any components of `e` that occurred before `i` will 
     with a single `}`.
 3. If `Fc` ended with a `bool` out argument, a check on that `bool` value is generated. If true, the methods in `Fa` will be called. Otherwise, they will not be called.
 4. For every `Fax` in `Fa`, `Fax` is called on `ib` with either the current literal component or _interpolation_ expression, as appropriate. If `Fax` returns a `bool`, the result is
-logically anded with all preceeding `Fax` calls.
+logically anded with all preceding `Fax` calls.
     1. If `Fax` is a call to `AppendLiteral`, the literal component is unescaped by replacing any _open_brace_escape_sequence_ with a single `{`, and any _close_brace_escape_sequence_
     with a single `}`.
 5. The result of the conversion is `ib`.


### PR DESCRIPTION
preceeding -> preceding