### PR TITLE
Revert "Flow `scoped` in anonymous function conversion"

### DIFF
--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -446,9 +446,6 @@ The diagnostic is reported as an _error_ if the mismatched signatures are both u
 
 The scoped mismatch warning may be reported on a module compiled with C#7.2 ref safety rules where `scoped` is not available. In some such cases, it may be necessary to suppress the warning if the other mismatched signature cannot be modified.
 
-The `scoped` modifier also affects the anonymous function conversion (§11.17.1):
-In an implicitly typed parameter list, the types, **ref kinds and scopes** of the parameters are inferred from the context in which the anonymous function occurs—specifically, when the anonymous function is converted to a compatible delegate type or expression tree type, that type provides the parameter types, **ref kinds and scopes**.
-
 The `scoped` modifier and `[UnscopedRef]` attribute also have the following effects on method signatures:
 - The `scoped` modifier and `[UnscopedRef]` attribute do not affect hiding
 - Overloads cannot differ only on `scoped` or `[UnscopedRef]`


### PR DESCRIPTION
Reverts dotnet/csharplang#6551

From email discussion with Mads and others, we're going to require lambdas to use explicit types to specify `scoped`. This will be the same as for `ref`.
Separately, we'll make a clarification to the spec that the conversion from lambda to delegate don't **exist** when `scoped` differs in incompatible ways (as opposed to having a conversion that exists with an error reported).