### PR TITLE
Fix: Remove excess brace in lambda-improvements.md

### DIFF
--- a/proposals/csharp-10.0/lambda-improvements.md
+++ b/proposals/csharp-10.0/lambda-improvements.md
@@ -30,7 +30,7 @@ app.MapAction((Func<Todo, Todo>)PostTodo);
 [HttpGet("/")] Todo GetTodo() => new(Id: 0, Name: "Name");
 app.MapAction(GetTodo);
 
-[HttpPost("/")] Todo PostTodo([FromBody] Todo todo) => todo);
+[HttpPost("/")] Todo PostTodo([FromBody] Todo todo) => todo;
 app.MapAction(PostTodo);
 ```
 


### PR DESCRIPTION
I think I found a small oversight in the specification.