### PR TITLE
Update syntax for `out scoped` variable declaration

### DIFF
--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -438,7 +438,7 @@ argument_value
     : expression
     | 'in' variable_reference
     | 'ref' variable_reference
-    | 'scoped'? 'out' local_variable_type? identifier
+    | 'out' ('scoped'? local_variable_type)? identifier
     ;
 ```
 


### PR DESCRIPTION
Use `out scoped` rather than `scoped out` since `scoped` applies to the value in the calling method rather than the reference in the method being called.