### PR TITLE
Capture implemented native int conversions

### DIFF
--- a/proposals/csharp-9.0/native-integers.md
+++ b/proposals/csharp-9.0/native-integers.md
@@ -46,31 +46,32 @@ The tables below cover the conversions between special types.
 | Operand | Target | Conversion | IL |
 |:---:|:---:|:---:|:---:|
 | `object` | `nint` | Unboxing | `unbox` |
-| `void*` | `nint` | PointerToVoid | `conv.i` |
+| `void*` | `nint` | PointerToVoid | `conv.i`/`conv.ovf.i.un` |
 | `sbyte` | `nint` | ImplicitNumeric | `conv.i` |
 | `byte` | `nint` | ImplicitNumeric | `conv.u` |
 | `short` | `nint` | ImplicitNumeric | `conv.i` |
 | `ushort` | `nint` | ImplicitNumeric | `conv.u` |
 | `int` | `nint` | ImplicitNumeric | `conv.i` |
-| `uint` | `nint` | ExplicitNumeric | `conv.u` / `conv.ovf.u` |
+| `uint` | `nint` | ExplicitNumeric | `conv.u` / `conv.ovf.i.un` |
 | `long` | `nint` | ExplicitNumeric | `conv.i` / `conv.ovf.i` |
-| `ulong` | `nint` | ExplicitNumeric | `conv.i` / `conv.ovf.i` |
-| `char` | `nint` | ImplicitNumeric | `conv.i` |
+| `ulong` | `nint` | ExplicitNumeric | `conv.i` / `conv.ovf.i.un` |
+| `char` | `nint` | ImplicitNumeric | `conv.u` |
 | `float` | `nint` | ExplicitNumeric | `conv.i` / `conv.ovf.i` |
 | `double` | `nint` | ExplicitNumeric | `conv.i` / `conv.ovf.i` |
 | `decimal` | `nint` | ExplicitNumeric | `long decimal.op_Explicit(decimal) conv.i` / `... conv.ovf.i` |
 | `IntPtr` | `nint` | Identity | |
 | `UIntPtr` | `nint` | None | |
+| | | | |
 | `object` | `nuint` | Unboxing | `unbox` |
 | `void*` | `nuint` | PointerToVoid | `conv.u` |
-| `sbyte` | `nuint` | ExplicitNumeric | `conv.u` / `conv.ovf.u` |
+| `sbyte` | `nuint` | ExplicitNumeric | `conv.i` / `conv.ovf.u` |
 | `byte` | `nuint` | ImplicitNumeric | `conv.u` |
-| `short` | `nuint` | ExplicitNumeric | `conv.u` / `conv.ovf.u` |
+| `short` | `nuint` | ExplicitNumeric | `conv.i` / `conv.ovf.u` |
 | `ushort` | `nuint` | ImplicitNumeric | `conv.u` |
-| `int` | `nuint` | ExplicitNumeric | `conv.u` / `conv.ovf.u` |
+| `int` | `nuint` | ExplicitNumeric | `conv.i` / `conv.ovf.u` |
 | `uint` | `nuint` | ImplicitNumeric | `conv.u` |
 | `long` | `nuint` | ExplicitNumeric | `conv.u` / `conv.ovf.u` |
-| `ulong` | `nuint` | ExplicitNumeric | `conv.u` / `conv.ovf.u` |
+| `ulong` | `nuint` | ExplicitNumeric | `conv.u` / `conv.ovf.u.un` |
 | `char` | `nuint` | ImplicitNumeric | `conv.u` |
 | `float` | `nuint` | ExplicitNumeric | `conv.u` / `conv.ovf.u` |
 | `double` | `nuint` | ExplicitNumeric | `conv.u` / `conv.ovf.u` |
@@ -83,7 +84,7 @@ The tables below cover the conversions between special types.
 | Operand | Target | Conversion | IL |
 |:---:|:---:|:---:|:---:|
 | `nint` | `object` | Boxing | `box` |
