### PR TITLE
Fix type name, nameof argument in primary constructors speclet

### DIFF
--- a/proposals/csharp-12.0/primary-constructors.md
+++ b/proposals/csharp-12.0/primary-constructors.md
@@ -24,7 +24,7 @@ public class C(bool b, int i, string s) : B(b) // b passed to base constructor
     public string S // s used directly in function members
     {
         get => s;
-        set => s = value ?? throw new NullArgumentException(nameof(X));
+        set => s = value ?? throw new ArgumentNullException(nameof(S));
     }
     public C(string s) : this(true, 0, s) { } // must call this(...)
 }


### PR DESCRIPTION
Fixes dotnet/docs#37377

The exception name was spelled incorrectly, as was the argument to the `nameof` expression