### PR TITLE
Meetings 2024 Feb/March

### DIFF
--- a/meetings/2024/README.md
+++ b/meetings/2024/README.md
@@ -4,12 +4,7 @@ All schedule items must have a public issue or checked-in proposal that can be l
 
 ## Schedule ASAP
 
-- Open question: [`params` mismatches across inheritance](../../proposals/params-collections.md#consider-enforcing-scoped-or-params-across-overrides) (Fred, Aleksey)
-
 ## Schedule when convenient
-
-- [Implementation specific documentation](https://github.com/dotnet/csharplang/issues/7898). (Bill, on a Monday)
-- [Runtime Async Experiment](https://github.com/dotnet/runtime/issues/94620) (Andy)
 
 ## Recurring topics
 
@@ -32,10 +27,12 @@ All schedule items must have a public issue or checked-in proposal that can be l
 
 ### Mon Apr 8, 2024
 
+- [Implementation specific documentation](https://github.com/dotnet/csharplang/issues/7898). (Bill, on a Monday)
+
 ### Mon Apr 1, 2024
 
-
-- _Open slot_
+- Open question: [`params` mismatches across inheritance](../../proposals/params-collections.md#consider-enforcing-scoped-or-params-across-overrides) (Fred, Aleksey)
+- [Runtime Async Experiment](https://github.com/dotnet/runtime/issues/94620) (Andy)
 
 ### Wed Mar 27, 2024
 

--- a/meetings/2024/README.md
+++ b/meetings/2024/README.md
@@ -4,9 +4,13 @@ All schedule items must have a public issue or checked-in proposal that can be l
 
 ## Schedule ASAP
 
+- Open question: [`params` mismatches across inheritance](../../proposals/params-collections.md#consider-enforcing-scoped-or-params-across-overrides) (Fred, Aleksey)
+
 ## Schedule when convenient
 
 - [Implementation specific documentation](https://github.com/dotnet/csharplang/issues/7898). (Bill, on a Monday)
+- [Runtime Async Experiment](https://github.com/dotnet/runtime/issues/94620) (Andy)
+
 ## Recurring topics
 
 - *Triage championed features and milestones*
@@ -30,7 +34,7 @@ All schedule items must have a public issue or checked-in proposal that can be l
 
 ### Mon Apr 1, 2024
 
-- [Implementation specific documentation](https://github.com/dotnet/csharplang/issues/7898). (Bill, on a Monday)
+
 - _Open slot_
 
 ### Wed Mar 27, 2024
@@ -62,7 +66,7 @@ All schedule items must have a public issue or checked-in proposal that can be l
 ### Wed Feb 7, 2024
 
 - [Partial type inference](https://github.com/dotnet/csharplang/pull/7582) (Rikki / [Tomas](https://github.com/TomatorCZ))
-- [Breaking change warnings](https://github.com/dotnet/csharplang/issues/7189) (Mads)
+- [Breaking change warnings](https://github.com/dotnet/csharplang/issues/7918) (Mads)
 
 ### Mon Feb 5, 2024
 

--- a/meetings/2024/README.md
+++ b/meetings/2024/README.md
@@ -6,6 +6,7 @@ All schedule items must have a public issue or checked-in proposal that can be l
 
 ## Schedule when convenient
 
+- [Implementation specific documentation](https://github.com/dotnet/csharplang/issues/7898). (Bill, on a Monday)
 ## Recurring topics
 
 - *Triage championed features and milestones*

--- a/meetings/2024/README.md
+++ b/meetings/2024/README.md
@@ -51,7 +51,6 @@ All schedule items must have a public issue or checked-in proposal that can be l
 
 - Extensions (Julien and Mads)
 
-
 ### Wed Feb 26, 2024
 
 - Dictionary-expressions + Collection-expressions future: WG to go over our plans, and the initial design space (Cyrus)

--- a/meetings/2024/README.md
+++ b/meetings/2024/README.md
@@ -51,14 +51,16 @@ All schedule items must have a public issue or checked-in proposal that can be l
 
 - Extensions (Julien and Mads)
 
-### Mon Feb 26, 2024
+
+### Wed Feb 26, 2024
+
+- Dictionary-expressions + Collection-expressions future: WG to go over our plans, and the initial design space (Cyrus)
+
+### Mon Feb 21, 2024
 
 - Review [metadata](https://github.com/dotnet/csharplang/blob/main/proposals/params-collections.md#metadata) section for"Params Collections". (Aleksey)
 - Review: [Allow lambdas with parameter modifiers, but without parameter types](https://github.com/dotnet/csharplang/pull/7369) (Cyrus)
 
-### Wed Feb 21, 2024
-
-- Dictionary-expressions + Collection-expressions future: WG to go over our plans, and the initial design space (Cyrus)
 
 ### Wed Feb 7, 2024
 

--- a/meetings/2024/README.md
+++ b/meetings/2024/README.md
@@ -29,7 +29,8 @@ All schedule items must have a public issue or checked-in proposal that can be l
 
 ### Mon Apr 1, 2024
 
-- Meeting on meeting (Mads)
+- [Implementation specific documentation](https://github.com/dotnet/csharplang/issues/7898). (Bill, on a Monday)
+- _Open slot_
 
 ### Wed Mar 27, 2024
 
@@ -37,8 +38,7 @@ All schedule items must have a public issue or checked-in proposal that can be l
 
 ### Mon Mar 11, 2024
 
-- [Implementation specific documentation](https://github.com/dotnet/csharplang/issues/7898). (Bill, on a Monday)
-- _Open slot_
+- Meeting on meeting (Mads)
 
 ### Mon Mar 4, 2024
 

--- a/meetings/2024/README.md
+++ b/meetings/2024/README.md
@@ -57,11 +57,11 @@ All schedule items must have a public issue or checked-in proposal that can be l
 
 - Extensions (Julien and Mads)
 
-### Wed Feb 26, 2024
+### Mon Feb 26, 2024
 
 - Dictionary-expressions + Collection-expressions future: WG to go over our plans, and the initial design space (Cyrus)
 
-### Mon Feb 21, 2024
+### Wed Feb 21, 2024
 
 - Review [metadata](https://github.com/dotnet/csharplang/blob/main/proposals/params-collections.md#metadata) section for"Params Collections". (Aleksey)
 - Review: [Allow lambdas with parameter modifiers, but without parameter types](https://github.com/dotnet/csharplang/pull/7369) (Cyrus)

--- a/meetings/2024/README.md
+++ b/meetings/2024/README.md
@@ -4,17 +4,7 @@ All schedule items must have a public issue or checked-in proposal that can be l
 
 ## Schedule ASAP
 
-- Review [metadata](https://github.com/dotnet/csharplang/blob/main/proposals/params-collections.md#metadata) section for"Params Collections". (Aleksey)
-- 2 hours please. Dictionary-expressions + Collection-expressions future: WG to go over our plans, and the initial design space (Cyrus)
-- Review: Allow lambdas with parameter modifiers, but without parameter types: https://github.com/dotnet/csharplang/pull/7369 (Cyrus)
-
 ## Schedule when convenient
-
-- [Overload resolution priority](https://github.com/dotnet/csharplang/pull/7906) (Fred)
-- Discriminated Union WG (Matt)
-- Extensions (Julien and Mads (after Feb 5))
-- [Implementation specific documentation](https://github.com/dotnet/csharplang/issues/7898). (Bill, on a Monday)
-- [Non-enumerable collection types](https://github.com/dotnet/csharplang/pull/7895) (Julien)
 
 ## Recurring topics
 
@@ -39,17 +29,34 @@ All schedule items must have a public issue or checked-in proposal that can be l
 
 ### Mon Apr 1, 2024
 
+- Meeting on meeting (Mads)
+
 ### Wed Mar 27, 2024
+
+- Discriminated Union WG (Matt)
 
 ### Mon Mar 11, 2024
 
+- [Implementation specific documentation](https://github.com/dotnet/csharplang/issues/7898). (Bill, on a Monday)
+- _Open slot_
+
 ### Mon Mar 4, 2024
+
+- [Non-enumerable collection types](https://github.com/dotnet/csharplang/pull/7895) (Julien)
+- [Overload resolution priority](https://github.com/dotnet/csharplang/pull/7906) (Fred)
 
 ### Wed Feb 28, 2024
 
+- Extensions (Julien and Mads)
+
 ### Mon Feb 26, 2024
 
+- Review [metadata](https://github.com/dotnet/csharplang/blob/main/proposals/params-collections.md#metadata) section for"Params Collections". (Aleksey)
+- Review: [Allow lambdas with parameter modifiers, but without parameter types](https://github.com/dotnet/csharplang/pull/7369) (Cyrus)
+
 ### Wed Feb 21, 2024
+
+- Dictionary-expressions + Collection-expressions future: WG to go over our plans, and the initial design space (Cyrus)
 
 ### Wed Feb 7, 2024
 


### PR DESCRIPTION
We are making a procedural change to better manage the backlog.
 
I am scheduling quite a ways out and need input from everyone on the schedule: 
 
* Can your item be delayed past its current scheduled date? We have tough scheduling choices, so lets make sure we are prioritizing the right things.
* Do I have the correct time allotted. One item means two hours, two items are 1 hour each, and comment if you think your item is less than 1 hour?
* Will the right people be available on the scheduled date?
* If work will be blocked if we can't scheduled something earlier, comment, but with the missed meetings, there are no great answers.
* Please get links in as early as possible, definitely at least a week ahead of time.