-| `nint` | `void*` | PointerToVoid | `conv.i` |
+| `nint` | `void*` | PointerToVoid | `conv.i`/`conv.ovf.u` |
 | `nint` | `nuint` | ExplicitNumeric | `conv.u` / `conv.ovf.u` |
 | `nint` | `sbyte` | ExplicitNumeric | `conv.i1` / `conv.ovf.i1` |
 | `nint` | `byte` | ExplicitNumeric | `conv.u1` / `conv.ovf.u1` |
@@ -92,29 +93,30 @@ The tables below cover the conversions between special types.
 | `nint` | `int` | ExplicitNumeric | `conv.i4` / `conv.ovf.i4` |
 | `nint` | `uint` | ExplicitNumeric | `conv.u4` / `conv.ovf.u4` |
 | `nint` | `long` | ImplicitNumeric | `conv.i8` / `conv.ovf.i8` |
-| `nint` | `ulong` | ExplicitNumeric | `conv.i8` / `conv.ovf.i8` |
+| `nint` | `ulong` | ExplicitNumeric | `conv.i8` / `conv.ovf.u8` |
 | `nint` | `char` | ExplicitNumeric | `conv.u2` / `conv.ovf.u2` |
 | `nint` | `float` | ImplicitNumeric | `conv.r4` |
 | `nint` | `double` | ImplicitNumeric | `conv.r8` |
-| `nint` | `decimal` | ImplicitNumeric | `conv.i8 decimal decimal.op_Implicit(long)` |
+| `nint` | `decimal` | ImplicitNumeric | `decimal decimal.op_Implicit(long)` |
 | `nint` | `IntPtr` | Identity | |
 | `nint` | `UIntPtr` | None | |
 | `nint` |Enumeration|ExplicitEnumeration||
+| | | | |
 | `nuint` | `object` | Boxing | `box` |
 | `nuint` | `void*` | PointerToVoid | `conv.u` |
-| `nuint` | `nint` | ExplicitNumeric | `conv.i` / `conv.ovf.i` |
-| `nuint` | `sbyte` | ExplicitNumeric | `conv.i1` / `conv.ovf.i1` |
-| `nuint` | `byte` | ExplicitNumeric | `conv.u1` / `conv.ovf.u1` |
-| `nuint` | `short` | ExplicitNumeric | `conv.i2` / `conv.ovf.i2` |
-| `nuint` | `ushort` | ExplicitNumeric | `conv.u2` / `conv.ovf.u2` |
-| `nuint` | `int` | ExplicitNumeric | `conv.i4` / `conv.ovf.i4` |
-| `nuint` | `uint` | ExplicitNumeric | `conv.u4` / `conv.ovf.u4` |
-| `nuint` | `long` | ExplicitNumeric | `conv.i8` / `conv.ovf.i8` |
-| `nuint` | `ulong` | ImplicitNumeric | `conv.u8` / `conv.ovf.u8` |
+| `nuint` | `nint` | ExplicitNumeric | `conv.i` / `conv.ovf.i.un` |
+| `nuint` | `sbyte` | ExplicitNumeric | `conv.i1` / `conv.ovf.i1.un` |
+| `nuint` | `byte` | ExplicitNumeric | `conv.u1` / `conv.ovf.u1.un` |
+| `nuint` | `short` | ExplicitNumeric | `conv.i2` / `conv.ovf.i2.un` |
+| `nuint` | `ushort` | ExplicitNumeric | `conv.u2` / `conv.ovf.u2.un` |
+| `nuint` | `int` | ExplicitNumeric | `conv.i4` / `conv.ovf.i4.un` |
+| `nuint` | `uint` | ExplicitNumeric | `conv.u4` / `conv.ovf.u4.un` |
+| `nuint` | `long` | ExplicitNumeric | `conv.u8` / `conv.ovf.i8.un` |
+| `nuint` | `ulong` | ImplicitNumeric | `conv.u8` / `conv.u8` |
 | `nuint` | `char` | ExplicitNumeric | `conv.u2` / `conv.ovf.u2.un` |
