### PR TITLE
Spec out as return only 

### DIFF
--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -333,17 +333,17 @@ The language "does not contribute" means the arguments are simply not considered
 
 The method invocation rules can now be simplified. The receiver no longer needs to be special cased, in the case of `struct` it is now simply a `scoped ref T`. The value rules need to change to account for `ref` field returns:
 
-> A value resulting from a method invocation `e1.M(e2, ...)` is *safe-to-escape* from the smallest of the following scopes:
+> A value resulting from a method invocation `e1.M(e2, ...)` is *safe-to-escape* from the narrowest of the following scopes:
 > 1. The *calling method*
-> 2. When the return is a `ref struct`:
->    1. The *safe-to-escape* contributed by all argument expressions
->    2. The *ref-safe-to-escape* contributed by all `ref` arguments
+> 2. When the return is a `ref struct` the *safe-to-escape* contributed by all argument expressions
+> 3. When the return is a `ref struct` the *ref-safe-to-escape* contributed by all `ref` arguments
 
 The `ref` calling rules can be simplified to:
 
-> A value resulting from a method invocation `ref e1.M(e2, ...)` is *ref-safe-to-escape* the smallest of the following scopes:
-> 1. The *safe-to-escape* of the rvalue of `e1.M(e2, ...)`
-> 2. The *ref-safe-to-escape* contributed by all `ref` arguments
+> A value resulting from a method invocation `ref e1.M(e2, ...)` is *ref-safe-to-escape* the narrowest of the following scopes:
+> 1. The *calling method*
+> 2. The *safe-to-escape* contributed by all argument expressions
+> 3. The *ref-safe-to-escape* contributed by all `ref` arguments
 
 This rule now lets us define the two variants of desired methods:
 

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -157,7 +157,7 @@ Next the rules for ref reassignment need to be adjusted for the presence of `ref
 The left operand of the `= ref` operator must be an expression that binds to a ref local variable, a ref parameter (other than `this`), an out parameter, **or a ref field**.
 
 > For a ref reassignment in the form ...
-> 1. `x.e1 = ref e2`: where `x` is *safe-to-escape* at least *return only* then `e2` must have at least the same *ref-safe-to-escape* as `x`.
+> 1. `x.e1 = ref e2`: where `x` is *safe-to-escape* at least *return only* then `e2` must have at least *ref-safe-to-escape* at least as large as `x`
 > 2. `e1 = ref e2`: where `e1` is a `ref` local or `ref` parameter then `e2` must have a *safe-to-escape* equal to *safe-to-escape* for `e1` and `e2` must have *ref-safe-to-escape* at least as large as *ref-safe-to-escape* of the *ref-safe-to-escape* of `e1`
 
 That means the desired `Span<T>` constructor works without any extra annotation:

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -316,7 +316,7 @@ The details of *return only* is that it's a scope which is greater than *current
 There are three locations which default to *return only*:
 - A `ref` or `in` parameter. This is done in part for `ref struct` to prevent [silly cyclic assignment](#cyclic-assignment) issues. It is done uniformly though to simplify the model as well as minimize compat changes.
 - A `out` parameter for a `ref struct` will have *safe-to-escape* of *return only*. This allows for return and `out` to be equally expressive. This does not have the silly cyclic assignment problem because `out` is implicitly `scoped` so the *ref-safe-to-escape* is still smaller than the *safe-to-escape*.
-- A `this` parameter for a `struct` constructor. This falls out due them being modeled as `out` parameters. 
+- A `this` parameter for a `struct` constructor. This falls out due to being modeled as `out` parameters. 
 
 Any expression or statement which explicitly returns a value from a method or lambda must have a *safe-to-escape*, and if applicable a *ref-safe-to-escape*, of at least *return only*. That includes `return` statements, expression bodied members and lambda expressions.
 
@@ -552,7 +552,7 @@ The [rationale](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-
 
 To fix this the  language will provide the opposite of the `scoped` lifetime annotation by supporting an `UnscopedRefAttribute`. This can be applied to any `ref` and it will change the *ref-safe-to-escape* to be one level wider than its default. For example:
 - if applied to a `struct` instance method it will become *return only* where previously it was *containing method*.
-- if applied to a `ref` parameter it will become *containing method* where previously it was *return only*
+- if applied to a `ref` parameter it will become *calling method* where previously it was *return only*
 
 When applying `[UnscopedRef]` to an instance method of a `struct` it has the impact of modifying the implicit `this` parameter. This means `this` acts as an unannotated `ref` of the same type. 
 

--- a/proposals/low-level-struct-improvements.md
+++ b/proposals/low-level-struct-improvements.md
@@ -386,23 +386,17 @@ Span<int> ComplexScopedRefExample(scoped ref Span<int> span)
 The presence of `ref` fields means the rules around method arguments must match need to be updated as a `ref` parameter can now be stored as a field in a `ref struct` argument to the method. Previously the rule only had to consider another `ref struct` being stored as a field. The impact of this is discussed in [the compat considerations](#compat-considerations). The new rule is ... 
 
 > For any method invocation `e.M(a1, a2, ... aN)`
-> 1. Calculate the *safe-to-escape* of the method return.
->     - Ignore the *ref-safe-to-escape* of arguments whose corresponding parameters have a *ref-safe-to-escape* of *return-only* or smaller.
->     - Assume the method has a `ref struct` return type.
-> 2. All `ref` arguments of `ref struct` types must be assignable by a value with that *safe-to-escape*. This applies even when the `ref` argument matches a `scoped ref` parameter.
-
-> For any method invocation `e.M(a1, a2, ... aN)`
-> 1. Calculate the minimum of the following:
+> 1. Calculate the narrowest *safe-to-escape* from:
 >     - *calling method*
 >     - The *safe-to-escape* of all arguments
->     - The *ref-safe-to-escape* of all ref arguments whose corresponding parameters have a *ref-safe-to-escape* of *calling method* or smaller.
-> 2. All `ref` arguments of `ref struct` types must be assignable by a value with that *safe-to-escape*. This applies even when the `ref` argument matches a `scoped ref` parameter.
+>     - The *ref-safe-to-escape* of all ref arguments whose corresponding parameters have a *ref-safe-to-escape* of *calling method*
+> 2. All `ref` arguments of `ref struct` types must be assignable by a value with that *safe-to-escape*. This is a case where `ref` does **not** generalize to include `in` and `out`
 
-
-> Further for any method invocation `e.M(a1, a2, ... aN)`
-> 1. Calculate the *safe-to-escape* of the method return.
->     - Ignore the *ref-safe-to-escape* of arguments whose corresponding parameters are `scoped`
->     - Assume the method has a `ref struct` return type.
+> For any method invocation `e.M(a1, a2, ... aN)`
+> 1. Calculate the narrowest *safe-to-escape* from:
+>     - *calling method*
+>     - The *safe-to-escape* of all arguments
+>     - The *ref-safe-to-escape* of all ref arguments whose corresponding parameters are not `scoped` 
 > 2. All `out` arguments of `ref struct` types must be assignable by a value with that *safe-to-escape*.
 
 The presence of `scoped` allows developers to reduce the friction this rule creates by marking parameters which are not returned as `scoped`. This removes their arguments from (1) in both cases above and provides greater flexibility to callers.
@@ -1630,7 +1624,7 @@ ref struct S
 
 There are roughly two approaches:
 
-1. Model as a `static` method where `this` is a local where it's *safe-to-escape* is *calling method*
+1. Model as a `static` method where `this` is a local where its *safe-to-escape* is *calling method*
 2. Model as a `static` method where `this` is an `out` parameter. 
 
 Further a constructor must meet the following invariants:


### PR DESCRIPTION
Considering how the spec changes would look if we went forward with `out` parameters having *safe-to-return* of *return only*

https://github.com/dotnet/roslyn/issues/64155