### PR TITLE
Define capture behavior when primary ctor bypassed

### DIFF
--- a/proposals/primary-constructors.md
+++ b/proposals/primary-constructors.md
@@ -160,6 +160,8 @@ If a primary constructor parameter is referenced from within an instance member,
 
 Capturing is not allowed for parameters that have ref-like type, and capturing is not allowed for `ref`, `in` or `out` parameters. This is similar to a limitation for capturing in lambdas. 
 
+Structs present a challenge for primary constructor parameter capture: there is no way to enforce the execution of constructors on structs. (For example, creating a single-element array of some struct type will produce an instance of that type without running any of its constructors.) Section [§9.2.5](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/variables#925-value-parameters) of the C# spec states that constructor parameters do not come into existence until the constructor is invoked. Since primary constructor parameters are in scope throughout the type, this can create the awkward situation in which a parameter is in scope, but does not actually exist. If a parameter of a struct's primary constructor is captured, this would mean that the member causing its capture would be using a variable that does not exist. To avoid this, we assert that in cases where an instance of a type with a primary constructor was created through a mechanism that bypasses that constructor, all captured parameters come into existence when the instance is created, and are all initialized with the default value for their type.
+
 If a primary constructor parameter is only referenced from within instance member initializers, those can directly reference the parameter of the generated constructor, as they are executed as part of it.
 
 Primary Constructor will do the following sequence of operations:


### PR DESCRIPTION
As discussed at https://github.com/dotnet/csharplang/issues/2691#issuecomment-1642188788 the Primary Constructors spec runs into a problem when the execution of the constructor can be bypassed (as can happen with any `struct`.) Capture of constructor parameters results in variables that are in scope but which, according to the C# language specification, do not actually exist.

This change defines behaviour for captured parameters that avoids this problem.

This does not require any change in the implementation of this language feature. The preview already works exactly as this spec change describes. This just removes ambiguity arising from the fact that the existing C# language specification does not define what should happen when using a variable that does not exist. The existing implementation chose to resolve that ambiguity in an obvious way, and this spec change simply aligns with that.