### PR TITLE
Determine element type for write-only CollectionBuilder collection types

### DIFF
--- a/proposals/csharp-12.0/collection-expressions.md
+++ b/proposals/csharp-12.0/collection-expressions.md
@@ -103,22 +103,25 @@ Collection literals are [target-typed](https://github.com/dotnet/csharplang/blob
 A *collection expression conversion* allows a collection expression to be converted to a type.
 
 An implicit *collection expression conversion* exists from a collection expression to the following types:
-* A single dimensional *array type* `T[]`
+* A single dimensional *array type* `T[]`, in which case the *element type* is `T`
 * A *span type*:
   * `System.Span<T>`
   * `System.ReadOnlySpan<T>`
-* A *type* with a *[create method](#create-methods)* with an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) determined from a `GetEnumerator` instance method or enumerable interface, not from an extension method
+  in which cases the *element type* is `T`
+* A *type* with an appropriate *[create method](#create-methods)* and a corresponding *element type* resulting from that determination
 * A *struct* or *class type* that implements `System.Collections.IEnumerable` where:
   * The *type* has an *[applicable](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#11642-applicable-function-member)* constructor that can be invoked with no arguments, and the constructor is accessible at the location of the collection expression.
   * The *type* has an *[applicable](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#11642-applicable-function-member)* instance or extension method `Add` that can be invoked with a single argument of the [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement), and the method is accessible at the location of the collection expression.
+  in which case the *element type* is the *iteration type* of the *type*.
 * An *interface type*:
   * `System.Collections.Generic.IEnumerable<T>`
   * `System.Collections.Generic.IReadOnlyCollection<T>`
   * `System.Collections.Generic.IReadOnlyList<T>`
   * `System.Collections.Generic.ICollection<T>`
   * `System.Collections.Generic.IList<T>`
+  in which cases the *element type* is `T`
 
-The implicit conversion exists if the type has an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) `U` where for each *element* `Eᵢ` in the collection expression:
+The implicit conversion exists if the type has an [*element type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) `U` where for each *element* `Eᵢ` in the collection expression:
 * If `Eᵢ` is an *expression element*, there is an implicit conversion from `Eᵢ` to `U`.
 * If `Eᵢ` is an *spread element* `Sᵢ`, there is an implicit conversion from the *iteration type* of `Sᵢ` to `U`.
 
@@ -158,8 +161,6 @@ namespace System.Runtime.CompilerServices
 The attribute can be applied to a `class`, `struct`, `ref struct`, or `interface`.
 The attribute is not inherited although the attribute can be applied to a base `class` or an `abstract class`.
 
-The collection type must have an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement).
-
 For the *create method*:
 
 * The *builder type* must be a non-generic `class` or `struct`.
@@ -167,8 +168,13 @@ For the *create method*:
 * The method must be `static`.
 * The method must be accessible where the collection expression is used.
 * The *arity* of the method must match the *arity* of the collection type.
-* The method must have a single parameter of type `System.ReadOnlySpan<E>`, passed by value, and there is an [*identity conversion*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/conversions.md#1022-identity-conversion) from `E` to the [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) of the *collection type*.
+* The method must have a single parameter of type `System.ReadOnlySpan<E>`, passed by value, and if the collection type has an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement), there is an [*identity conversion*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/conversions.md#1022-identity-conversion) from `E` to the *iteration type*.
 * There is an [*identity conversion*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/conversions.md#1022-identity-conversion), [*implicit reference conversion*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/conversions.md#1028-implicit-reference-conversions), or [*boxing conversion*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/conversions.md#1029-boxing-conversions) from the method return type to the *collection type*.
+
+Determination of the *element type*:
+
+* If the collection type has an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) determined from a `GetEnumerator` instance method or enumerable interface (not from an extension method) then the *element type* is the *iteration type*.
+* Otherwise, if there is a single *create method* then the *element type* is `E` given by the method's only parameter (of type `System.ReadOnlySpan<E>`).
 
 An error is reported if the `[CollectionBuilder]` attribute does not refer to an invocable method with the expected signature.
 
@@ -377,7 +383,7 @@ The existing rules for the [*first phase*](https://github.com/dotnet/csharpstand
 >
 > An *input type inference* is made *from* an expression `E` *to* a type `T` in the following way:
 >
-> * If `E` is a *collection expression* with elements `Eᵢ`, and `T` is a type with an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) `Tₑ` or `T` is a *nullable value type* `T0?` and `T0` has an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) `Tₑ`, then for each `Eᵢ`:
+> * If `E` is a *collection expression* with elements `Eᵢ`, and `T` is a type with an *element type* `Tₑ` or `T` is a *nullable value type* `T0?` and `T0` has an *element type* `Tₑ`, then for each `Eᵢ`:
 >   * If `Eᵢ` is an *expression element*, then an *input type inference* is made *from* `Eᵢ` *to* `Tₑ`.
 >   * If `Eᵢ` is an *spread element* with an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) `Sᵢ`, then a [*lower-bound inference*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#116310-lower-bound-inferences) is made *from* `Sᵢ` *to* `Tₑ`.
 > * *[existing rules from first phase]* ...
@@ -386,7 +392,7 @@ The existing rules for the [*first phase*](https://github.com/dotnet/csharpstand
 >
 > An *output type inference* is made *from* an expression `E` *to* a type `T` in the following way:
 >
-> * If `E` is a *collection expression* with elements `Eᵢ`, and `T` is a type with an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) `Tₑ` or `T` is a *nullable value type* `T0?` and `T0` has an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) `Tₑ`, then for each `Eᵢ`:
+> * If `E` is a *collection expression* with elements `Eᵢ`, and `T` is a type with an *element type* `Tₑ` or `T` is a *nullable value type* `T0?` and `T0` has an *element type* `Tₑ`, then for each `Eᵢ`:
 >   * If `Eᵢ` is an *expression element*, then an *output type inference* is made *from* `Eᵢ` *to* `Tₑ`.
 >   * If `Eᵢ` is an *spread element*, no inference is made from `Eᵢ`.
 > * *[existing rules from output type inferences]* ...
@@ -437,7 +443,7 @@ In the updated rules:
 >
 > * **`E` is a *collection expression* and one of the following holds:**
 >   * **`T₁` is `System.ReadOnlySpan<E₁>`, and `T₂` is `System.Span<E₂>`, and an implicit conversion exists from `E₁` to `E₂`**
->   * **`T₁` is `System.ReadOnlySpan<E₁>` or `System.Span<E₁>`, and `T₂` is an *array_or_array_interface* with *iteration type* `E₂`, and an implicit conversion exists from `E₁` to `E₂`**
+>   * **`T₁` is `System.ReadOnlySpan<E₁>` or `System.Span<E₁>`, and `T₂` is an *array_or_array_interface* with *element type* `E₂`, and an implicit conversion exists from `E₁` to `E₂`**
 >   * **`T₁` is not a *span_type*, and `T₂` is not a *span_type*, and an implicit conversion exists from `T₁` to `T₂`**
 > * **`E` is not a *collection expression* and one of the following holds:**
 >   * `E` exactly matches `T₁` and `E` does not exactly match `T₂`

--- a/proposals/csharp-12.0/collection-expressions.md
+++ b/proposals/csharp-12.0/collection-expressions.md
@@ -180,10 +180,9 @@ If the `CM` set is empty, then the *collection type* doesn't have *element type*
 
 Second, an attempt is made to determine the [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) of the *collection type* from a `GetEnumerator` instance method or enumerable interface, not from an extension method.
 
-- If an *iteration type* can be determined, then the *element type* of the *collection type* is the *iteration type*. If only one method among those in the `CM` set has an [*identity conversion*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/conversions.md#1022-identity-conversion) from `E` to the *element type* of the *collection type*, that is the *create method* for the *collection type*. Otherwise, the *collection type* doesn't have *create method*. None of the following steps apply.  
-- Otherwise, then the *collection type* doesn't have *element type* and doesn't have *create method*. None of the following steps apply. 
+If an *iteration type* can be determined, then the *element type* of the *collection type* is the *iteration type*. If only one method among those in the `CM` set has an [*identity conversion*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/conversions.md#1022-identity-conversion) from `E` to the *element type* of the *collection type*, that is the *create method* for the *collection type*. Otherwise, the *collection type* doesn't have *create method*. None of the following steps apply.  
 
-Third, an attempt is made to infer the *element type*.
+Third (ie. if an *iteration type* cannot be determined), an attempt is made to infer the *element type*.
 If the `CM` set contains more than one method, the inference fails and the *collection type* doesn't have an *element type* and doesn't have a *create method*.
 
 Otherwise, type `E1` is determined from the only method `M` in the `CM` set by substituting the type parameters of the *collection type* for the type parameters of `M` in `E`. If any generic constraints are violated for `E1`, the *collection type* doesn't have *element type* and doesn't have *create method*. Otherwise, `E1` is the *element type* and `M` is the *create method* for the *collection type*.

--- a/proposals/csharp-12.0/collection-expressions.md
+++ b/proposals/csharp-12.0/collection-expressions.md
@@ -166,7 +166,7 @@ The *builder type* must be a non-generic `class` or `struct`.
 First, the set of applicable *create methods* `CM` is determined.  
 It consists of methods that meet the following requirements:
 
-* The method must have name specified in the `[CollectionBuilder(...)]` attribute. 
+* The method must have the name specified in the `[CollectionBuilder(...)]` attribute. 
 * The method must be defined on the *builder type* directly.
 * The method must be `static`.
 * The method must be accessible where the collection expression is used.
@@ -180,12 +180,12 @@ If the `CM` set is empty, then the *collection type* doesn't have *element type*
 
 Second, an attempt is made to determine the [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) of the *collection type* from a `GetEnumerator` instance method or enumerable interface, not from an extension method.
 
-If an *iteration type* can be determined, then the *element type* of the *collection type* is the *iteration type*. If only one method among those in the `CM` set has an [*identity conversion*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/conversions.md#1022-identity-conversion) from `E` to the *element type* of the *collection type*, that is the *create method* for the *collection type*. Otherwise, the *collection type* doesn't have *create method*. None of the following steps apply.  
+If an *iteration type* can be determined, then the *element type* of the *collection type* is the *iteration type*. If only one method among those in the `CM` set has an [*identity conversion*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/conversions.md#1022-identity-conversion) from `E` to the *element type* of the *collection type*, that is the *create method* for the *collection type*. Otherwise, the *collection type* doesn't have a *create method*. None of the following steps apply.  
 
 Third (ie. if an *iteration type* cannot be determined), an attempt is made to infer the *element type*.
 If the `CM` set contains more than one method, the inference fails and the *collection type* doesn't have an *element type* and doesn't have a *create method*.
 
-Otherwise, type `E1` is determined by substituting type parameters of the only method from the `CM` set (`M`) with corresponding *collection type* type parameters in its `E`. If any generic constraints are violated for `E1`, the *collection type* doesn't have *element type* and doesn't have *create method*. Otherwise, `E1` is the *element type* and `M` is the *create method* for the *collection type*.
+Otherwise, type `E1` is determined by substituting type parameters of the only method from the `CM` set (`M`) with corresponding *collection type* type parameters in its `E`. If any generic constraints are violated for `E1`, the *collection type* doesn't have an *element type* and doesn't have a *create method*. Otherwise, `E1` is the *element type* and `M` is the *create method* for the *collection type*.
 
 An error is reported if the `[CollectionBuilder]` attribute does not refer to an invokable method with the expected signature.
 

--- a/proposals/csharp-12.0/collection-expressions.md
+++ b/proposals/csharp-12.0/collection-expressions.md
@@ -106,19 +106,19 @@ An implicit *collection expression conversion* exists from a collection expressi
 * A single dimensional *array type* `T[]`, in which case the *element type* is `T`
 * A *span type*:
   * `System.Span<T>`
-  * `System.ReadOnlySpan<T>`
+  * `System.ReadOnlySpan<T>`  
   in which cases the *element type* is `T`
 * A *type* with an appropriate *[create method](#create-methods)* and a corresponding *element type* resulting from that determination
 * A *struct* or *class type* that implements `System.Collections.IEnumerable` where:
   * The *type* has an *[applicable](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#11642-applicable-function-member)* constructor that can be invoked with no arguments, and the constructor is accessible at the location of the collection expression.
-  * The *type* has an *[applicable](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#11642-applicable-function-member)* instance or extension method `Add` that can be invoked with a single argument of the [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement), and the method is accessible at the location of the collection expression.
+  * The *type* has an *[applicable](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#11642-applicable-function-member)* instance or extension method `Add` that can be invoked with a single argument of the [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement), and the method is accessible at the location of the collection expression.  
   in which case the *element type* is the *iteration type* of the *type*.
 * An *interface type*:
   * `System.Collections.Generic.IEnumerable<T>`
   * `System.Collections.Generic.IReadOnlyCollection<T>`
   * `System.Collections.Generic.IReadOnlyList<T>`
   * `System.Collections.Generic.ICollection<T>`
-  * `System.Collections.Generic.IList<T>`
+  * `System.Collections.Generic.IList<T>`  
   in which cases the *element type* is `T`
 
 The implicit conversion exists if the type has an [*element type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) `U` where for each *element* `Eᵢ` in the collection expression:
@@ -161,7 +161,7 @@ namespace System.Runtime.CompilerServices
 The attribute can be applied to a `class`, `struct`, `ref struct`, or `interface`.
 The attribute is not inherited although the attribute can be applied to a base `class` or an `abstract class`.
 
-The determination of an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) must be from a `GetEnumerator` instance method or enumerable interface (not from an extension method).
+The determination of an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) must be from a `GetEnumerator` instance method or enumerable interface, not from an extension method.
 
 For the *create method*:
 

--- a/proposals/csharp-12.0/collection-expressions.md
+++ b/proposals/csharp-12.0/collection-expressions.md
@@ -110,8 +110,8 @@ An implicit *collection expression conversion* exists from a collection expressi
   in which cases the *element type* is `T`
 * A *type* with an appropriate *[create method](#create-methods)* and a corresponding *element type* resulting from that determination
 * A *struct* or *class type* that implements `System.Collections.IEnumerable` where:
-  * The *type* has an *[applicable](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#11642-applicable-function-member)* constructor that can be invoked with no arguments, and the constructor is accessible at the location of the collection expression.
-  * The *type* has an *[applicable](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#11642-applicable-function-member)* instance or extension method `Add` that can be invoked with a single argument of the [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement), and the method is accessible at the location of the collection expression.  
+  * The *type* has an *[applicable](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#11642-applicable-function-member)* constructor that can be invoked with no arguments, and the constructor is accessible at the location of the collection expression, and
+  * The *type* has an *[applicable](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#11642-applicable-function-member)* instance or extension method `Add` that can be invoked with a single argument of the [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement), and the method is accessible at the location of the collection expression,
   in which case the *element type* is the *iteration type* of the *type*.
 * An *interface type*:
   * `System.Collections.Generic.IEnumerable<T>`
@@ -121,7 +121,7 @@ An implicit *collection expression conversion* exists from a collection expressi
   * `System.Collections.Generic.IList<T>`  
   in which cases the *element type* is `T`
 
-The implicit conversion exists if the type has an [*element type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) `U` where for each *element* `Eᵢ` in the collection expression:
+The implicit conversion exists if the type has an *element type* `U` where for each *element* `Eᵢ` in the collection expression:
 * If `Eᵢ` is an *expression element*, there is an implicit conversion from `Eᵢ` to `U`.
 * If `Eᵢ` is an *spread element* `Sᵢ`, there is an implicit conversion from the *iteration type* of `Sᵢ` to `U`.
 
@@ -163,7 +163,7 @@ The attribute is not inherited although the attribute can be applied to a base `
 
 The *builder type* must be a non-generic `class` or `struct`.
 
-First, the set of applicable *create method*s `CM` is determined.  
+First, the set of applicable *create methods* `CM` is determined.  
 It consists of methods that meet the following requirements:
 
 * The method must have name specified in the `[CollectionBuilder(...)]` attribute. 
@@ -178,7 +178,7 @@ Methods declared on base types or interfaces are ignored and not part of the `CM
 
 If the `CM` set is empty, then the *collection type* doesn't have *element type* and doesn't have *create method*. None of the following steps apply.
 
-Second, an attempt is made to determine [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) of the *collection type* from a `GetEnumerator` instance method or enumerable interface, not from an extension method.
+Second, an attempt is made to determine the [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) of the *collection type* from a `GetEnumerator` instance method or enumerable interface, not from an extension method.
 
 - If an *iteration type* can be determined, then the *element type* of the *collection type* is the *iteration type*. If only one method among those in the `CM` set has an [*identity conversion*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/conversions.md#1022-identity-conversion) from `E` to the *element type* of the *collection type*, that is the *create method* for the *collection type*. Otherwise, the *collection type* doesn't have *create method*. None of the following steps apply.  
 - Otherwise, then the *collection type* doesn't have *element type* and doesn't have *create method*. None of the following steps apply. 
@@ -186,7 +186,7 @@ Second, an attempt is made to determine [*iteration type*](https://github.com/do
 Third, an attempt is made to infer the *element type*.
 If the `CM` set contains more than one method, the inference fails and the *collection type* doesn't have an *element type* and doesn't have a *create method*.
 
-Otherwise, type `E1` is determined by substituting type parameters of the only method from the `CM` set (`M`) with corresponding *collection type* type parameters in its `E`. If any generic constraints are violated for `E1`, the *collection type* doesn't have *element type* and doesn't have *create method*. Otherwise, `E1` is the *element type* and `M` is the *create method* for the *collection type*.
+Otherwise, type `E1` is determined from the only method `M` in the `CM` set by substituting the type parameters of the *collection type* for the type parameters of `M` in `E`. If any generic constraints are violated for `E1`, the *collection type* doesn't have *element type* and doesn't have *create method*. Otherwise, `E1` is the *element type* and `M` is the *create method* for the *collection type*.
 
 An error is reported if the `[CollectionBuilder]` attribute does not refer to an invokable method with the expected signature.
 

--- a/proposals/csharp-12.0/collection-expressions.md
+++ b/proposals/csharp-12.0/collection-expressions.md
@@ -176,7 +176,7 @@ For the *create method*:
 Determination of the *element type*:
 
 * If the collection type has an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) (with above restriction) then the *element type* is the *iteration type*.
-* Otherwise, if there is a single *create method* then the *element type* is `E` given by the method's only parameter (of type `System.ReadOnlySpan<E>`).
+* Otherwise, if there is a single non-generic *create method* then the *element type* is `E` given by the method's only parameter (of type `System.ReadOnlySpan<E>`).
 
 An error is reported if the `[CollectionBuilder]` attribute does not refer to an invocable method with the expected signature.
 

--- a/proposals/csharp-12.0/collection-expressions.md
+++ b/proposals/csharp-12.0/collection-expressions.md
@@ -176,7 +176,7 @@ It consists of methods that meet the following requirements:
 
 Methods declared on base types or interfaces are ignored and not part of the `CM` set.
 
-If the `CM` set is empty, then the *collection type* doesn't have *element type* and doesn't have *create method*. None of the following steps apply.
+If the `CM` set is empty, then the *collection type* doesn't have an *element type* and doesn't have a *create method*. None of the following steps apply.
 
 Second, an attempt is made to determine the [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) of the *collection type* from a `GetEnumerator` instance method or enumerable interface, not from an extension method.
 

--- a/proposals/csharp-12.0/collection-expressions.md
+++ b/proposals/csharp-12.0/collection-expressions.md
@@ -161,6 +161,8 @@ namespace System.Runtime.CompilerServices
 The attribute can be applied to a `class`, `struct`, `ref struct`, or `interface`.
 The attribute is not inherited although the attribute can be applied to a base `class` or an `abstract class`.
 
+The determination of an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) must be from a `GetEnumerator` instance method or enumerable interface (not from an extension method).
+
 For the *create method*:
 
 * The *builder type* must be a non-generic `class` or `struct`.
@@ -168,12 +170,12 @@ For the *create method*:
 * The method must be `static`.
 * The method must be accessible where the collection expression is used.
 * The *arity* of the method must match the *arity* of the collection type.
-* The method must have a single parameter of type `System.ReadOnlySpan<E>`, passed by value, and if the collection type has an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement), there is an [*identity conversion*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/conversions.md#1022-identity-conversion) from `E` to the *iteration type*.
+* The method must have a single parameter of type `System.ReadOnlySpan<E>`, passed by value, and if the collection type has an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) (with above restriction), there is an [*identity conversion*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/conversions.md#1022-identity-conversion) from `E` to the *iteration type*.
 * There is an [*identity conversion*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/conversions.md#1022-identity-conversion), [*implicit reference conversion*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/conversions.md#1028-implicit-reference-conversions), or [*boxing conversion*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/conversions.md#1029-boxing-conversions) from the method return type to the *collection type*.
 
 Determination of the *element type*:
 
-* If the collection type has an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) determined from a `GetEnumerator` instance method or enumerable interface (not from an extension method) then the *element type* is the *iteration type*.
+* If the collection type has an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) (with above restriction) then the *element type* is the *iteration type*.
 * Otherwise, if there is a single *create method* then the *element type* is `E` given by the method's only parameter (of type `System.ReadOnlySpan<E>`).
 
 An error is reported if the `[CollectionBuilder]` attribute does not refer to an invocable method with the expected signature.

--- a/proposals/csharp-12.0/collection-expressions.md
+++ b/proposals/csharp-12.0/collection-expressions.md
@@ -185,7 +185,7 @@ If an *iteration type* can be determined, then the *element type* of the *collec
 Third (ie. if an *iteration type* cannot be determined), an attempt is made to infer the *element type*.
 If the `CM` set contains more than one method, the inference fails and the *collection type* doesn't have an *element type* and doesn't have a *create method*.
 
-Otherwise, type `E1` is determined from the only method `M` in the `CM` set by substituting the type parameters of the *collection type* for the type parameters of `M` in `E`. If any generic constraints are violated for `E1`, the *collection type* doesn't have *element type* and doesn't have *create method*. Otherwise, `E1` is the *element type* and `M` is the *create method* for the *collection type*.
+Otherwise, type `E1` is determined by substituting type parameters of the only method from the `CM` set (`M`) with corresponding *collection type* type parameters in its `E`. If any generic constraints are violated for `E1`, the *collection type* doesn't have *element type* and doesn't have *create method*. Otherwise, `E1` is the *element type* and `M` is the *create method* for the *collection type*.
 
 An error is reported if the `[CollectionBuilder]` attribute does not refer to an invokable method with the expected signature.
 

--- a/proposals/params-collections.md
+++ b/proposals/params-collections.md
@@ -53,12 +53,12 @@ The *type* of a parameter collection shall be one of the following valid target 
   - `System.ReadOnlySpan<T>`  
   in which cases the *element type* is `T`
 - A *type* with an appropriate *[create method](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/collection-expressions.md#create-methods)*,
-  which is at least as accessible as the declaring member and a corresponding *element type* resulting from that determination
+  which is at least as accessible as the declaring member, and with a corresponding *element type* resulting from that determination
 - A *struct* or *class type* that implements `System.Collections.IEnumerable` where:
-  - The *type* has a constructor that can be invoked with no arguments, and the constructor is at least as accessible as the declaring member.
+  - The *type* has a constructor that can be invoked with no arguments, and the constructor is at least as accessible as the declaring member, and
   - The *type* has an instance (not an extension) method `Add` that can be invoked with a single argument of
     the [*iteration type*](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/statements.md#1395-the-foreach-statement),
-    and the method is at least as accessible as the declaring member.  
+    and the method is at least as accessible as the declaring member,
   in which case the *element type* is the *iteration type*
 - An *interface type*
   - `System.Collections.Generic.IEnumerable<T>`,

--- a/proposals/params-collections.md
+++ b/proposals/params-collections.md
@@ -47,28 +47,31 @@ A *parameter_collection* consists of an optional set of *attributes*, a `params`
 a *type*, and an *identifier*. A parameter collection declares a single parameter of the given type with the given name.
 The *type* of a parameter collection shall be one of the following valid target types for a collection expression
 (see https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/collection-expressions.md#conversions):
-- A single dimensional *array type* `T[]`
+- A single dimensional *array type* `T[]` in which case the *element type* is `T`
 - A *span type*
   - `System.Span<T>`
   - `System.ReadOnlySpan<T>`
-- A *type* with a *[create method](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/collection-expressions.md#create-methods)*,
-  which is at least as accessible as the declaring member, and with an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/statements.md#1395-the-foreach-statement)
+  in which cases the *element type* is `T`
+- A *type* with an appropriate *[create method](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/collection-expressions.md#create-methods)*,
+  which is at least as accessible as the declaring member and a corresponding *element type* resulting from that determination
   determined from a `GetEnumerator` instance method or enumerable interface, not from an extension method.
 - A *struct* or *class type* that implements `System.Collections.IEnumerable` where:
   - The *type* has a constructor that can be invoked with no arguments, and the constructor is at least as accessible as the declaring member.
   - The *type* has an instance (not an extension) method `Add` that can be invoked with a single argument of
     the [*iteration type*](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/statements.md#1395-the-foreach-statement),
     and the method is at least as accessible as the declaring member.
+  in which case the *element type* is the *iteration type*
 - An *interface type*
   - `System.Collections.Generic.IEnumerable<T>`,
   - `System.Collections.Generic.IReadOnlyCollection<T>`,
   - `System.Collections.Generic.IReadOnlyList<T>`,
   - `System.Collections.Generic.ICollection<T>`,
   - `System.Collections.Generic.IList<T>`
+  in which cases the *element type* is `T`
 
 In a method invocation, a parameter collection permits either a single argument of the given parameter type to be specified, or
-it permits zero or more arguments of the collection [iteration type](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/statements.md#1395-the-foreach-statement)
-to be specified. Parameter collections are described further in *[Parameter collections](#parameter-collections)*.
+it permits zero or more arguments of the collection's *element type* to be specified. 
+Parameter collections are described further in *[Parameter collections](#parameter-collections)*.
 
 A *parameter_collection* may occur after an optional parameter, but cannot have a default value – the omission of arguments for a *parameter_collection*
 would instead result in the creation of an empty collection.
@@ -87,7 +90,7 @@ A parameter collection permits arguments to be specified in one of two ways in a
 - The argument given for a parameter collection can be a single expression that is implicitly convertible to the parameter collection type.
   In this case, the parameter collection acts precisely like a value parameter.
 - Alternatively, the invocation can specify zero or more arguments for the parameter collection, where each argument is an expression
-  that is implicitly convertible to the parameter collection [iteration type](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/statements.md#1395-the-foreach-statement).
+  that is implicitly convertible to the parameter collection's *element type*.
   In this case, the invocation creates an instance of the parameter collection type according to the rules specified in
   [Collection expressions](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/collection-expressions.md)
   as though the arguments were used as expression elements in a collection expression in the same order,
@@ -117,7 +120,7 @@ The [Applicable function member](https://github.com/dotnet/csharpstandard/blob/d
 If a function member that includes a parameter collection is not applicable in its normal form, the function member might instead be applicable in its ***expanded form***:
 
 - The expanded form is constructed by replacing the parameter collection in the function member declaration with
-  zero or more value parameters of the parameter collection [iteration type](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/statements.md#1395-the-foreach-statement)
+  zero or more value parameters of the parameter collection's *element type*
   such that the number of arguments in the argument list `A` matches the total number of parameters.
   If `A` has fewer arguments than the number of fixed parameters in the function member declaration,
   the expanded form of the function member cannot be constructed and is thus not applicable.
@@ -158,7 +161,7 @@ In case the parameter type sequences `{P₁, P₂, ..., Pᵥ}` and `{Q₁, Q₂,
   - **params collection of `Mᵢ` is `System.ReadOnlySpan<Eᵢ>`, and params collection of `Mₑ` is `System.Span<Eₑ>`, and an implicit conversion exists from `Eᵢ` to `Eₑ`**
   - **params collection of `Mᵢ` is `System.ReadOnlySpan<Eᵢ>` or `System.Span<Eᵢ>`, and params collection of `Mₑ` is
     an *[array_or_array_interface__type](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/collection-expressions.md#overload-resolution)*
-    with *[iteration type](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/statements.md#1395-the-foreach-statement)* `Eₑ`, and an implicit conversion exists from `Eᵢ` to `Eₑ`**
+    with *element type* `Eₑ`, and an implicit conversion exists from `Eᵢ` to `Eₑ`**
   - **both params collections are not *span_type*s, and an implicit conversion exists from params collection of `Mᵢ` to params collection of `Mₑ`**  
 - Otherwise, no function member is better.
 

--- a/proposals/params-collections.md
+++ b/proposals/params-collections.md
@@ -47,10 +47,10 @@ A *parameter_collection* consists of an optional set of *attributes*, a `params`
 a *type*, and an *identifier*. A parameter collection declares a single parameter of the given type with the given name.
 The *type* of a parameter collection shall be one of the following valid target types for a collection expression
 (see https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/collection-expressions.md#conversions):
-- A single dimensional *array type* `T[]` in which case the *element type* is `T`
+- A single dimensional *array type* `T[]`, in which case the *element type* is `T`
 - A *span type*
   - `System.Span<T>`
-  - `System.ReadOnlySpan<T>`
+  - `System.ReadOnlySpan<T>`  
   in which cases the *element type* is `T`
 - A *type* with an appropriate *[create method](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/collection-expressions.md#create-methods)*,
   which is at least as accessible as the declaring member and a corresponding *element type* resulting from that determination
@@ -58,14 +58,14 @@ The *type* of a parameter collection shall be one of the following valid target 
   - The *type* has a constructor that can be invoked with no arguments, and the constructor is at least as accessible as the declaring member.
   - The *type* has an instance (not an extension) method `Add` that can be invoked with a single argument of
     the [*iteration type*](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/statements.md#1395-the-foreach-statement),
-    and the method is at least as accessible as the declaring member.
+    and the method is at least as accessible as the declaring member.  
   in which case the *element type* is the *iteration type*
 - An *interface type*
   - `System.Collections.Generic.IEnumerable<T>`,
   - `System.Collections.Generic.IReadOnlyCollection<T>`,
   - `System.Collections.Generic.IReadOnlyList<T>`,
   - `System.Collections.Generic.ICollection<T>`,
-  - `System.Collections.Generic.IList<T>`
+  - `System.Collections.Generic.IList<T>`  
   in which cases the *element type* is `T`
 
 In a method invocation, a parameter collection permits either a single argument of the given parameter type to be specified, or

--- a/proposals/params-collections.md
+++ b/proposals/params-collections.md
@@ -54,7 +54,6 @@ The *type* of a parameter collection shall be one of the following valid target 
   in which cases the *element type* is `T`
 - A *type* with an appropriate *[create method](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/collection-expressions.md#create-methods)*,
   which is at least as accessible as the declaring member and a corresponding *element type* resulting from that determination
-  determined from a `GetEnumerator` instance method or enumerable interface, not from an extension method.
 - A *struct* or *class type* that implements `System.Collections.IEnumerable` where:
   - The *type* has a constructor that can be invoked with no arguments, and the constructor is at least as accessible as the declaring member.
   - The *type* has an instance (not an extension) method `Add` that can be invoked with a single argument of


### PR DESCRIPTION
This PR is a proposed change allowing write-only CollectionBuilder collection types ([proposal](https://github.com/dotnet/csharplang/issues/7744)) and rephrasing the existing spec mostly in terms of *element type* instead of *iteration type*.

The plan is to review this proposal with the collection expression and params working groups, then review in LDM before merging this PR if approved.
 
Open issue: is this treated as a C# 12 bugfix or a C# 13 feature? (this affects whether we should update the C# 12 collection expression speclet)

Tagging @CyrusNajmabadi @cston @RikkiGibson @AlekseyTs for review.