### PR TITLE
Remove bullets from breaking-change-warnings.md speclet

### DIFF
--- a/proposals/breaking-change-warnings.md
+++ b/proposals/breaking-change-warnings.md
@@ -1,10 +1,5 @@
 # Breaking change warnings
 
-* [x] Proposed
-* [ ] Prototype: [Not started](https://github.com/PROTOTYPE_OWNER/roslyn/BRANCH_NAME)
-* [ ] Implementation: [In Progress](https://github.com/dotnet/roslyn/BRANCH_NAME)
-* [ ] Specification: [Not Started](pr/1)
-
 ## Summary
 [summary]: #summary
 


### PR DESCRIPTION
FYI @MadsTorgersen 
Those status bullets are best kept in the championed issue (easier to update) instead of the speclet.