### PR TITLE
Fix generic parameter rendering

### DIFF
--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -1174,7 +1174,7 @@ This snippet wants to mutate a parameter by escaping elements of the data. The e
 
 ### Fun Samples
 
-#### ReadOnlySpan<T>
+#### ReadOnlySpan\<T>
 
 ```c#
 public readonly ref struct ReadOnlySpan<T>

--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -1182,7 +1182,7 @@ public readonly ref struct ReadOnlySpan<T>
     readonly ref readonly T _value;
     readonly int _length;
 
-    public ReadOnlySpan<T>(in T value)
+    public ReadOnlySpan(in T value)
     {
         _value = ref value;
         _length = 1;


### PR DESCRIPTION
This is how it previously rendered both in GitHub and in [docs](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-11.0/low-level-struct-improvements)
 
![image](https://user-images.githubusercontent.com/31348972/198021890-4ef8b8a9-26a4-426a-913d-b021a45d486e.png)

Escaping the `<` so that `<T>` isn't treated as HTML tag.

Another way to fix it is to wrap `ReadOnlySpan<T>` with backticks
