### PR TITLE
Spec behavior for default parameter values in partial properties

### DIFF
--- a/proposals/partial-properties.md
+++ b/proposals/partial-properties.md
@@ -82,6 +82,7 @@ Signature matching requirements include:
 3. All other syntactic differences in the signatures of partial property declarations result in a compile-time warning, with the following exceptions:
     - Attribute lists on or within partial property declarations do not need to match. Instead, merging of attributes in corresponding positions is performed, per [Attribute merging](#attribute-merging).
     - Nullable context differences do not cause warnings. In other words, a difference where one of the types is nullable-oblivious and the other type is either nullable-annotated or not-nullable-annotated does not result in any warnings.
+    - Default parameter values do not need to match. A warning is reported when the implementation part of a partial indexer has default parameter values. This is similar to an existing warning which occurs when the implementation part of a partial method has default parameter values.
 
 ```cs
 partial class C1
@@ -106,6 +107,15 @@ partial class C3
 
     // Error: implementation of 'Prop' cannot have a 'set' accessor because the definition does not have a 'set' accessor.
     public partial string Prop { get => field; set => field = value; }
+}
+
+partial class C4
+{
+    public partial string this[string s = "a"] { get; set; }
+    public partial string this[string s] { get => s; set { } } // ok
+
+    public partial string this[int i, string s = "a"] { get; set; }
+    public partial string this[int i, string s = "a"] { get => s; set { } } // CS1066: The default value specified for parameter 'x' will have no effect because it applies to a member that is used in contexts that do not allow optional arguments
 }
 ```
 

--- a/proposals/partial-properties.md
+++ b/proposals/partial-properties.md
@@ -115,7 +115,7 @@ partial class C4
     public partial string this[string s] { get => s; set { } } // ok
 
     public partial string this[int i, string s = "a"] { get; set; }
-    public partial string this[int i, string s = "a"] { get => s; set { } } // CS1066: The default value specified for parameter 'x' will have no effect because it applies to a member that is used in contexts that do not allow optional arguments
+    public partial string this[int i, string s = "a"] { get => s; set { } } // CS1066: The default value specified for parameter 's' will have no effect because it applies to a member that is used in contexts that do not allow optional arguments
 }
 ```
 


### PR DESCRIPTION
@jcouv

[SharpLab](https://sharplab.io/#v2:EYLgtghglgdgNAExAagD4AEDMACADhAJwBcoIAbbdAJmwGEBYAKAG8nt3Kd9jSL0AWbAFkAFLCLYAHtgC82AAwBKANxsOWPIRLlKg0eKmyFi7MwC+TM0A===) showing a similar partial methods scenario. In short, partial methods expect only the definition part to have default parameter values. A warning occurs when the implementation part has a default value, even if it matches the definition part.

I wasn't able to find any spec language or LDM notes which indicates that this is supposed to happen for partial methods. However, it seems to be an old behavior dating back to native compiler, which we haven't heard complaints about from generator authors etc. So, it seems reasonable to carry it over, and to help make things clear for feature development purposes, we spec a similar behavior for partial proeprties.