### PR TITLE
Adjust invocation rules for ref return of ref struct type

### DIFF
--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -353,17 +353,21 @@ The language "does not contribute" means the arguments are simply not considered
 
 The method invocation rules can now be simplified. The receiver no longer needs to be special cased, in the case of `struct` it is now simply a `scoped ref T`. The value rules need to change to account for `ref` field returns:
 
-> A value resulting from a method invocation `e1.M(e2, ...)` is *safe-to-escape* from the narrowest of the following scopes:
+> A value resulting from a method invocation `e1.M(e2, ...)`, where M() does not return ref to ref struct, is *safe-to-escape* from the narrowest of the following scopes:
 > 1. The *calling method*
 > 2. When the return is a `ref struct` the *safe-to-escape* contributed by all argument expressions
 > 3. When the return is a `ref struct` the *ref-safe-to-escape* contributed by all `ref` arguments
+> If M() does return ref-to-ref-struct, the *safe-to-escape* is the same as the *safe-to-escape* of all arguments which are ref-to-ref-struct. It is an error if there are multiple arguments with different *safe-to-escape*.
+
+See [STE invariance for ref to ref struct variables](#ste-invariance-for-ref-to-ref-struct-variables).
 
 The `ref` calling rules can be simplified to:
 
-> A value resulting from a method invocation `ref e1.M(e2, ...)` is *ref-safe-to-escape* the narrowest of the following scopes:
+> A value resulting from a method invocation `ref e1.M(e2, ...)`, where M() does not return ref to ref struct, is *ref-safe-to-escape* the narrowest of the following scopes:
 > 1. The *calling method*
 > 2. The *safe-to-escape* contributed by all argument expressions
 > 3. The *ref-safe-to-escape* contributed by all `ref` arguments
+> If M() does return ref-to-ref-struct, the *ref-safe-to-escape* is the narrowest *ref-safe-to-escape* contributed by all arguments which are ref-to-ref-struct.
 
 This rule now lets us define the two variants of desired methods:
 
@@ -403,6 +407,7 @@ Span<int> ComplexScopedRefExample(scoped ref Span<int> span)
 }
 ```
 
+### Method arguments must match
 <a name="rules-method-arguments-must-match"></a>
 
 The presence of `ref` fields means the rules around method arguments must match need to be updated as a `ref` parameter can now be stored as a field in a `ref struct` argument to the method. Previously the rule only had to consider another `ref struct` being stored as a field. The impact of this is discussed in [the compat considerations](#compat-considerations). The new rule is ... 

--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -353,7 +353,7 @@ The language "does not contribute" means the arguments are simply not considered
 
 The method invocation rules can now be simplified. The receiver no longer needs to be special cased, in the case of `struct` it is now simply a `scoped ref T`. The value rules need to change to account for `ref` field returns:
 
-> A value resulting from a method invocation `e1.M(e2, ...)`, where M() does not return ref to ref struct, is *safe-to-escape* from the narrowest of the following scopes:
+> A value resulting from a method invocation `e1.M(e2, ...)`, where `M()` does not return ref-to-ref-struct, is *safe-to-escape* from the narrowest of the following scopes:
 > 1. The *calling method*
 > 2. When the return is a `ref struct` the *safe-to-escape* contributed by all argument expressions
 > 3. When the return is a `ref struct` the *ref-safe-to-escape* contributed by all `ref` arguments
@@ -362,7 +362,7 @@ The method invocation rules can now be simplified. The receiver no longer needs 
 
 The `ref` calling rules can be simplified to:
 
-> A value resulting from a method invocation `ref e1.M(e2, ...)`, where M() does not return ref-to-ref-struct, is *ref-safe-to-escape* the narrowest of the following scopes:
+> A value resulting from a method invocation `ref e1.M(e2, ...)`, where `M()` does not return ref-to-ref-struct, is *ref-safe-to-escape* the narrowest of the following scopes:
 > 1. The *calling method*
 > 2. The *safe-to-escape* contributed by all argument expressions
 > 3. The *ref-safe-to-escape* contributed by all `ref` arguments

--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -358,16 +358,16 @@ The method invocation rules can now be simplified. The receiver no longer needs 
 > 2. When the return is a `ref struct` the *safe-to-escape* contributed by all argument expressions
 > 3. When the return is a `ref struct` the *ref-safe-to-escape* contributed by all `ref` arguments
 >
-> If M() does return ref-to-ref-struct, the *safe-to-escape* is the same as the *safe-to-escape* of all arguments which are ref-to-ref-struct. It is an error if there are multiple arguments with different *safe-to-escape*.
+> If `M()` does return ref-to-ref-struct, the *safe-to-escape* is the same as the *safe-to-escape* of all arguments which are ref-to-ref-struct. It is an error if there are multiple arguments with different *safe-to-escape* because of [method arguments must match](#rules-method-arguments-must-match).
 
 The `ref` calling rules can be simplified to:
 
-> A value resulting from a method invocation `ref e1.M(e2, ...)`, where M() does not return ref to ref struct, is *ref-safe-to-escape* the narrowest of the following scopes:
+> A value resulting from a method invocation `ref e1.M(e2, ...)`, where M() does not return ref-to-ref-struct, is *ref-safe-to-escape* the narrowest of the following scopes:
 > 1. The *calling method*
 > 2. The *safe-to-escape* contributed by all argument expressions
 > 3. The *ref-safe-to-escape* contributed by all `ref` arguments
 >
-> If M() does return ref-to-ref-struct, the *ref-safe-to-escape* is the narrowest *ref-safe-to-escape* contributed by all arguments which are ref-to-ref-struct.
+> If `M()` does return ref-to-ref-struct, the *ref-safe-to-escape* is the narrowest *ref-safe-to-escape* contributed by all arguments which are ref-to-ref-struct.
 
 This rule now lets us define the two variants of desired methods:
 

--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -357,9 +357,8 @@ The method invocation rules can now be simplified. The receiver no longer needs 
 > 1. The *calling method*
 > 2. When the return is a `ref struct` the *safe-to-escape* contributed by all argument expressions
 > 3. When the return is a `ref struct` the *ref-safe-to-escape* contributed by all `ref` arguments
+>
 > If M() does return ref-to-ref-struct, the *safe-to-escape* is the same as the *safe-to-escape* of all arguments which are ref-to-ref-struct. It is an error if there are multiple arguments with different *safe-to-escape*.
-
-See [STE invariance for ref to ref struct variables](#ste-invariance-for-ref-to-ref-struct-variables).
 
 The `ref` calling rules can be simplified to:
 
@@ -367,6 +366,7 @@ The `ref` calling rules can be simplified to:
 > 1. The *calling method*
 > 2. The *safe-to-escape* contributed by all argument expressions
 > 3. The *ref-safe-to-escape* contributed by all `ref` arguments
+>
 > If M() does return ref-to-ref-struct, the *ref-safe-to-escape* is the narrowest *ref-safe-to-escape* contributed by all arguments which are ref-to-ref-struct.
 
 This rule now lets us define the two variants of desired methods:


### PR DESCRIPTION
Related to dotnet/roslyn#65648

We think that because ref-struct ref-returns can only happen using ref-to-ref-struct parameters, the STE calculation should be adjusted accordingly.

There's an additional rule we want to add around STE invariance for ref expressions of ref struct type, but I want to do it in a separate spec PR and separate implementation PR.

I also added a visible section header for *method arguments must match*, because I need that phrase to be ctrl-F friendly.