### PR TITLE
Edit pass.

### DIFF
--- a/proposals/csharp-13.0/overload-resolution-priority.md
+++ b/proposals/csharp-13.0/overload-resolution-priority.md
@@ -121,7 +121,7 @@ It is an error to apply `OverloadResolutionPriorityAttribute` to the following l
 * Conversion operators
 * Lambdas
 * Local functions
-* Destructors
+* Finalizers
 * Static constructors
 
 Attributes encountered on these locations in metadata are ignored by C#.

--- a/proposals/csharp-13.0/params-collections.md
+++ b/proposals/csharp-13.0/params-collections.md
@@ -16,7 +16,7 @@ convenience when calling APIs that take other collection types. For example, an 
 plain `IEnumerable`. Especially in cases when compiler is able to avoid an implicit array allocation for the purpose of
 creating the collection (`ImmutableArray<T>`, `ReadOnlySpan<T>`, etc).
 
-Today, in situations when an API takes a collection type, developers usually add `params` overload that takes an array,
+Today, in situations when an API takes a collection type, developers usually add a `params` overload that takes an array,
 construct the target collection and call the original overload with that collection, thus consumers of the API have to
 trade an extra array allocation for convenience.
 
@@ -366,7 +366,7 @@ The order of evaluation is the following:
 3. `GetA` is called
 4. `Test` is called
 
-Note, in params array case, the array is created right before the target methos is invoked, after all
+Note, in params array case, the array is created right before the target method is invoked, after all
 arguments are evaluated in their lexical order.
 
 #### Compound assignment
@@ -548,7 +548,7 @@ Params parameters are implicitly scoped - https://github.com/dotnet/csharplang/b
 
 ### [Resolved] Consider enforcing `scoped` or `params` across overrides
 
-We've previously stated that `params` parameters should be `scoped` by default. However, this introduces odd behavior in overridding, due
+We've previously stated that `params` parameters should be `scoped` by default. However, this introduces odd behavior in overriding, due
 to our existing rules around restating `params`:
 
 ```cs
@@ -560,7 +560,7 @@ class Base
 class Derived : Base
 {
     internal override Span<int> M1(Span<int> s1, // Error, missing `scoped` on override
-                                   Span<int> s2  // No error: parameter is implicitly params, and therefore implicitly scoped
+                                   Span<int> s2  // Proposal: Error: parameter must include either `params` or `scoped`
                                   ) => throw null!;
 }
 ```
@@ -599,7 +599,7 @@ class Program
         Test(2, 3); // error CS9035: Required member 'MyCollection1.F' must be set in the object initializer or attribute constructor.
     }
 
-    // Should an error be reported for the parameter indicating that the constructor that is required
+    // Proposal: An error is reported for the parameter indicating that the constructor that is required
     // to be available doesn't initialize required members? In other words, should one be able
     // to declare such a parameter under the specified conditions?
     static void Test(params MyCollection1 a)

--- a/proposals/csharp-13.0/ref-struct-interfaces.md
+++ b/proposals/csharp-13.0/ref-struct-interfaces.md
@@ -48,24 +48,25 @@ interface I1
 struct S1
 {
     [UnscopedRef]
-    ref int P1 { get; }
-    ref int P2 { get; }
+    internal ref int P1 { get {...} }
+
+    internal ref int P2 { get {...} }
 }
 
-int M<T>(T t, S1 s)
-    where T : allows ref struct, I1
+ref int M<T>(T t, S1 s)
+    where T : I1, allows ref struct
 {
     // Error: may return ref to t
-    return t.P1;
+    return ref t.P1;
 
     // Error: may return ref to t
-    return s.P1;
+    return ref s.P1;
 
     // Okay
-    return t.P2;
+    return ref t.P2;
 
     // Okay
-    return s.p2;
+    return ref s.P2;
 }
 ```
 
@@ -79,32 +80,32 @@ interface I1
     ref int P2 { get; }
 }
 
-struct S1 : I1
+struct S1
 {
-    ref int P1 { get; }
-    ref int P2 { get; }
+    internal ref int P1 { get {...} }
+    internal ref int P2 { get {...} }
 }
 
-struct S2 : I1
+struct S2
 {
     [UnscopedRef]
-    ref int P1 { get; }
-    ref int P2 { get; }
+    internal ref int P1 { get {...} }
+    internal ref int P2 { get {...} }
 }
 
 struct S3 : I1
 {
-    ref int P1 { get; }
+    internal ref int P1 { get {...} }
     // Error: P2 is marked with [UnscopedRef] and cannot implement I1.P2 as is not marked 
     // with [UnscopedRef]
     [UnscopedRef]
-    ref int P2 { get; }
+    internal ref int P2 { get {...} }
 }
 
 class C1 : I1
 {
-    ref int P1 { get; }
-    ref int P2 { get; }
+    internal ref int P1 { get; }
+    internal ref int P2 { get; }
 }
 ```
 
@@ -115,13 +116,14 @@ interface I1
 {
     void M()
     {
-        // Error: both of these box if I1 is implemented by a ref struct
+        // Danger: both of these box if I1 is implemented by a ref struct
         I1 local1 = this;
         object local2 = this;
     }
 }
 
-ref struct S = I1 { }
+// Error: I1.M cannot implement interface member I1.M() for ref struct S
+ref struct S : I1 { }
 ```
 
 To handle this a `ref struct` will be forced to implement all members of an interface, even if they have default implementations.
@@ -233,33 +235,25 @@ Examples of these rules in action:
 ```csharp
 interface I1 { }
 I1 M1<T>(T p)
-    where T : allows ref struct, I1
+    where T : I1, allows ref struct
 {
     // Error: cannot box potential ref struct
     return p;
 }
 
-T M2<T>(T p)
+ref T M2<T>(ref T p)
     where T : allows ref struct
 {
-    Span<int> span = stackalloc int[42];
 
     // The safe-to-escape of the return is current method because one of the inputs is
     // current method
-    T t = M3<T>(span);
+    T t = M3<T>(default);
 
     // Error: the safe-to-escape is current method.
-    return t;
+    return ref t;
 
     // Okay
-    return default;
-    return p;
-}
-
-T M3<T>(Span<T> span)
-    where T : allows ref struct
-{
-    return default;
+    return ref p;
 }
 ```
 

--- a/proposals/csharp-13.0/ref-unsafe-in-iterators-async.md
+++ b/proposals/csharp-13.0/ref-unsafe-in-iterators-async.md
@@ -260,7 +260,7 @@ class C
         await Task.Yield();
         using (new R()) { } // allowed under this proposal
         foreach (var x in new C()) { } // allowed under this proposal
-        foreach (ref int x in new int[0]) { } // allowed under this proposal
+        foreach (ref int x in new int[0]) { } // allowed under this proposal, but not implemented in C# 13
         lock (new System.Threading.Lock()) { } // allowed under this proposal
         await Task.Yield();
     }


### PR DESCRIPTION
Make sure code is correct, as commented for C# 13. If an example is invalid, add a clear comment why.

I found one or two other editorial nits as well.

Starting with C# 13, and I'll open other PRs for older versions.


Contributes to #8098