### PR TITLE
Collection expressions: prefer ReadOnlySpan<T> over Span<T> in overload resolution

### DIFF
--- a/proposals/csharp-12.0/collection-expressions.md
+++ b/proposals/csharp-12.0/collection-expressions.md
@@ -441,8 +441,8 @@ In the updated rules:
 > Given an implicit conversion `C₁` that converts from an expression `E` to a type `T₁`, and an implicit conversion `C₂` that converts from an expression `E` to a type `T₂`, `C₁` is a ***better conversion*** than `C₂` if one of the following holds:
 >
 > * **`E` is a *collection expression* and one of the following holds:**
->   * **`T₁` is `System.ReadOnlySpan<E₁>`, and `T₂` is `System.ReadOnlySpan<E₂>`, and an implicit conversion exists from `E₁` to `E₂`**
->   * **`T₁` is `System.ReadOnlySpan<E₁>` or `System.Span<E₁>`, and `T₂` is `System.Span<E₂>` or an *array_or_array_interface_or_string_type* with *iteration type* `E₂`, and an implicit conversion exists from `E₁` to `E₂`**
+>   * **`T₁` is `System.ReadOnlySpan<E₁>`, and `T₂` is `System.Span<E₂>`, and an implicit conversion exists from `E₁` to `E₂`**
+>   * **`T₁` is `System.ReadOnlySpan<E₁>` or `System.Span<E₁>`, and `T₂` is an *array_or_array_interface_or_string_type* with *iteration type* `E₂`, and an implicit conversion exists from `E₁` to `E₂`**
 >   * **`T₁` is not a *span_type*, and `T₂` is not a *span_type*, and an implicit conversion exists from `T₁` to `T₂`**
 > * **`E` is not a *collection expression* and one of the following holds:**
 >   * `E` exactly matches `T₁` and `E` does not exactly match `T₂`

--- a/proposals/csharp-12.0/collection-expressions.md
+++ b/proposals/csharp-12.0/collection-expressions.md
@@ -440,12 +440,14 @@ In the updated rules:
 
 > Given an implicit conversion `C₁` that converts from an expression `E` to a type `T₁`, and an implicit conversion `C₂` that converts from an expression `E` to a type `T₂`, `C₁` is a ***better conversion*** than `C₂` if one of the following holds:
 >
-> * `E` exactly matches `T₁` and `E` does not exactly match `T₂`
-> * `E` exactly matches both or neither of `T₁` and `T₂`, and `T₁` is a [*better conversion target*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#11646-better-conversion-target) than `T₂` **and the following is *not true*:**
->   * **`C₁` and `C₂` are collection expression conversions *and***
->   * **`T₁` is a *span_type* and `T₂` is an *array_or_array_interface_or_string_type*, *or* `T₂` is a *span_type* and `T₁` is an *array_or_array_interface_or_string_type***
-> * **`C₁` and `C₂` are collection expression conversions, and `T₁` is a *span_type* with *iteration type* `E₁`, and `T₂` is an *array_or_array_interface_or_string_type* with *iteration type* `E₂`, and `E₁` is implicitly convertible to `E₂`**
-> * ...
+> * **`E` is a *collection expression* and one of the following holds:**
+>   * **`T₁` is `System.ReadOnlySpan<E₁>`, and `T₂` is `System.ReadOnlySpan<E₂>`, and an implicit conversion exists from `E₁` to `E₂`**
+>   * **`T₁` is `System.ReadOnlySpan<E₁>` or `System.Span<E₁>`, and `T₂` is `System.Span<E₂>` or an *array_or_array_interface_or_string_type* with *iteration type* `E₂`, and an implicit conversion exists from `E₁` to `E₂`**
+>   * **`T₁` is not a *span_type*, and `T₂` is not a *span_type*, and an implicit conversion exists from `T₁` to `T₂`**
+> * **`E` is not a *collection expression* and one of the following holds:**
+>   * `E` exactly matches `T₁` and `E` does not exactly match `T₂`
+>   * `E` exactly matches both or neither of `T₁` and `T₂`, and `T₁` is a [*better conversion target*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#11646-better-conversion-target) than `T₂`
+> * `E` is a method group, ...
 
 Examples of differences with overload resolution between array initializers and collection expressions:
 ```c#


### PR DESCRIPTION
See [LDM-2023-10-11.md](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-10-11.md#conclusion)

See https://github.com/dotnet/roslyn/issues/70318