### PR TITLE
Lifetime annotation notation

### DIFF
--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -870,10 +870,11 @@ ref struct S<T>
 ```
 
 ### Annotations
-Lifetime models are most naturally expressed via a more explicit annotation model. While the syntax of C# implicitly adds lifetimes to values, there is an underlying model that describes the fundamental rules here. It's often easier to discuss the implication of changes to the design in terms of these rules so they are included here for discussion sake.
+Lifetimes are most naturally expressed using types. A given program's lifetimes are safe when the lifetime types type check. While the syntax of C# implicitly adds lifetimes to values, there is an underlying type system that describes the fundamental rules here. It's often easier to discuss the implication of changes to the design in terms of these rules so they are included here for discussion sake.
 
 Note that this is not meant to be a 100% complete documentation. Documenting every single behavior isn't a goal here. Instead it's meant to establish a general understanding and common verbiage by which the model, and potential changes to it, can be discussed.
 
+Usually it's not necessary to directly talk about lifetime types. The exceptions are places where lifetimes can vary based on particular "instantiation" sites. This is a kind of polymorphism and we call these varying lifetimes "generic lifetimes", represented as generic parameters. C# does not provide syntax for expressing lifetime generics, so we define an implicit "translation" from C# to an expanded lowered language that contains explicit generic parameters.
 The below examples make use of named lifetimes. The syntax `$a` refers to a lifetime named `a`. It is a lifetime that has no meaning by itself but can be given a relationship to other lifetimes via the `where lifetime` syntax. There are a few predefined lifetimes for convenience and brevity below:
 
 - `$heap`: this is the lifetime of any value that exists on the heap

--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -874,61 +874,61 @@ Lifetime models are most naturally expressed via a more explicit annotation mode
 
 Note that this is not meant to be a 100% complete documentation. Documenting every single behavior isn't a goal here. Instead it's meant to establish a general understanding and common verbiage by which the model, and potential changes to it, can be discussed.
 
-The below examples make use of named lifetimes. The syntax `'a` refers to a lifetime named `a`. It is a lifetime that has no meaning byitself but can be given a relationship to other lifetimes via the `where lifetime` syntax. There are a few predefined lifetimes for convenience and brevity below:
+The below examples make use of named lifetimes. The syntax `$a` refers to a lifetime named `a`. It is a lifetime that has no meaning byitself but can be given a relationship to other lifetimes via the `where lifetime` syntax. There are a few predefined lifetimes for convenience and brevity below:
 
-- `'heap`: this is the lifetime of any value that exists on the heap
-- `'local`: this is the lifetime of any value that exists on the method stack. It's effectively a name place holder for *current method*
-- `'ro`: name place holder for the *return only* safe to escape scope
-- `'cm`: name place holder for the *calling method* safe to escape scope
-- `'this`: this is the lifetime of the implicit `this` value in an instance method or field declaration.
+- `$heap`: this is the lifetime of any value that exists on the heap
+- `$local`: this is the lifetime of any value that exists on the method stack. It's effectively a name place holder for *current method*
+- `$ro`: name place holder for the *return only* safe to escape scope
+- `$cm`: name place holder for the *calling method* safe to escape scope
+- `$this`: this is the lifetime of the implicit `this` value in an instance method or field declaration.
 
 There are a few predefined relationships between lifetimes:
 
-- `lifetime 'heap >= 'a` for all lifetimes `'a`
-- `lifetime 'cm >= 'ro` 
-- `lifetime 'x >= 'local` for all predefined lifetimes. User defined lifetimes have no relationship to local unless explictly defined.
-- `lifetime 'this >= ro`
+- `lifetime $heap >= $a` for all lifetimes `$a`
+- `lifetime $cm >= $ro` 
+- `lifetime $x >= $local` for all predefined lifetimes. User defined lifetimes have no relationship to local unless explictly defined.
+- `lifetime $this >= $ro`
 
-Note: while both `'this` and `'cm` are `>= ro` there is no relationship between the two of them.
+Note: while both `$this` and `$cm` are `>= $ro` there is no relationship between the two of them.
 
 The C# method syntax maps to the model in the following ways: 
 
-- `ref` parameters have a ref lifetime of `'ro`
-- parameters of type `ref struct` have a value lifetime of `'cm`
-- ref returns have a ref lifetime of `'ro`
-- returns of type `ref struct` have a value lifetime of `'ro`
-- `scoped` on a parameter or `ref` changes the lifetime to be `'local`
-- `ref this` has lifetime `'local` by default but it becomes `'ro` when the method is annotated with `[UnscopedRef]`
+- `ref` parameters have a ref lifetime of `$ro`
+- parameters of type `ref struct` have a value lifetime of `$cm`
+- ref returns have a ref lifetime of `$ro`
+- returns of type `ref struct` have a value lifetime of `$ro`
+- `scoped` on a parameter or `ref` changes the lifetime to be `$local`
+- `ref this` has lifetime `$local` by default but it becomes `$ro` when the method is annotated with `[UnscopedRef]`
 
 The basic rules for the lifetime are defined as:
 
