### PR TITLE
Update static-abstracts-in-interfaces.md to Fix Reference to Incorrect Type

### DIFF
--- a/proposals/csharp-11.0/static-abstracts-in-interfaces.md
+++ b/proposals/csharp-11.0/static-abstracts-in-interfaces.md
@@ -25,7 +25,7 @@ interface IAddable<T> where T : IAddable<T>
 // Classes and structs (including built-ins) can implement interface
 struct Int32 : …, IAddable<Int32>
 {
-    static Int32 I.operator +(Int32 x, Int32 y) => x + y; // Explicit
+    static Int32 IAddable<Int32>.operator +(Int32 x, Int32 y) => x + y; // Explicit
     public static int Zero => 0;                          // Implicit
 }
 


### PR DESCRIPTION
In [Static abstract members in interfaces - Motivation](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-11.0/static-abstracts-in-interfaces#motivation), the line beginning with `static Int32 I.operator +` won't work: `I` is not the correct type. It should be `IAddable<Int32>`.