### PR TITLE
Address docs issues in speclets

### DIFF
--- a/proposals/csharp-9.0/init.md
+++ b/proposals/csharp-9.0/init.md
@@ -106,7 +106,7 @@ class Base
 
 class Derived : Base
 {
-    Derived()
+    public Derived()
     {
         // Not allowed with get only properties but allowed with init
         Value = true;
@@ -117,7 +117,7 @@ class Consumption
 {
     void Example()
     {
-        var d = new Derived() { Value = true; };
+        var d = new Derived() { Value = true };
     }
 }
 


### PR DESCRIPTION
Fixes dotnet/docs#32023

Fix two syntax errors in examples. The ctor for `Derived` isn't accessible. Also, remove invalid `;`.

