### PR TITLE
Remove gender specific pronoun from caller-argument-expression.md

### DIFF
--- a/proposals/csharp-10.0/caller-argument-expression.md
+++ b/proposals/csharp-10.0/caller-argument-expression.md
@@ -20,7 +20,7 @@ T Single<T>(this T[] array)
 }
 ```
 
-When one of the asserts fail, only the filename, line number, and method name will be provided in the stack trace. The developer will not be able to tell which assert failed from this information-- (s)he will have to open the file and navigate to the provided line number to see what went wrong.
+When one of the asserts fail, only the filename, line number, and method name will be provided in the stack trace. The developer will not be able to tell which assert failed from this information-- they will have to open the file and navigate to the provided line number to see what went wrong.
 
 This is also the reason testing frameworks have to provide a variety of assert methods. With xUnit, `Assert.True` and `Assert.False` are not frequently used because they do not provide enough context about what failed.
 


### PR DESCRIPTION
`they` sounds better :)