### PR TITLE
Add RefSafetyRulesAttribute for interop with existing assemblies

### DIFF
--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -501,7 +501,10 @@ Detailed Notes:
     - A parameter passed by reference that is not implicitly scoped
 
 ### ScopedRefAttribute
-The `scoped` annotations will be emitted into metadata via the type `System.Runtime.CompilerServices.ScopedRefAttribute` attribute. This attribute will be matched by name meaning it does not need to appear in any specific assembly.
+The `scoped` annotations will be emitted into metadata via the type `System.Runtime.CompilerServices.ScopedRefAttribute` attribute.
+The attribute will be matched by namespace-qualified name so the definition does not need to appear in any specific assembly.
+
+The `ScopedRefAttribute` type is for compiler use only - it is not permitted in source. The type declaration is synthesized by the compiler if not already included in the compilation.
 
 The type will have the following definition:
 
@@ -516,6 +519,43 @@ namespace System.Runtime.CompilerServices
 ```
 
 The compiler will emit this attribute on the parameter with `scoped` syntax. This will only be emitted when the syntax causes the value to differ from its default state. For example `scoped out` will cause no attribute to be emitted.
+
+### RefSafetyRulesAttribute
+When compiling with a corelib that contains the feature flag for `ref` fields _or_ when compiling with language version 11 or higher, the compiler will emit a `[module: RefSafetyRules(11)]` attribute.
+
+The argument to the attribute indicates the language version of the _safety rules_ and will be `11` regardless of the actual language version passed to the compiler.
+The argument indicates that the C#11 safety rules were used when compiling the module.
+
+The attribute will be matched by namespace-qualified name so the definition does not need to appear in any specific assembly.
+
+The `RefSafetyRulesAttribute` type is for compiler use only - it is not permitted in source. The type declaration is synthesized by the compiler if not already included in the compilation.
+
+```csharp
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Module, AllowMultiple = false, Inherited = false)]
+    internal sealed class RefSafetyRulesAttribute : Attribute
+    {
+        public RefSafetyRulesAttribute(int version) { Version = version; }
+        public readonly int Version;
+    }
+}
+```
+
+The intent of `RefSafetyRulesAttribute` is to improve interoperating with existing assemblies.
+Specifically, the compiler will use the module-level `RefSafetyRulesAttribute` to determine the scope of unannotated parameters within that module.
+
+If the containing module includes a module-level `RefSafetyRulesAttribute` with `Version = 11`:
+- unannotated `out` parameters are implicitly `scoped out`,
+- unannotated `ref` parameters to `ref struct` types are implicitly `scoped ref`.
+
+If the containing module _does not_ include a module-level `RefSafetyRulesAttribute`, _or_ the containing module includes a module-level `RefSafetyRulesAttribute` with `Version != 11`:
+- unannotated `out` parameters are unscoped,
+- unannotated `ref` parameters to `ref struct` types are unscoped.
+
+The presence or absence of a `RefSafetyRulesAttribute` affects the unannotated parameters listed above only.
+There are no other changes to defaults or the updated safety rules used by the compiler.
+In particular, an unannotated `this` parameter for a `struct` instance method is implicitly `scoped ref` regardless of `RefSafetyRulesAttribute`.
 
 ### Safe fixed size buffers
 The language will relax the restrictions on fixed sized arrays such that they can be declared in safe code and the element type can be managed or unmanaged.  This will make types like the following legal:

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -529,7 +529,12 @@ To reduce the chance of breaking changes when recompiling with C#11, we will upd
 
 To enable this, the compiler will emit a new `[module: RefSafetyRules(11)]` attribute when the module is compiled with `-langversion:11` or higher or compiled with a corlib containing the feature flag for `ref` fields.
 
-The argument to the attribute indicates the language version of the _ref safety rules_ used when the module was compiled. The version is currently fixed at `11` regardless of the actual language version passed to the compiler.
+The argument to the attribute indicates the language version of the _ref safety rules_ used when the module was compiled.
+The verion is currently fixed at `11` regardless of the actual language version passed to the compiler.
+
+The expectation is that future versions of the compiler will update the ref safety rules and emit attributes with distinct versions.
+
+If the compiler loads a module that includes a `[module: RefSafetyRules(version)]` _with a `version` other than `11`_, the compiler will report a warning for the unrecognized version if there are any calls to methods declared in that module.
 
 When the C#11 compiler _analyzes a method call_:
 - If the module containing the method declaration includes `[module: RefSafetyRules(version)]`, regardless of `version`, the method call is analyzed with C#11 rules.

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -520,14 +520,21 @@ namespace System.Runtime.CompilerServices
 The compiler will emit this attribute on the parameter with `scoped` syntax. This will only be emitted when the syntax causes the value to differ from its default state. For example `scoped out` will cause no attribute to be emitted.
 
 ### RefSafetyRulesAttribute
-To improve interoperability between modules compiled with different ref safety rules, the compiler will emit a `[module: RefSafetyRules(11)]` attribute when compiling a module with `-langversion:11` or higher or with a corlib containing the feature flag for `ref` fields.
+There are several differences in the _ref safety rules_ between C#7.2 and C#11. Any of these differences could result in breaking changes when recompiling with C#11 against references compiled with C#10 or earlier.
+1. unscoped `ref`/`in`/`out` parameters may escape a method invocation as a `ref` field of a `ref struct` in C#11, not in C#7.2
+1. `out` parameters are implicitly scoped in C#11, and unscoped in C#7.2
+1. `ref`/`in` parameters to `ref struct` types are implicitly scoped in C#11, and unscoped in C#7.2
+
+To reduce the chance of breaking changes when recompiling with C#11, we will update the C#11 compiler to use the ref safety rules _for method invocation_ that _match the rules that were used to analyze the method declaration_. Essentially, when analyzing a call to a method compiled with an older compiler, the C#11 compiler will use C#7.2 ref safety rules. 
+
+To enable this, the compiler will emit a new `[module: RefSafetyRules(11)]` attribute when the module is compiled with `-langversion:11` or higher or compiled with a corlib containing the feature flag for `ref` fields.
 
 The argument to the attribute indicates the language version of the _ref safety rules_ used when the module was compiled. The version is currently fixed at `11` regardless of the actual language version passed to the compiler.
 
 When the C#11 compiler _analyzes a method call_:
 - If the module containing the method declaration includes `[module: RefSafetyRules(version)]`, regardless of `version`, the method call is analyzed with C#11 rules.
 - If the module containing the method declaration is from source, and compiled with `-langversion:11` or with a corlib containing the feature flag for `ref` fields, the method call is analyzed with C#11 rules.
-- _If the module containing the method declaration references `System.Runtime { ver: 7.0 }`, the method call is analyzed with C#11 rules. This rule is a temporary mitigation for modules compiled with earlier previews of C#11 and .NET 7 and may be removed later._
+- _If the module containing the method declaration references `System.Runtime { ver: 7.0 }`, the method call is analyzed with C#11 rules. This rule is a temporary mitigation for modules compiled with earlier previews of C#11 / .NET 7 and may be removed later._
 - Otherwise, the method call is analyzed with C#7.2 rules.
 
 A pre-C#11 compiler will ignore any `RefSafetyRulesAttribute` and analyze method calls with C#7.2 rules only.

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -524,6 +524,14 @@ To improve interoperability between modules compiled with different ref safety r
 
 The argument to the attribute indicates the language version of the _ref safety rules_ used when the module was compiled. The version is currently fixed at `11` regardless of the actual language version passed to the compiler.
 
+When the C#11 compiler _analyzes a method call_:
+- If the module containing the method declaration includes `[module: RefSafetyRules(version)]`, regardless of `version`, the method call is analyzed with C#11 rules.
+- If the module containing the method declaration is from source, and compiled with `-langversion:11` or with a corlib containing the feature flag for `ref` fields, the method call is analyzed with C#11 rules.
+- _If the module containing the method declaration references `System.Runtime { ver: 7.0 }`, the method call is analyzed with C#11 rules. This rule is a temporary mitigation for modules compiled with earlier previews of C#11 and .NET 7 and may be removed later._
+- Otherwise, the method call is analyzed with C#7.2 rules.
+
+A pre-C#11 compiler will ignore any `RefSafetyRulesAttribute` and analyze method calls with C#7.2 rules only.
+
 The `RefSafetyRulesAttribute` will be matched by namespace-qualified name so the definition does not need to appear in any specific assembly.
 
 The `RefSafetyRulesAttribute` type is for compiler use only - it is not permitted in source. The type declaration is synthesized by the compiler if not already included in the compilation.
@@ -539,13 +547,6 @@ namespace System.Runtime.CompilerServices
     }
 }
 ```
