### PR TITLE
Require types to match between pattern variable redeclarations

### DIFF
--- a/proposals/pattern-variables.md
+++ b/proposals/pattern-variables.md
@@ -60,7 +60,7 @@
 	- Across top-level condition expressions within a single `if` statement (includes `else if`)
 
   These names can possibly reference either of variables based on the result of the pattern-matching at runtime.
-- Pattern variables with multiple declarations must be of the same type, excluding tuple names and nullability for reference types.
+- Pattern variables with multiple declarations must be of the same type, including tuple names and nullability for reference types.
 
 ### Definite assignment
 


### PR DESCRIPTION
FYI @alrz @333fred 
If we allow some type variation, we're going to have to merge types (find the best type, by eliminating tuple name differences and resolving nullability differences) and I don't see the benefit. I'll go ahead and merge for purpose of LDM discussion today.