### PR TITLE
Fix the new discussion link to avoid GitHub warning message

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Propose a language idea or ask a question
-    url: https://github.com/dotnet/csharplang/discussions/new
+    url: https://github.com/dotnet/csharplang/discussions/new/choose
     about: Starting with discussion is the way to create a new proposal.


### PR DESCRIPTION
The new issue template page shows a link for "Propose a language idea or ask a question." When clicking that link button, GitHub shows a warning message at the top of the page stating:

> Sorry, we didn't recognize that category! Please choose one of the following valid categories.

This is because the link for the button is slightly incorrect. GitHub redirects to the correct URL, but this experience made me pause before proceeding. This PR applies the URL that GitHub redirects to so that the warning will not be shown.