-
-When the C#11 compiler _analyzes a method call_:
-- If the module containing the method declaration includes `[module: RefSafetyRules(version)]`, regardless of `version`, the method call is analyzed with C#11 rules.
-- If the module containing the method declaration is from source, and compiled with `-langversion:11` or with a corlib containing the feature flag for `ref` fields, the method call is analyzed with C#11 rules.
-- Otherwise, the method call is analyzed with C#7.2 rules.
-
-A pre-C#11 compiler will ignore any `RefSafetyRulesAttribute` and analyze method calls with C#7.2 rules only.
 
 ### Safe fixed size buffers
 The language will relax the restrictions on fixed sized arrays such that they can be declared in safe code and the element type can be managed or unmanaged.  This will make types like the following legal:

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -539,7 +539,7 @@ If the compiler loads a module that includes a `[module: RefSafetyRules(version)
 When the C#11 compiler _analyzes a method call_:
 - If the module containing the method declaration includes `[module: RefSafetyRules(version)]`, regardless of `version`, the method call is analyzed with C#11 rules.
 - If the module containing the method declaration is from source, and compiled with `-langversion:11` or with a corlib containing the feature flag for `ref` fields, the method call is analyzed with C#11 rules.
-- _If the module containing the method declaration references `System.Runtime { ver: 7.0 }`, the method call is analyzed with C#11 rules. This rule is a temporary mitigation for modules compiled with earlier previews of C#11 / .NET 7 and may be removed later._
+- _If the module containing the method declaration references `System.Runtime { ver: 7.0 }`, the method call is analyzed with C#11 rules. This rule is a temporary mitigation for modules compiled with earlier previews of C#11 / .NET 7 and will be removed later._
 - Otherwise, the method call is analyzed with C#7.2 rules.
 
 A pre-C#11 compiler will ignore any `RefSafetyRulesAttribute` and analyze method calls with C#7.2 rules only.

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -501,8 +501,7 @@ Detailed Notes:
     - A parameter passed by reference that is not implicitly scoped
 
 ### ScopedRefAttribute
-The `scoped` annotations will be emitted into metadata via the type `System.Runtime.CompilerServices.ScopedRefAttribute` attribute.
-The attribute will be matched by namespace-qualified name so the definition does not need to appear in any specific assembly.
+The `scoped` annotations will be emitted into metadata via the type `System.Runtime.CompilerServices.ScopedRefAttribute` attribute. The attribute will be matched by namespace-qualified name so the definition does not need to appear in any specific assembly.
 
 The `ScopedRefAttribute` type is for compiler use only - it is not permitted in source. The type declaration is synthesized by the compiler if not already included in the compilation.
 
@@ -523,8 +522,7 @@ The compiler will emit this attribute on the parameter with `scoped` syntax. Thi
 ### RefSafetyRulesAttribute
 When compiling with a corelib that contains the feature flag for `ref` fields _or_ when compiling with language version 11 or higher, the compiler will emit a `[module: RefSafetyRules(11)]` attribute.
 
-The argument to the attribute indicates the language version of the _safety rules_ and will be `11` regardless of the actual language version passed to the compiler.
-The argument indicates that the C#11 safety rules were used when compiling the module.
+The argument to the attribute indicates the language version of the _safety rules_ used when compiling the module, and will be `11` regardless of the actual language version passed to the compiler.
 
 The attribute will be matched by namespace-qualified name so the definition does not need to appear in any specific assembly.
 


### PR DESCRIPTION
Add a module-level `RefSafetyRulesAttribute` to indicate the scope of unannotated parameters within the module.

_Proposed by @jaredpar._