### PR TITLE
Improve wording versus referring to ".Add"

### DIFF
--- a/meetings/working-groups/collection-literals/CL-2023-05-26.md
+++ b/meetings/working-groups/collection-literals/CL-2023-05-26.md
@@ -10,7 +10,7 @@
 
 ### Capacity of constructed collections
 
-If an exact length is able to be calculated for the constructed collection, the capacity could be set ahead of time to avoid resizing the backing storage of the collection. But if the constructed collection escapes outside the method body, the next .Add would trigger a resize to double the backing storage size.
+If an exact length is able to be calculated for the constructed collection, the capacity could be set ahead of time to avoid resizing the backing storage of the collection. But if the constructed collection escapes outside the method body, adding a single item to the collection after that would trigger a resize to double the backing storage size.
 
 People will be able to write better code by hand than the compiler can generate if they have outside knowledge of the eventual state of the collection during its life past the construction of the collection literal. This would be a caveat to a statement about the collection literals feature generating optimal code. This is fine; the compiler can strike a good balance, and people can drop down to manual construction of the collection if they need more control over the initial capacity.
 


### PR DESCRIPTION
Received feedback on ".Add" without backticks being confusing to read.