### PR TITLE
Fix n-1 version, it is version 12, not 11

### DIFF
--- a/proposals/breaking-change-warnings.md
+++ b/proposals/breaking-change-warnings.md
@@ -25,7 +25,7 @@ It is customary that newer compilers are used to compile older versions of C#. T
 
 ### Example: field access in auto-properties
 
-As an example, let's say we introduce [field access in auto-properties](https://github.com/dotnet/csharplang/blob/main/proposals/semi-auto-properties.md) in C# 13, with a design that introduces a new `field` parameter in scope within property accessors. This new `field` parameter would shadow access to any field etc. called `field` in existing property accessors, potentially altering its meaning. We would accompany that feature with a warning in C# 11 and lower for any code that uses the identifier `field` within a property accessor:
+As an example, let's say we introduce [field access in auto-properties](https://github.com/dotnet/csharplang/blob/main/proposals/semi-auto-properties.md) in C# 13, with a design that introduces a new `field` parameter in scope within property accessors. This new `field` parameter would shadow access to any field etc. called `field` in existing property accessors, potentially altering its meaning. We would accompany that feature with a warning in C# 12 and lower for any code that uses the identifier `field` within a property accessor:
 
 ``` c#
 public class Entity
@@ -33,8 +33,8 @@ public class Entity
     string field;
     public string Field
     {
-        get { return field; }         // Warning in C# 11 and below
-        set { field = value.Trim(); } // Warning in C# 11 and below
+        get { return field; }         // Warning in C# 12 and below
+        set { field = value.Trim(); } // Warning in C# 12 and below
     }
     ...
 }


### PR DESCRIPTION
I believe this should be C# 12, not C# 11 where warnings would be shown.