### PR TITLE
Relax some rules in unsafe context

### DIFF
--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -704,7 +704,7 @@ For a `new` expression with initializers, the initializer expressions count as a
 
 ## Changes in unsafe context
 
-Pointer types are extended to allow managed types as referent type, but only in local declarations and casts.
+Pointer types are extended to allow managed types as referent type, but only in casts.
 Such pointer types are written as a managed type followed by a `*` token. They produce a warning.
 The address-of operator is relaxed to accept a variable with a managed type as its operand.
 

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -702,6 +702,12 @@ Namely the rules of [method invocation](#rules-method-invocation) updated above:
 
 For a `new` expression with initializers, the initializer expressions count as arguments (they contribute their *safe-to-escape*) and the `ref` initializer expressions count as `ref` arguments (they contribute their *ref-safe-to-escape*), recursively.
 
+## Changes in unsafe context
+
+Pointer types are extended to allow managed types as referent type, but only in local declarations and casts.
+Such pointer types are written as a managed type followed by a `*` token. They produce a warning.
+The address-of operator is relaxed to accept a variable with a managed type as its operand.
+
 ## Considerations
 There are considerations other parts of the development stack should consider when evaluating this feature.
 


### PR DESCRIPTION
Relevant background: https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/unsafe-code.md

Relates to https://github.com/dotnet/runtime/issues/73850