### PR TITLE
Add docs template for spec issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/docs-feedback.yml
@@ -3,6 +3,9 @@ description: |
   ⛔ This template is hooked into the feedback control on the bottom of every page on the learn.microsoft.com site. It automatically fills in several fields for you. Don't use for other purposes. ⛔
 assignees:
   - BillWagner
+labels:
+  - Area-Speclets
+  - untriaged
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/docs-feedback.yml
@@ -1,0 +1,47 @@
+name: Learn feedback control.
+description: |
+  ⛔ This template is hooked into the feedback control on the bottom of every page on the learn.microsoft.com site. It automatically fills in several fields for you. Don't use for other purposes. ⛔
+assignees:
+  - BillWagner
+body:
+  - type: markdown
+    attributes:
+      value: "## Issue information"
+  - type: markdown
+    attributes:
+      value: Select the issue type, and describe the issue in the text box below. Add as much detail as needed to help us resolve the issue.
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Type of issue
+      options:
+        - Typo
+        - Spec incorrect
+        - Spec incomplete
+        - Other (describe below)
+    validations:
+      required: true
+  - type: textarea
+    id: feedback
+    validations:
+      required: true
+    attributes:
+      label: Description
+  - type: markdown
+    attributes:
+      value: "## 🚧 Article information 🚧"
+  - type: markdown
+    attributes:
+      value: "*Don't modify the following fields*. They are automatically filled in for you. Doing so will disconnect your issue from the affected article. *Don't edit them*."
+  - type: input
+    id: pageUrl
+    validations:
+      required: true
+    attributes:
+      label: Page URL
+  - type: input
+    id: contentSourceUrl
+    validations:
+      required: true
+    attributes:
+      label: Content source URL


### PR DESCRIPTION
Once this is merged I'll add the config to direct customer issues to this template.

The "View file" tab on changes will give a reasonable facsimile of the experience a user will see when they are routed to this form. The fields at the bottom will be filled it.
