### PR TITLE
Meeting notes grammar fix

### DIFF
--- a/meetings/2022/LDM-2022-10-10.md
+++ b/meetings/2022/LDM-2022-10-10.md
@@ -54,7 +54,7 @@ Now that we've gone through our working set, we've decided on the following work
 
 We also decided on a set of norms for working groups to follow with respect to notes and keeping track of their progress: every working group
 will add a folder under the [`meetings`](/meetings/) directory where they will put meeting notes. These notes will anonymized, like LDM notes,
-but are likely to be much rougher than dedicated LDM notes. We will not create dedicated discussions when posting these working group notes, users
+but are likely to be much rougher than dedicated LDM notes. We will not create dedicated discussions when posting these working group notes. Users
 that want to comment on them can either comment on the issue for the group or create a discussion, as they choose. Working groups will each have
 a leader, and that leader will be responsible for coordinating with the broader LDM on when things need to be brought back to the full group.
 

--- a/meetings/2022/LDM-2022-10-10.md
+++ b/meetings/2022/LDM-2022-10-10.md
@@ -24,7 +24,7 @@ Today we wrapped up our triage of the working set. All of the remaining items ar
 
 https://github.com/dotnet/csharplang/issues/5783
 
-We feel that there's about one design-meetings worth of open questions in this issue before we could reasonably let it be open for implementation,
+We feel that there's about one design meeting's worth of open questions in this issue before we could reasonably let it be open for implementation,
 either from the compiler team or from the community, so we'll try to do that work at some point in the near future.
 
 #### Null-conditional assignment

--- a/meetings/2022/LDM-2022-10-10.md
+++ b/meetings/2022/LDM-2022-10-10.md
@@ -53,7 +53,7 @@ Now that we've gone through our working set, we've decided on the following work
 * `params` improvements
 
 We also decided on a set of norms for working groups to follow with respect to notes and keeping track of their progress: every working group
-will add a folder under the [`meetings`](/meetings/) directory where they will put meeting notes. These notes will anonymized, like LDM notes,
+will add a folder under the [`meetings`](/meetings/) directory where they will put meeting notes. These notes will be anonymized, like LDM notes,
 but are likely to be much rougher than dedicated LDM notes. We will not create dedicated discussions when posting these working group notes. Users
 that want to comment on them can either comment on the issue for the group or create a discussion, as they choose. Working groups will each have
 a leader, and that leader will be responsible for coordinating with the broader LDM on when things need to be brought back to the full group.


### PR DESCRIPTION
The phrase "thing's worth" includes a possessive, as in "the worth of the thing."