-- All lifetimes are expressed syntactically as generic arguments, coming before type arguments. This is true for predefined lifetimes except `'heap` and `'local`. 
-- All variables have their lifetime defined at declaration by annotating the type. For example `'a ref 'b Span<int> span` defines a local `span` whose value lifetime is `'b` and whose ref lifetime is `'a`. 
-- All values that are not typed to `ref struct` implicitly have a lifetime of `'heap`. That is there is no need to write `'heap int` everywhere, one can simply write `'int`. 
-- The `ref` of a non-ref local has ref lifetime `'local`
+- All lifetimes are expressed syntactically as generic arguments, coming before type arguments. This is true for predefined lifetimes except `$heap` and `$local`. 
+- All variables have their lifetime defined at declaration by annotating the type. For example `$a ref $b Span<int> span` defines a local `span` whose value lifetime is `$b` and whose ref lifetime is `$a`. 
+- All values that are not typed to `ref struct` implicitly have a lifetime of `$heap`. That is there is no need to write `$heap int` everywhere, one can simply write `$int`. 
+- The `ref` of a non-ref local has ref lifetime `$local`
 - An assignment is only legal when the lifetime of the RHS is greater than or equal to the LHS.
 - An return is only legal when the lifetime of the value is greater than or equal to lifetime on the return
 - Lifetimes of expressions can be made explicit by putting annotations in front of them:
-    - `'a expr` the value lifetime is explicitly `'a`
-    - `'a ref 'b expr` the value lifetime is `'b` and the ref lifetime is `'a`.
+    - `$a expr` the value lifetime is explicitly `$a`
+    - `$a ref $b expr` the value lifetime is `$b` and the ref lifetime is `$a`.
 - A method call has the value return of the smallest of all the lifetimes input: ref or value. In the case there is no total ordering of the lifetimes, for example if two lifetimes have no relationship to each other, then the result is a new named lifetime that has no relationship to any other lifetime.
 
 Given that let's explore a simple example that demonstrates the model here: 
 
-```txt
+```csharp
 ref int M1(ref int i) => ...
 
 // Maps to the following. 
-`ro ref int Identity<'ro>('ro ref int i)
+$ro ref int Identity<$ro>($ro ref int i)
 {
-    // okay: has ref lifteime 'ro which is equal to 'ro
+    // okay: has ref lifteime $ro which is equal to $ro
     return ref i;
 
-    // okay: has ref lifetime 'heap which is >= 'ro
+    // okay: has ref lifetime $heap which is >= $ro
     int[] array = new int[42];
     return ref array[0];
 
-    // error: has ref lifetime 'local which has no relationship to 'a hence 
+    // error: has ref lifetime $local which has no relationship to $a hence 
     // it's illegal
     int local = 42;
     return ref local;
@@ -942,7 +942,7 @@ ref struct S
 {
     ref int Field;
 
-    'ro S<'ro>(ref int f)
+    $ro S<$ro>(ref int f)
     {
         Field = ref f;
     }
@@ -951,29 +951,29 @@ ref struct S
 S M2(ref int i, S span1, scoped S span2) => ...
 
 // Maps to 
-'ro S<int> M2<'ro>(
-    'ro ref int i,
-    'ro S span1)
-    'local S span2)
+$ro S<int> M2<$ro>(
+    $ro ref int i,
+    $ro S span1)
+    $local S span2)
 {
-    // okay: has lifteime 'ro which is equal to 'ro
+    // okay: has lifteime $ro which is equal to $ro
     return span1;
 
-    // error: has lifetime 'local which is not >= 'ro
+    // error: has lifetime $local which is not >= $ro
     return span2;
 
-    // okay: the smallest lifetime input to the method is 'ro therefore it is 
+    // okay: the smallest lifetime input to the method is $ro therefore it is 
     // the return
-    'ro S local = new S<'ro>(ref 'i);
+    $ro S local = new S<$ro>(ref $i);
     return local;
 
-    // okay: has ref lifetime 'heap which is >= 'ro
-    // okay: the smallest lifetime input to the method is 'heap therefore it is 
-    // is a 'heap value and that is >= 'ro
+    // okay: has ref lifetime $heap which is >= $ro
+    // okay: the smallest lifetime input to the method is $heap therefore it is 
+    // is a $heap value and that is >= $ro
     int[] array = new int[42];
-    return new S<'heap>(ref array[0]);
+    return new S<$heap>(ref array[0]);
 
-    // error: has ref lifetime 'local which has no relationship to 'a hence 
+    // error: has ref lifetime $local which has no relationship to $a hence 
     // it's illegal
     int local = 42;
     return ref local;
@@ -1001,7 +1001,7 @@ ref struct S
     int field;
     ref int refField;
 
-    static void SelfAssign<'ro, 'cm>('ro ref 'cm S s)
+    static void SelfAssign<$ro, $cm>($ro ref $cm S s)
     {
         // error: ref s.field has ref lifetime 'ro and cannot be assigned to refField which
         // has lifetime 'cm as 'ro <= 'cm

--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -919,6 +919,7 @@ Given that let's explore a simple example that demonstrates the model here:
 ref int M1(ref int i) => ...
 
 // Maps to the following. 
+
 $ro ref int Identity<$ro>($ro ref int i)
 {
     // okay: has ref lifteime $ro which is equal to $ro
@@ -937,12 +938,12 @@ $ro ref int Identity<$ro>($ro ref int i)
 
 Now let's explore the same example using a `ref struct`: 
 
-```txt
+```csharp
 ref struct S
 {
     ref int Field;
 
-    $ro S<$ro>(ref int f)
+    $ro S<$ro>($ro ref int f)
     {
         Field = ref f;
     }
@@ -951,6 +952,7 @@ ref struct S
 S M2(ref int i, S span1, scoped S span2) => ...
 
 // Maps to 
+
 $ro S<int> M2<$ro>(
     $ro ref int i,
     $ro S span1)
@@ -982,7 +984,7 @@ $ro S<int> M2<$ro>(
 
 Next let's see how this helps with the cyclic self assignment problem:
 
-```txt
+```csharp
 ref struct S
 {
     int field;
@@ -1003,9 +1005,9 @@ ref struct S
 
     static void SelfAssign<$ro, $cm>($ro ref $cm S s)
     {
-        // error: ref s.field has ref lifetime 'ro and cannot be assigned to refField which
-        // has lifetime 'cm as 'ro <= 'cm
-        s.refField = 'ro ref s.field;
+        // error: ref s.field has ref lifetime $ro and cannot be assigned to refField which
+        // has lifetime $cm as $ro <= $cm
+        s.refField = $ro ref s.field;
     }
 }
 ```