-| `nuint` | `float` | ImplicitNumeric | `conv.r.un conv.r4` |
-| `nuint` | `double` | ImplicitNumeric | `conv.r.un conv.r8` |
-| `nuint` | `decimal` | ImplicitNumeric | `conv.u8 decimal decimal.op_Implicit(ulong)` |
+| `nuint` | `float` | ImplicitNumeric | `conv.r4` |
+| `nuint` | `double` | ImplicitNumeric | `conv.r8` |
+| `nuint` | `decimal` | ImplicitNumeric | `decimal decimal.op_Implicit(ulong)` |
 | `nuint` | `IntPtr` | None | |
 | `nuint` | `UIntPtr` | Identity | |
 | `nuint` |Enumeration|ExplicitEnumeration||

--- a/proposals/csharp-9.0/native-integers.md
+++ b/proposals/csharp-9.0/native-integers.md
@@ -56,7 +56,7 @@ General notes:
   - `conv.u*` for `any to unsigned *` (where * is the target width)
 - Taking a few examples:
   - `sbyte->nint` and `sbyte->nuint` use `conv.i` while `byte->nint` and `byte->nuint` use `conv.u` because they are all **widening**.
-  - `nint->byte` and `nuint->byte` use `conv.u1` while `nint->sbyte` and `nuint->sbyte` use `conv.i1` as a _pre-existing semantic_. For `byte`, `sbyte`, `short`, and `ushort` the "stack type" is `int32`. So `conv.i1` is effectively "downcast to a signed byte and then sign-extend up to int32" while `conv.u1` is effectively "downcast to an unsigned byte and then zero-extend up to int32"
+  - `nint->byte` and `nuint->byte` use `conv.u1` while `nint->sbyte` and `nuint->sbyte` use `conv.i1`. For `byte`, `sbyte`, `short`, and `ushort` the "stack type" is `int32`. So `conv.i1` is effectively "downcast to a signed byte and then sign-extend up to int32" while `conv.u1` is effectively "downcast to an unsigned byte and then zero-extend up to int32"
   - `checked(void*->nint)` uses `conv.ovf.i.un` the same way that `checked(void*->long)` uses `conv.ovf.i8.un`.
 
 | Operand | Target | Conversion | IL |

--- a/proposals/csharp-9.0/native-integers.md
+++ b/proposals/csharp-9.0/native-integers.md
@@ -97,7 +97,7 @@ The tables below cover the conversions between special types.
 | `nint` | `char` | ExplicitNumeric | `conv.u2` / `conv.ovf.u2` |
 | `nint` | `float` | ImplicitNumeric | `conv.r4` |
 | `nint` | `double` | ImplicitNumeric | `conv.r8` |
-| `nint` | `decimal` | ImplicitNumeric | `decimal decimal.op_Implicit(long)` |
+| `nint` | `decimal` | ImplicitNumeric | `conv.i8 decimal decimal.op_Implicit(long)` |
 | `nint` | `IntPtr` | Identity | |
 | `nint` | `UIntPtr` | None | |
 | `nint` |Enumeration|ExplicitEnumeration||
@@ -116,7 +116,7 @@ The tables below cover the conversions between special types.
 | `nuint` | `char` | ExplicitNumeric | `conv.u2` / `conv.ovf.u2.un` |
 | `nuint` | `float` | ImplicitNumeric | `conv.r4` |
 | `nuint` | `double` | ImplicitNumeric | `conv.r8` |
-| `nuint` | `decimal` | ImplicitNumeric | `decimal decimal.op_Implicit(ulong)` |
+| `nuint` | `decimal` | ImplicitNumeric | `conv.u8 decimal decimal.op_Implicit(ulong)` |
 | `nuint` | `IntPtr` | None | |
 | `nuint` | `UIntPtr` | Identity | |
 | `nuint` |Enumeration|ExplicitEnumeration||

