### PR TITLE
fix include, markdown lint

### DIFF
--- a/proposals/csharp-12.0/inline-arrays.md
+++ b/proposals/csharp-12.0/inline-arrays.md
@@ -1,6 +1,8 @@
 Inline Arrays
 =====
 
+[!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
+
 ## Summary
 
 Provide a general-purpose and safe mechanism for consuming struct types utilizing

--- a/proposals/csharp-12.0/lambda-method-group-defaults.md
+++ b/proposals/csharp-12.0/lambda-method-group-defaults.md
@@ -1,6 +1,6 @@
 # Optional and parameter array parameters for lambdas and method groups
 
-[!INCLUDE[Specletdisclaimer](speclet-disclaimer.md)]
+[!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
 
 ## Summary
 

--- a/proposals/csharp-12.0/primary-constructors.md
+++ b/proposals/csharp-12.0/primary-constructors.md
@@ -1,6 +1,6 @@
 # Primary constructors
 
-[!INCLUDE[Specletdisclaimer](speclet-disclaimer.md)]
+[!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
 
 ## Summary
 [summary]: #summary

--- a/proposals/csharp-12.0/using-alias-types.md
+++ b/proposals/csharp-12.0/using-alias-types.md
@@ -1,6 +1,6 @@
 # Allow using alias directive to reference any kind of Type
 
-[!INCLUDE[Specletdisclaimer](speclet-disclaimer.md)]
+[!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
 
 ## Summary
 Relax the using_alias_directive ([§13.5.2](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/namespaces.md#1352-using-alias-directives)) to allow it to point at any sort of type, not just named types.  This would support types not allowed today, like: tuple types, pointer types, array types, etc.  For example, this would now be allowed:


### PR DESCRIPTION
Fix the location for the disclaimer include file for the files that moved from the parent folder into the "csharp-12.0" folder. Where that disclaimer hasn't been added, it it.

In addition, fix markdown lint issues.

Hide whitespace diff for easier review.

This will fix the docs build errors and warnings in dotnet/docs#36699