### PR TITLE
Fix incorrect metadata representation section for ref readonly returns

### DIFF
--- a/proposals/csharp-7.2/readonly-ref.md
+++ b/proposals/csharp-7.2/readonly-ref.md
@@ -392,7 +392,7 @@ Therefore for the purpose of capturing in lambdas, async, iterators, stack spill
 ### Metadata representation.
 When `System.Runtime.CompilerServices.IsReadOnlyAttribute` is applied to the return of a byref returning method, it means that the method returns a readonly reference.
 
-In addition, the result signature of such methods (and only those methods) must have `modreq[System.Runtime.CompilerServices.IsReadOnlyAttribute]`.
+In addition, the result signature of such methods (and only those methods) must have `modreq[System.Runtime.CompilerServices.InAttribute]`.
 
 **Motivation**: this is to ensure that existing compilers cannot simply ignore `readonly` when invoking methods with `ref readonly` returns
 

--- a/proposals/csharp-7.2/readonly-ref.md
+++ b/proposals/csharp-7.2/readonly-ref.md
@@ -392,7 +392,7 @@ Therefore for the purpose of capturing in lambdas, async, iterators, stack spill
 ### Metadata representation.
 When `System.Runtime.CompilerServices.IsReadOnlyAttribute` is applied to the return of a byref returning method, it means that the method returns a readonly reference.
 
-In addition, the result signature of such methods (and only those methods) must have `modreq[System.Runtime.CompilerServices.InAttribute]`.
+In addition, the result signature of such methods (and only those methods) must have `modreq[System.Runtime.InteropServices.InAttribute]`.
 
 **Motivation**: this is to ensure that existing compilers cannot simply ignore `readonly` when invoking methods with `ref readonly` returns
 


### PR DESCRIPTION
Reflecting the actual shipped behavior.

(These proposals are useful for documenting the compiler's behavior for tooling authors, or, hypothetically 🙃, someone writing unit tests that perform static analysis via reflection.)

https://sharplab.io/#v2:C4LglgNgPgAgTARgLACgYGYAE9MA1UDeqmJ2WATgKYBmmVAhgCYD2AdhAJ6ZivCYCyACgCUmALwA+TMAAW5ZgHdMrAK4QIAblQBfIA==