### PR TITLE
Clarify lambda defaults/`params` breaking change langversion

### DIFF
--- a/proposals/lambda-method-group-defaults.md
+++ b/proposals/lambda-method-group-defaults.md
@@ -156,7 +156,7 @@ int DoFunction(Func<int[], int> f, int p) {
   return f(new[] { p });
 }
 ```
-Following this change, code of this nature would cease to compile.
+Following this change, code of this nature would cease to compile with `-langversion:12` or higher.
 
 ```csharp
 void WriteInt(int i = 0) {

--- a/proposals/lambda-method-group-defaults.md
+++ b/proposals/lambda-method-group-defaults.md
@@ -156,7 +156,7 @@ int DoFunction(Func<int[], int> f, int p) {
   return f(new[] { p });
 }
 ```
-Following this change, code of this nature would cease to compile with `-langversion:12` or higher.
+Following this change, code of this nature would cease to compile in .NET SDK 7.0.200 or later.
 
 ```csharp
 void WriteInt(int i = 0) {


### PR DESCRIPTION
Implemented by https://github.com/dotnet/roslyn/pull/65300.