### PR TITLE
add speclet disclaimer

### DIFF
--- a/proposals/csharp-12.0/experimental-attribute.md
+++ b/proposals/csharp-12.0/experimental-attribute.md
@@ -1,5 +1,8 @@
 ExperimentalAttribute
 =====================
+
+[!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
+
 Report warnings for references to types and members marked with `System.Diagnostics.CodeAnalysis.ExperimentalAttribute`.
 ```cs
 namespace System.Diagnostics.CodeAnalysis


### PR DESCRIPTION
One speclet for C# 12 didn't include the speclet disclaimer that we publish on docs.

Added it.