### PR TITLE
add comment on doc updates

### DIFF
--- a/meetings/working-groups/nullability-improvements/NI-2022-10-24.md
+++ b/meetings/working-groups/nullability-improvements/NI-2022-10-24.md
@@ -99,6 +99,8 @@ Task<string?> x2 = x1!; // could be doc'ed usage of suppression
 x2 = Task.FromResult<string?>(""); // ok
 ```
 
+The current articles for `!` emphasize its use to assert that a variable is *not_null*. There's little coverage that the operator will suppress these conversion warnings as well. Adding this information, especially linked to the F1 service for the specific warning generated.
+
 ### Conclusion
 
 **Option 0 (special-casing)** would be most palatable, but we're not sure yet whether to prioritize making any change here. It will depend on how the cost/benefit of addressing this compares to other nullable issues on the docket.


### PR DESCRIPTION
I know our docs don't cover this use of the `!` operator. Adding that would help this situation.

After more thinking after we met, I'm thinking that might be the only necessary changes.