### PR TITLE
Fix definite assignment example in field keyword proposal

### DIFF
--- a/proposals/field-keyword.md
+++ b/proposals/field-keyword.md
@@ -218,7 +218,7 @@ public struct S
         P2 = 5;
     }
 
-    public int P1 { get => field; }
+    public int P2 { get => field; set => field = value; }
 }
 ```
 


### PR DESCRIPTION
A wrong line was deleted in e020a0c3bca44e52e85cbe1ce24e73913b5a38c6 when separating the sample code into two samples.