--- a/proposals/csharp-9.0/native-integers.md
+++ b/proposals/csharp-9.0/native-integers.md
@@ -43,8 +43,8 @@ There is an identity conversion between compound types that differ by native int
 The tables below cover the conversions between special types.
 (The IL for each conversion includes the variants for `unchecked` and `checked` contexts if different.)
 
-General notes:
-- Most docs explain `conv.u` as conversion to __native unsigned integer__ and `conv.i` as conversion to __native integer__. But a more appropriate description is that `conv.u` is zero-extending and `conv.i` is sign-extending (if the most significant bit is `1`, then the conversion fills with `1`s).
+General notes on the table below:
+- `conv.u` is a zero-extending conversion to native integer and `conv.i` is sign-extending conversion to native integer.
 - `checked` contexts for both **widening** and **narrowing** are:
   - `conv.ovf.*` for `signed to *`
   - `conv.ovf.*.un` for `unsigned to *`
@@ -54,10 +54,11 @@ General notes:
 - `unchecked` contexts for **narrowing** are:
   - `conv.i*` for `any to signed *` (where * is the target width)
   - `conv.u*` for `any to unsigned *` (where * is the target width)
-- Taking a few examples:
-  - `sbyte->nint` and `sbyte->nuint` use `conv.i` while `byte->nint` and `byte->nuint` use `conv.u` because they are all **widening**.
-  - `nint->byte` and `nuint->byte` use `conv.u1` while `nint->sbyte` and `nuint->sbyte` use `conv.i1`. For `byte`, `sbyte`, `short`, and `ushort` the "stack type" is `int32`. So `conv.i1` is effectively "downcast to a signed byte and then sign-extend up to int32" while `conv.u1` is effectively "downcast to an unsigned byte and then zero-extend up to int32"
-  - `checked(void*->nint)` uses `conv.ovf.i.un` the same way that `checked(void*->long)` uses `conv.ovf.i8.un`.
+
+Taking a few examples:
+- `sbyte to nint` and `sbyte to nuint` use `conv.i` while `byte to nint` and `byte to nuint` use `conv.u` because they are all **widening**.
+- `nint to byte` and `nuint to byte` use `conv.u1` while `nint to sbyte` and `nuint to sbyte` use `conv.i1`. For `byte`, `sbyte`, `short`, and `ushort` the "stack type" is `int32`. So `conv.i1` is effectively "downcast to a signed byte and then sign-extend up to int32" while `conv.u1` is effectively "downcast to an unsigned byte and then zero-extend up to int32".
+- `checked void* to nint` uses `conv.ovf.i.un` the same way that `checked void* to long` uses `conv.ovf.i8.un`.
 
 | Operand | Target | Conversion | IL |
 |:---:|:---:|:---:|:---:|

--- a/proposals/csharp-9.0/native-integers.md
+++ b/proposals/csharp-9.0/native-integers.md
@@ -45,7 +45,7 @@ The tables below cover the conversions between special types.
 
 General notes:
 - Most docs explain `conv.u` as conversion to __native unsigned integer__ and `conv.i` as conversion to __native integer__. But a more appropriate description is that `conv.u` is zero-extending and `conv.i` is sign-extending (if the most significant bit is `1`, then the conversion fills with `1`s).
-- Some non-obvious choices are guided by pre-existing semantics. For example, `sbyte`->`nint` uses `conv.i` and `byte`->`nint` uses `conv.u`, the same way that `sbyte`->`long` uses `conv.i8` and `byte`->`long` uses `conv.u8`.
+- Some non-obvious choices are guided by pre-existing semantics. For example, `sbyte->nint` uses `conv.i` and `byte->nint` uses `conv.u`, the same way that `sbyte->long` uses `conv.i8` and `byte->long` uses `conv.u8`. Also, `checked(void*->nint)` uses `conv.ovf.i.un` the same way that `checked(void*->long)` uses `conv.ovf.i8.un`.
 
 | Operand | Target | Conversion | IL |
 |:---:|:---:|:---:|:---:|

