### PR TITLE
refine speclet disclaimer language

### DIFF
--- a/proposals/speclet-disclaimer.md
+++ b/proposals/speclet-disclaimer.md
@@ -1,2 +1,6 @@
 > [!NOTE]
-> This article is a feature specification. The specification represents the *proposed* feature specification. There may be some discrepancies between the feature specification and the completed implementation. Those differences are captured in the pertinent [language design meeting (LDM) notes](https://github.com/dotnet/csharplang/tree/main/meetings). Links to pertinent meetings are included at the bottom of the spec. You can learn more about the process for merging feature speclets into the C# language standard in the article on the [specifications](https://learn.microsoft.com/dotnet/csharp/language-reference/specifications).
+> This article is a feature specification. The specification serves as the design document for the feature. It includes proposed specification changes, along with information needed during the design and development of the feature. These articles are published until the proposed spec changes are finalized and incorporated in the current ECMA specification.
+>
+> There may be some discrepancies between the feature specification and the completed implementation. Those differences are captured in the pertinent [language design meeting (LDM) notes](https://github.com/dotnet/csharplang/tree/main/meetings). Links to pertinent meetings are included at the bottom of the spec.
+>
+> You can learn more about the process for adopting feature speclets into the C# language standard in the article on the [specifications](https://learn.microsoft.com/dotnet/csharp/language-reference/specifications).

--- a/proposals/speclet-disclaimer.md
+++ b/proposals/speclet-disclaimer.md
@@ -1,6 +1,6 @@
 > [!NOTE]
 > This article is a feature specification. The specification serves as the design document for the feature. It includes proposed specification changes, along with information needed during the design and development of the feature. These articles are published until the proposed spec changes are finalized and incorporated in the current ECMA specification.
 >
-> There may be some discrepancies between the feature specification and the completed implementation. Those differences are captured in the pertinent [language design meeting (LDM) notes](https://github.com/dotnet/csharplang/tree/main/meetings). Links to pertinent meetings are included at the bottom of the spec.
+> There may be some discrepancies between the feature specification and the completed implementation. Those differences are captured in the pertinent [language design meeting (LDM) notes](https://github.com/dotnet/csharplang/tree/main/meetings).
 >
 > You can learn more about the process for adopting feature speclets into the C# language standard in the article on the [specifications](https://learn.microsoft.com/dotnet/csharp/language-reference/specifications).


### PR DESCRIPTION
Add details about the lifetime of these documents on Learn as it pertains to the standardization process.

Contributes to dotnet/docs#39814