### PR TITLE
Add the speclet disclaimer to the merged C# 13 features

### DIFF
--- a/proposals/lock-object.md
+++ b/proposals/lock-object.md
@@ -1,5 +1,7 @@
 # `Lock` object
 
+[!INCLUDE[Specletdisclaimer](speclet-disclaimer.md)]
+
 ## Summary
 [summary]: #summary
 

--- a/proposals/params-collections.md
+++ b/proposals/params-collections.md
@@ -1,5 +1,7 @@
 # `params Collections`
 
+[!INCLUDE[Specletdisclaimer](speclet-disclaimer.md)]
+
 ## Summary
 
 In C# 12 language added support for creating instances of collection types beyond just arrays.

--- a/proposals/params-collections.md
+++ b/proposals/params-collections.md
@@ -159,7 +159,7 @@ In case the parameter type sequences `{P₁, P₂, ..., Pᵥ}` and `{Q₁, Q₂,
   - An array type is more specific than another array type (with the same number of dimensions) if the element type of the first is more specific than the element type of the second.
 - Otherwise if one member is a non-lifted operator and the other is a lifted operator, the non-lifted one is better.
 - If neither function member was found to be better, and all parameters of `Mᵥ` have a corresponding argument whereas default arguments need to be substituted for at least one optional parameter in `Mₓ`, then `Mᵥ` is better than `Mₓ`.
-- If for at least one parameter `Mᵥ` uses the ***better parameter-passing choice*** ([§12.6.4.4](expressions.md#12644-better-parameter-passing-mode)) than the corresponding parameter in `Mₓ` and none of the parameters in `Mₓ` use the better parameter-passing choice than `Mᵥ`, `Mᵥ` is better than `Mₓ`.
+- If for at least one parameter `Mᵥ` uses the ***better parameter-passing choice*** ([§12.6.4.4](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/expressions.md#12644-better-parameter-passing-mode)) than the corresponding parameter in `Mₓ` and none of the parameters in `Mₓ` use the better parameter-passing choice than `Mᵥ`, `Mᵥ` is better than `Mₓ`.
 - **Otherwise, if both methods have params collections and are applicable only in their expanded forms then
    `Mᵢ` is better than `Mₑ` if the same set of arguments corresponds to the collection elements for both methods, and one of the following holds
    (this corresponds to https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/collection-expressions.md#overload-resolution):**
@@ -281,23 +281,23 @@ From [Compile-time checking of dynamic member invocation](https://github.com/dot
 > Even though overload resolution of a dynamically bound operation takes place at run-time, it is sometimes possible at compile-time to know
 > the list of function members from which an overload will be chosen:
 >
-> - For a delegate invocation ([§12.8.9.4](expressions.md#12894-delegate-invocations)), the list is a single function member with the same parameter list as the *delegate_type* of the invocation
-> - For a method invocation ([§12.8.9.2](expressions.md#12892-method-invocations)) on a type, or on a value whose static type is not dynamic, the set of accessible methods in the method group
+> - For a delegate invocation ([§12.8.9.4](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/expressions.md#12894-delegate-invocations)), the list is a single function member with the same parameter list as the *delegate_type* of the invocation
+> - For a method invocation ([§12.8.9.2](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/expressions.md#12892-method-invocations)) on a type, or on a value whose static type is not dynamic, the set of accessible methods in the method group
 >   is known at compile-time.
-> - For an object creation expression ([§12.8.16.2](expressions.md#128162-object-creation-expressions)) the set of accessible constructors in the type is known at compile-time.
-> - For an indexer access ([§12.8.11.3](expressions.md#128113-indexer-access)) the set of accessible indexers in the receiver is known at compile-time.
+> - For an object creation expression ([§12.8.16.2](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/expressions.md#128162-object-creation-expressions)) the set of accessible constructors in the type is known at compile-time.
+> - For an indexer access ([§12.8.11.3](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/expressions.md#128113-indexer-access)) the set of accessible indexers in the receiver is known at compile-time.
 >
 > In these cases a limited compile-time check is performed on each member in the known set of function members, to see if it can be known for certain never to be invoked at run-time.
 > For each function member `F` a modified parameter and argument list are constructed:
 >
 > - First, if `F` is a generic method and type arguments were provided, then those are substituted for the type parameters in the parameter list.
 >   However, if type arguments were not provided, no such substitution happens.
-> - Then, any parameter whose type is open (i.e., contains a type parameter; see [§8.4.3](types.md#843-open-and-closed-types)) is elided, along with its corresponding parameter(s).
+> - Then, any parameter whose type is open (i.e., contains a type parameter; see [§8.4.3](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/types.md#843-open-and-closed-types)) is elided, along with its corresponding parameter(s).
 >
 > For `F` to pass the check, all of the following shall hold:
 >
-> - The modified parameter list for `F` is applicable to the modified argument list in terms of [§12.6.4.2](expressions.md#12642-applicable-function-member).
-> - All constructed types in the modified parameter list satisfy their constraints ([§8.4.5](types.md#845-satisfying-constraints)).
+> - The modified parameter list for `F` is applicable to the modified argument list in terms of [§12.6.4.2](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/expressions.md#12642-applicable-function-member).
+> - All constructed types in the modified parameter list satisfy their constraints ([§8.4.5](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/types.md#845-satisfying-constraints)).
 > - If the type parameters of `F` were substituted in the step above, their constraints are satisfied.
 > - If `F` is a static method, the method group shall not have resulted from a *member_access* whose receiver is known at compile-time to be a variable or value.
 > - If `F` is an instance method, the method group shall not have resulted from a *member_access* whose receiver is known at compile-time to be a type.
@@ -305,7 +305,7 @@ From [Compile-time checking of dynamic member invocation](https://github.com/dot
 > If no candidate passes this test, a compile-time error occurs.
 
 From [Invocation expressions](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/expressions.md#12891-general):
-> An *invocation_expression* is dynamically bound ([§12.3.3](expressions.md#1233-dynamic-binding)) if at least one of the following holds:
+> An *invocation_expression* is dynamically bound ([§12.3.3](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/expressions.md#1233-dynamic-binding)) if at least one of the following holds:
 >
 > - The *primary_expression* has compile-time type `dynamic`.
 > - At least one argument of the optional *argument_list* has compile-time type `dynamic`.


### PR DESCRIPTION
These are being published (soon) on Learn, so add the included disclaimer.

In addition, update links to the standard where the link assumed the that destination file was in the same folder.
