### PR TITLE
Rename `LifetimeAnnotationAttribute` to `ScopedRefAttribute` and remove unnecessary members

### DIFF
--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -529,9 +529,7 @@ namespace System.Runtime.CompilerServices
 }
 ```
 
-The attribute uses `int` instead of `bool` to allow for future lifetime expansions in this space.
-
-The compiler will emit this attribute on the element targeted by the `scoped` syntax. This is true for types, methods and parameters. This will only be emitted when the syntax causes the value to differ from its default state. For example `scoped out` will cause no attribute to be emitted.
+The compiler will emit this attribute on parameters targeted by the `scoped` syntax. This will only be emitted when the syntax causes the value to differ from its default state. For example `scoped out` will cause no attribute to be emitted.
 
 ### Safe fixed size buffers
 The language will relax the restrictions on fixed sized arrays such that they can be declared in safe code and the element type can be managed or unmanaged.  This will make types like the following legal:

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -523,7 +523,7 @@ The type will have the following definition:
 namespace System.Runtime.CompilerServices
 {
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
-    public sealed class ScopedRefAttribute : Attribute
+    internal sealed class ScopedRefAttribute : Attribute
     {
     }
 }

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -515,7 +515,7 @@ Detailed Notes:
     - Any `static` member, `init` member or constructor on a `struct`
 
 ### ScopedRefAttribute
-The `scoped` and `unscoped` annotations will be emitted into metadata via the type `System.Runtime.CompilerServices.ScopedRefAttribute` attribute. This attribute will be matched by name meaning it does not need to appear in any specific assembly.
+The `scoped` annotations will be emitted into metadata via the type `System.Runtime.CompilerServices.ScopedRefAttribute` attribute. This attribute will be matched by name meaning it does not need to appear in any specific assembly.
 
 The type will have the following definition:
 
@@ -529,7 +529,7 @@ namespace System.Runtime.CompilerServices
 }
 ```
 
-The compiler will emit this attribute on parameters targeted by the `scoped` syntax. This will only be emitted when the syntax causes the value to differ from its default state. For example `scoped out` will cause no attribute to be emitted.
+The compiler will emit this attribute on the `scoped` parameter. For example `scoped out` will cause no attribute to be emitted.
 
 ### Safe fixed size buffers
 The language will relax the restrictions on fixed sized arrays such that they can be declared in safe code and the element type can be managed or unmanaged.  This will make types like the following legal:

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -529,7 +529,7 @@ namespace System.Runtime.CompilerServices
 }
 ```
 
-The compiler will emit this attribute on the `scoped` parameter. For example `scoped out` will cause no attribute to be emitted.
+The compiler will emit this attribute on the parameter with `scoped` syntax. This will only be emitted when the syntax causes the value to differ from its default state. For example `scoped out` will cause no attribute to be emitted.
 
 ### Safe fixed size buffers
 The language will relax the restrictions on fixed sized arrays such that they can be declared in safe code and the element type can be managed or unmanaged.  This will make types like the following legal:

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -514,28 +514,24 @@ Detailed Notes:
     - Any member that is not declared on a `struct`
     - Any `static` member, `init` member or constructor on a `struct`
 
-### LifetimeAnnotationAttribute
-The `scoped` and `unscoped` annotations will be emitted into metadata via the type `System.Runtime.CompilerServices.LifetimeAttribute` attribute. This attribute will be matched by name meaning it does not need to appear in any specific assembly.
+### ScopedRefAttribute
+The `scoped` and `unscoped` annotations will be emitted into metadata via the type `System.Runtime.CompilerServices.ScopedRefAttribute` attribute. This attribute will be matched by name meaning it does not need to appear in any specific assembly.
 
 The type will have the following definition:
 
 ```c#
-[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Parameter)]
-public sealed class LifetimeAnnotationAttribute : Attribute
+namespace System.Runtime.CompilerServices
 {
-    private int _value;
-    public bool IsScoped => _value == 1;
-
-    public LifetimeAnnotationAttribute(int value)
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public sealed class ScopedRefAttribute : Attribute
     {
-        _value = value;
     }
 }
 ```
 
 The attribute uses `int` instead of `bool` to allow for future lifetime expansions in this space.
 
-The compiler will emit this attribute on the element targeted by the `scoped` or `unscoped` syntax. This is true for types, methods and parameters. This will only be emitted when the syntax causes the value to differ from its default state. For example `scoped out` will cause no attribute to be emitted.
+The compiler will emit this attribute on the element targeted by the `scoped` syntax. This is true for types, methods and parameters. This will only be emitted when the syntax causes the value to differ from its default state. For example `scoped out` will cause no attribute to be emitted.
 
 ### Safe fixed size buffers
 The language will relax the restrictions on fixed sized arrays such that they can be declared in safe code and the element type can be managed or unmanaged.  This will make types like the following legal:


### PR DESCRIPTION
Relates to issue https://github.com/dotnet/roslyn/issues/62838