### PR TITLE
Update the params proposal in line with the new betterness rules

### DIFF
--- a/proposals/collection-expressions-better-conversion.md
+++ b/proposals/collection-expressions-better-conversion.md
@@ -43,6 +43,15 @@ Conversion comparisons are made using better conversion from expression if `ELáµ
 
 Otherwise, neither collection type is better, and the result is ambiguous.
 
+> [!NOTE]
+> These rules mean that methods that expose overloads that take different element types and without a conversion between the collection types are ambiguous for empty collection expressions. As an example:
+> ```cs
+> public void M(ReadOnlySpan<int> ros) { ... }
+> public void M(Span<int?> span) { ... }
+>
+> M([]); // Ambiguous
+> ```
+
 ### Scenarios:
 
 In plain English, the collection types themselves must be either the same, or unambiguously better (ie, `List<T>` and `List<T>` are the same, `List<T>` is unambiguously better than `IEnumerable<T>`, and `List<T>` and `HashSet<T>` cannot be compared), and

--- a/proposals/collection-expressions-better-conversion.md
+++ b/proposals/collection-expressions-better-conversion.md
@@ -28,15 +28,15 @@ Given:
 - `CE₁ᵢ` are the series of conversions from `ELᵢ` to `E₁`
 - `CE₂ᵢ` are the series of conversions from `ELᵢ` to `E₂`
 
-If there is an identity conversion from `E₁` to `E₂`, then the element conversions are as good as each other. Otherwise, the element conversions to `E₁` are better than the element conversions to `E₂` if:
+If there is an identity conversion from `E₁` to `E₂`, then the element conversions are as good as each other. Otherwise, the element conversions to `E₁` are ***better than the element conversions*** to `E₂` if:
 - For every `ELᵢ`, `CE₁ᵢ` is at least as good as `CE₂ᵢ`, and
 - There is at least one i where `CE₁ᵢ` is better than `CE₂ᵢ`
 Otherwise, neither set of element conversions is better than the other, and they are also not as good as each other.  
 Conversion comparisons are made using better conversion from expression if `ELᵢ` is not a spread element. If `ELᵢ` is a spread element, we use better conversion from the element type of the spread collection to `E₁` or `E₂`, respectively.
 
 `C₁` is a ***better collection conversion from expression*** than `C₂` if:
-- `T₁` or `T₂` is not a *span type*, and `T₁` is implicitly convertible to `T₂`, and `T₂` is not implicitly convertible to `T₁`, or
-- `E₁` does not have an identity conversion to `E₂`, and the element conversions to `E₁` are better than the element conversions to `E₂`, or
+- Both `T₁` or `T₂` are not *span types*, and `T₁` is implicitly convertible to `T₂`, and `T₂` is not implicitly convertible to `T₁`, or
+- `E₁` does not have an identity conversion to `E₂`, and the element conversions to `E₁` are ***better than the element conversions*** to `E₂`, or
 - `E₁` has an identity conversion to `E₂`, and one of the following holds:
    - `T₁` is `System.ReadOnlySpan<E₁>`, and `T₂` is `System.Span<E₂>`, or
    - `T₁` is `System.ReadOnlySpan<E₁>` or `System.Span<E₁>`, and `T₂` is an *array_or_array_interface* with *element type* `E₂`

--- a/proposals/params-collections.md
+++ b/proposals/params-collections.md
@@ -162,12 +162,12 @@ In case the parameter type sequences `{P₁, P₂, ..., Pᵥ}` and `{Q₁, Q₂,
 - If for at least one parameter `Mᵥ` uses the ***better parameter-passing choice*** ([§12.6.4.4](https://github.com/dotnet/csharpstandard/blob/draft-v9/standard/expressions.md#12644-better-parameter-passing-mode)) than the corresponding parameter in `Mₓ` and none of the parameters in `Mₓ` use the better parameter-passing choice than `Mᵥ`, `Mᵥ` is better than `Mₓ`.
 - **Otherwise, if both methods have params collections and are applicable only in their expanded forms then
    `Mᵢ` is better than `Mₑ` if the same set of arguments corresponds to the collection elements for both methods, and one of the following holds
-   (this corresponds to https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/collection-expressions.md#overload-resolution):**
-  - **params collection of `Mᵢ` is `System.ReadOnlySpan<Eᵢ>`, and params collection of `Mₑ` is `System.Span<Eₑ>`, and an implicit conversion exists from `Eᵢ` to `Eₑ`**
+   (this corresponds to https://github.com/dotnet/csharplang/blob/main/proposals/collection-expressions-better-conversion.md):**
+  - **both params collections are not *span_type*s, and an implicit conversion exists from params collection of `Mᵢ` to params collection of `Mₑ`**  
+  - **params collection of `Mᵢ` is `System.ReadOnlySpan<Eᵢ>`, and params collection of `Mₑ` is `System.Span<Eₑ>`, and an identity conversion exists from `Eᵢ` to `Eₑ`**
   - **params collection of `Mᵢ` is `System.ReadOnlySpan<Eᵢ>` or `System.Span<Eᵢ>`, and params collection of `Mₑ` is
     an *[array_or_array_interface__type](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/collection-expressions.md#overload-resolution)*
-    with *element type* `Eₑ`, and an implicit conversion exists from `Eᵢ` to `Eₑ`**
-  - **both params collections are not *span_type*s, and an implicit conversion exists from params collection of `Mᵢ` to params collection of `Mₑ`**  
+    with *element type* `Eₑ`, and an identity conversion exists from `Eᵢ` to `Eₑ`**
 - Otherwise, no function member is better.
 
 The reason why the new tie-breaking rule is placed at the end of the list is the last sub item
@@ -201,7 +201,7 @@ class Program
 {
     static void Test1()
     {
-        M1(['1', '2', '3']); // Span overload is used
+        M1(['1', '2', '3']); // IEnumerable<char> overload is used because `char` is an exact match
         M1('1', '2', '3');   // IEnumerable<char> overload is used because `char` is an exact match
     }
 
@@ -227,7 +227,7 @@ class Program
 
     static void Test3()
     {
-        M3("3", ["4"]); // Span overload is used, better on the first argument conversion, none is better on the second
+        M3("3", ["4"]); // Ambiguity, better-ness of argument conversions goes in opposite directions.
         M3("3", "4");   // Ambiguity, better-ness of argument conversions goes in opposite directions.
                         // Since parameter types are different ("object, string" vs. "string, object"), tie-breaking rules do not apply
     }
@@ -260,6 +260,48 @@ It doesn't feel reasonable to "compare" collections that are built from differen
 
 >This section was reviewed at [LDM](https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-01-29.md#better-function-member-changes)
 >and was approved.
+
+One effect of these rules is that when `params` of different element types are exposed, these will be ambiguous when called with an empty argument list.
+For example:
+
+```cs
+class Program
+{
+    static void Main()
+    {
+        // Old scenarios
+        C.M1(); // Ambiguous since params arrays were introduced
+        C.M1([]); // Ambiguous since params arrays were introduced
+
+        // New scenarios
+        C.M2(); // Ambiguous in C# 13
+        C.M2([]); // Ambiguous in C# 13
+        C.M3(); // Ambiguous in C# 13
+        C.M3([]); // Ambiguous in C# 13
+    }
+
+    public static void M1(params int[] a) {
+    }
+    
+    public static void M1(params int?[] a) {
+    }
+    
+    public static void M2(params ReadOnlySpan<int> a) {
+    }
+    
+    public static void M2(params Span<int?> a) {
+    }
+    
+    public static void M3(params ReadOnlySpan<int> a) {
+    }
+    
+    public static void M3(params ReadOnlySpan<int?> a) {
+    }
+}
+```
+
+Given that we prioritize element type over all else, this seems reasonable; there's nothing to tell the langauge whether the user would prefer `int?`
+over `int` in this scenario.
 
 ### Dynamic Binding
 

--- a/proposals/params-collections.md
+++ b/proposals/params-collections.md
@@ -300,7 +300,7 @@ class Program
 }
 ```
 
-Given that we prioritize element type over all else, this seems reasonable; there's nothing to tell the langauge whether the user would prefer `int?`
+Given that we prioritize element type over all else, this seems reasonable; there's nothing to tell the language whether the user would prefer `int?`
 over `int` in this scenario.
 
 ### Dynamic Binding


### PR DESCRIPTION
The main change here is that we now require an identity conversion between element types to tiebreak among collection types.