--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -874,7 +874,7 @@ Lifetime models are most naturally expressed via a more explicit annotation mode
 
 Note that this is not meant to be a 100% complete documentation. Documenting every single behavior isn't a goal here. Instead it's meant to establish a general understanding and common verbiage by which the model, and potential changes to it, can be discussed.
 
-The below examples make use of named lifetimes. The syntax `$a` refers to a lifetime named `a`. It is a lifetime that has no meaning byitself but can be given a relationship to other lifetimes via the `where lifetime` syntax. There are a few predefined lifetimes for convenience and brevity below:
+The below examples make use of named lifetimes. The syntax `$a` refers to a lifetime named `a`. It is a lifetime that has no meaning by itself but can be given a relationship to other lifetimes via the `where lifetime` syntax. There are a few predefined lifetimes for convenience and brevity below:
 
 - `$heap`: this is the lifetime of any value that exists on the heap
 - `$local`: this is the lifetime of any value that exists on the method stack. It's effectively a name place holder for *current method*

--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -893,7 +893,7 @@ Lifetime variables when defined on types can be invariant or covariant. These ar
 ```csharp
 // $this is covariant
 // $a is invariant
-ref struct S<out $this, out $a> 
+ref struct S<out $this, $a> 
 ```
 
 The lifetime of a ref is expressed by providing a lifetime argument to the ref. For example a `ref` that refers to the heap is expressed as `ref<$heap>`.

--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -1008,6 +1008,7 @@ ref struct S
         s.refField = 'ro ref s.field;
     }
 }
+```
 
 ## Open Issues
 

--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -911,12 +911,11 @@ The basic rules for the lifetime are defined as:
     - `$heap` for all reference types and fields of reference types
     - `$local` for everything else
 - An assignment or return is legal when the underlying type conversion is legal
-- A ref assignment or return where the LHS is `ref<$a> T1` and the RHS is `ref<$b> T2` is legal when both:
-    - `T1` is equal to `T2`. Variance is not considered here, the types must be equal.
-    - `$b` is a sub-type of `$a`
 - Lifetimes of expressions can be made explicit by using cast annotations:
     - `(T<$a> expr)` the value lifetime is explicitly `$a` for `T<...>`
     - `ref<$a> (T<$b>)expr` the value lifetime is `$b` for `T<...>` and the ref lifetime is `$a`.
+
+For the purpose of lifetime rules a `ref` is considered part of the type of the expression for purposes of conversions. It is logically represented by converting `ref<$a> T<...>` to `ref<$a, T<...>>` where `$a` is covariant and `T` is invariant. 
 
 Next let's define the rules that allow us to map C# syntax to the underlying model.
 


### PR DESCRIPTION
Added a section that introduces a notation for the underlying lifetime model that C# operates on. This notation is very useful when breaking down how the model works at a low level, discussing issues with the behavior and potential future features. 

As we start to look into ideas like `ref scoped`, `ref` fields to `ref struct` and similar, it will be helpful to have a shared verbiage with which to discuss it. 