--- a/proposals/csharp-9.0/native-integers.md
+++ b/proposals/csharp-9.0/native-integers.md
@@ -118,8 +118,8 @@ General notes:
 | `nuint` | `long` | ExplicitNumeric | `conv.u8` / `conv.ovf.i8.un` |
 | `nuint` | `ulong` | ImplicitNumeric | `conv.u8` / `conv.u8` |
 | `nuint` | `char` | ExplicitNumeric | `conv.u2` / `conv.ovf.u2.un` |
-| `nuint` | `float` | ImplicitNumeric | `conv.r4` |
-| `nuint` | `double` | ImplicitNumeric | `conv.r8` |
+| `nuint` | `float` | ImplicitNumeric | `conv.r.un conv.r4` |
+| `nuint` | `double` | ImplicitNumeric | `conv.r.un conv.r8` |
 | `nuint` | `decimal` | ImplicitNumeric | `conv.u8 decimal decimal.op_Implicit(ulong)` |
 | `nuint` | `IntPtr` | None | |
 | `nuint` | `UIntPtr` | Identity | |

--- a/proposals/csharp-9.0/native-integers.md
+++ b/proposals/csharp-9.0/native-integers.md
@@ -43,6 +43,10 @@ There is an identity conversion between compound types that differ by native int
 The tables below cover the conversions between special types.
 (The IL for each conversion includes the variants for `unchecked` and `checked` contexts if different.)
 
+General notes:
+- Most docs explain `conv.u` as conversion to __native unsigned integer__ and `conv.i` as conversion to __native integer__. But a more appropriate description is that `conv.u` is zero-extending and `conv.i` is sign-extending (if the most significant bit is `1`, then the conversion fills with `1`s).
+- Some non-obvious choices are guided by pre-existing semantics. For example, `sbyte`->`nint` uses `conv.i` and `byte`->`nint` uses `conv.u`, the same way that `sbyte`->`long` uses `conv.i8` and `byte`->`long` uses `conv.u8`.
+
 | Operand | Target | Conversion | IL |
 |:---:|:---:|:---:|:---:|
 | `object` | `nint` | Unboxing | `unbox` |

--- a/proposals/csharp-9.0/native-integers.md
+++ b/proposals/csharp-9.0/native-integers.md
@@ -56,8 +56,7 @@ General notes:
   - `conv.u*` for `any to unsigned *` (where * is the target width)
 - Taking a few examples:
   - `sbyte->nint` and `sbyte->nuint` use `conv.i` while `byte->nint` and `byte->nuint` use `conv.u` because they are all **widening**.
-  - `nint->byte` and `nuint->byte` use `conv.u1` while `nint->sbyte` and `nuint->sbyte` use `conv.i1` as a _pre-existing semantic_. These are both **narrowing** and so there isn't a specific need to pick `signed` (`i1`) or `unsigned` (`u1`), its just a semantic of what's already done.
-  - The overflow cases do have semantics that are important and that's `conv.ovf.*` where the input is treated as `signed` and the output is `*` and `conv.ovf.*.un` where the input is treated as `unsigned` and the output is `*`.
+  - `nint->byte` and `nuint->byte` use `conv.u1` while `nint->sbyte` and `nuint->sbyte` use `conv.i1` as a _pre-existing semantic_. For `byte`, `sbyte`, `short`, and `ushort` the "stack type" is `int32`. So `conv.i1` is effectively "downcast to a signed byte and then sign-extend up to int32" while `conv.u1` is effectively "downcast to an unsigned byte and then zero-extend up to int32"
   - `checked(void*->nint)` uses `conv.ovf.i.un` the same way that `checked(void*->long)` uses `conv.ovf.i8.un`.
 
 | Operand | Target | Conversion | IL |


### PR DESCRIPTION
We've reviewed this PR with @cston and @tannergooding. Our conclusion is that the roslyn implementation is correct, except for:
- the `nuint -> double` and `nuint -> float` cases (https://github.com/dotnet/roslyn/issues/60714)
- `nuint->nint` (https://github.com/dotnet/roslyn/issues/60944)