### PR TITLE
Update links

### DIFF
--- a/proposals/csharp-11.0/pattern-match-span-of-char-on-string.md
+++ b/proposals/csharp-11.0/pattern-match-span-of-char-on-string.md
@@ -31,15 +31,13 @@ static bool IsABC(Span<char> s)
 ## Detailed design
 [design]: #detailed-design
 
-We alter the [spec](../csharp-7.0/pattern-matching.md#constant-pattern) for constant patterns as follows (the proposed addition is shown in bold):
+We alter the [spec](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/patterns.md#1123-constant-pattern) for constant patterns as follows (the proposed addition is shown in bold):
 
-> A constant pattern tests the value of an expression against a constant value. The constant may be any constant expression, such as a literal, the name of a declared `const` variable, or an enumeration constant, or a `typeof` expression etc.
+> Given a pattern input value `e` and a constant pattern `P` with converted value `v`,
 >
-> If both *e* and *c* are of integral types, the pattern is considered matched if the result of the expression `e == c` is `true`.
->
-> **If *e* is of type `System.Span<char>` or `System.ReadOnlySpan<char>`, and *c* is a constant string, and *c* does not have a constant value of `null`, then the pattern is considered matching if `System.MemoryExtensions.SequenceEqual<char>(e, System.MemoryExtensions.AsSpan(c))` returns `true`.**
-> 
-> Otherwise the pattern is considered matching if `object.Equals(e, c)` returns `true`. In this case it is a compile-time error if the static type of *e* is not *pattern compatible* with the type of the constant.
+> - if *e* has integral type or enum type, or a nullable form of one of those, and *v* has integral type, the pattern `P` *matches* the value *e* if result of the expression `e == v` is `true`; otherwise
+> - **If *e* is of type `System.Span<char>` or `System.ReadOnlySpan<char>`, and *c* is a constant string, and *c* does not have a constant value of `null`, then the pattern is considered matching if `System.MemoryExtensions.SequenceEqual<char>(e, System.MemoryExtensions.AsSpan(c))` returns `true`.**
+> - the pattern `P` *matches* the value *e* if `object.Equals(e, v)` returns `true`.
 
 ### Well-known members
 `System.Span<T>` and `System.ReadOnlySpan<T>` are matched by name, must be `ref struct`s, and can be defined outside corlib.

--- a/proposals/csharp-12.0/inline-arrays.md
+++ b/proposals/csharp-12.0/inline-arrays.md
@@ -272,7 +272,7 @@ Regular definite assignment rules are applicable to variables that have an inlin
 
 ### Collection literals
 
-An inline array type is a valid *constructible collection* target type for a [collection literal](https://github.com/dotnet/csharplang/blob/main/proposals/collection-literals.md).
+An inline array type is a valid *constructible collection* target type for a [collection expression](collection-expressions.md).
 
 For example:
 ``` C#
@@ -284,7 +284,7 @@ is known at compile time and it doesn't match the target length, an error is rep
 to be thrown at runtime once the mismatch is encountered. The exact exception type is TBD. Some candidates are:
 System.NotSupportedException, System.InvalidOperationException.
 
-An instance of an inline array type is a valid expression in a [*spread_element*](https://github.com/dotnet/csharplang/blob/main/proposals/collection-literals.md#detailed-design).
+An instance of an inline array type is a valid expression in a [*spread_element*](collection-expressions.md#detailed-design).
 
 ### Validation of the InlineArrayAttribute applications
 

--- a/proposals/speclet-disclaimer.md
+++ b/proposals/speclet-disclaimer.md
@@ -3,4 +3,4 @@
 >
 > There may be some discrepancies between the feature specification and the completed implementation. Those differences are captured in the pertinent [language design meeting (LDM) notes](https://github.com/dotnet/csharplang/tree/main/meetings).
 >
-> You can learn more about the process for adopting feature speclets into the C# language standard in the article on the [specifications](https://learn.microsoft.com/dotnet/csharp/language-reference/specifications).
+> You can learn more about the process for adopting feature speclets into the C# language standard in the article on the [specifications](https://learn.microsoft.com/dotnet/csharp/specification/feature-spec-overview).


### PR DESCRIPTION
Fixes dotnet/docs#42777

Three changes in this PR:

- Update the destination for the spec process in speclet-disclaimer.md.
- Update the links in inline-arrays from the original "collection-literal" speclet to the updated "collection-expressions" speclet.
- Update the link and spec text in pattern-match-span-of-char-on-string. The 7.0 pattern matching capability has been incorporated in the standard, so point there. In addition, update the surrounding text to match that adopted by the committee.