### PR TITLE
Edit C# 12 speclets for features that are still proposals

### DIFF
--- a/proposals/csharp-12.0/collection-expressions.md
+++ b/proposals/csharp-12.0/collection-expressions.md
@@ -81,14 +81,14 @@ Collection literals are [target-typed](https://github.com/dotnet/csharplang/blob
   * Literals with no `spread_element` in them.
   * Literals with arbitrary ordering of any element type.
 
-* The *iteration type* of `..s_n` is the type of the *iteration variable* determined as if `s_n` were used as the expression being iterated over in a [`foreach_statement`](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement).
+* The *iteration type* of `..s_n` is the type of the *iteration variable* determined as if `s_n` were used as the expression being iterated over in a [`foreach_statement`](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/statements.md#1395-the-foreach-statement).
 * Variables starting with `__name` are used to represent the results of the evaluation of `name`, stored in a location so that it is only evaluated once.  For example `__e1` is the evaluation of `e1`.
 * `List<T>`, `IEnumerable<T>`, etc. refer to the respective types in the `System.Collections.Generic` namespace.
-* The specification defines a [translation](#collection-literal-translation) of the literal to existing C# constructs.  Similar to the [*query expression translation*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#11173-query-expression-translation), the literal is itself only legal if the translation would result in legal code.  The purpose of this rule is to avoid having to repeat other rules of the language that are implied (for example, about convertibility of expressions when assigned to storage locations).
+* The specification defines a [translation](#collection-literal-translation) of the literal to existing C# constructs.  Similar to the [*query expression translation*](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12203-query-expression-translation), the literal is itself only legal if the translation would result in legal code.  The purpose of this rule is to avoid having to repeat other rules of the language that are implied (for example, about convertibility of expressions when assigned to storage locations).
 * An implementation is not required to translate literals exactly as specified below.  Any translation is legal if the same result is produced and there are no observable differences in the production of the result.
   * For example, an implementation could translate literals like `[1, 2, 3]` directly to a `new int[] { 1, 2, 3 }` expression that itself bakes the raw data into the assembly, eliding the need for `__index` or a sequence of instructions to assign each value. Importantly, this does mean if any step of the translation might cause an exception at runtime that the program state is still left in the state indicated by the translation.
 
-* References to 'stack allocation' refer to any strategy to allocate on the stack and not the heap.  Importantly, it does not imply or require that that strategy be through the actual `stackalloc` mechanism.  For example, the use of [inline arrays](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/inline-arrays.md) is also an allowed and desirable approach to accomplish stack allocation where available. 
+* References to 'stack allocation' refer to any strategy to allocate on the stack and not the heap.  Importantly, it does not imply or require that that strategy be through the actual `stackalloc` mechanism.  For example, the use of [inline arrays](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/inline-arrays.md) is also an allowed and desirable approach to accomplish stack allocation where available. Note that in C# 12, inline arrays can't be initialized with a collection expression. That remains an open proposal.
 
 * Collections are assumed to be well-behaved.  For example:
 
@@ -116,7 +116,7 @@ An implicit *collection expression conversion* exists from a collection expressi
     * If the method is generic, the type arguments can be inferred from the collection and argument.
     * The method is accessible at the location of the collection expression.
 
-    In which case the *element type* is the [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) of the *type*.
+    In which case the *element type* is the [*iteration type*](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/statements.md#1395-the-foreach-statement) of the *type*.
 * An *interface type*:
   * `System.Collections.Generic.IEnumerable<T>`
   * `System.Collections.Generic.IReadOnlyCollection<T>`
@@ -182,7 +182,7 @@ Methods declared on base types or interfaces are ignored and not part of the `CM
 
 If the `CM` set is empty, then the *collection type* doesn't have an *element type* and doesn't have a *create method*. None of the following steps apply.
 
-If only one method among those in the `CM` set has an [*identity conversion*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/conversions.md#1022-identity-conversion) from `E` to the *element type* of the *collection type*, that is the *create method* for the *collection type*. Otherwise, the *collection type* doesn't have a *create method*.
+If only one method among those in the `CM` set has an [*identity conversion*](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#1022-identity-conversion) from `E` to the *element type* of the *collection type*, that is the *create method* for the *collection type*. Otherwise, the *collection type* doesn't have a *create method*.
 
 An error is reported if the `[CollectionBuilder]` attribute does not refer to an invokable method with the expected signature.
 
@@ -377,9 +377,9 @@ static T[] AsArray<T>(T[] arg) => arg;
 static List<T[]> AsListOfArray<T>(List<T[]> arg) => arg;
 ```
 
-The [*type inference*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#1163-type-inference) rules are updated as follows.
+The [*type inference*](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1263-type-inference) rules are updated as follows.
 
-The existing rules for the [*first phase*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#11632-the-first-phase) are extracted to a new *input type inference* section, and a  rule is added to *input type inference* and *output type inference* for collection expression expressions.
+The existing rules for the [*first phase*](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12632-the-first-phase) are extracted to a new *input type inference* section, and a  rule is added to *input type inference* and *output type inference* for collection expression expressions.
 
 > 11.6.3.2 The first phase
 >
@@ -391,7 +391,7 @@ The existing rules for the [*first phase*](https://github.com/dotnet/csharpstand
 >
 > * If `E` is a *collection expression* with elements `Eᵢ`, and `T` is a type with an *element type* `Tₑ` or `T` is a *nullable value type* `T0?` and `T0` has an *element type* `Tₑ`, then for each `Eᵢ`:
 >   * If `Eᵢ` is an *expression element*, then an *input type inference* is made *from* `Eᵢ` *to* `Tₑ`.
->   * If `Eᵢ` is a *spread element* with an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement) `Sᵢ`, then a [*lower-bound inference*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#116310-lower-bound-inferences) is made *from* `Sᵢ` *to* `Tₑ`.
+>   * If `Eᵢ` is a *spread element* with an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/statements.md#1395-the-foreach-statement) `Sᵢ`, then a [*lower-bound inference*](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#126310-lower-bound-inferences) is made *from* `Sᵢ` *to* `Tₑ`.
 > * *[existing rules from first phase]* ...
 
 > 11.6.3.7 Output type inferences
@@ -405,9 +405,9 @@ The existing rules for the [*first phase*](https://github.com/dotnet/csharpstand
 
 ## Extension methods
 
-No changes to [*extension method invocation*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#11783-extension-method-invocations) rules. 
+No changes to [*extension method invocation*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#128103-extension-method-invocations) rules. 
 
-> 11.7.8.3 Extension method invocations
+> 12.8.10.3 Extension method invocations
 >
 > An extension method `Cᵢ.Mₑ` is *eligible* if:
 >
@@ -430,7 +430,7 @@ var z = Extensions.AsImmutableArray([3]); // ok
 ## Overload resolution
 [overload-resolution]: #overload-resolution
 
-[*Better conversion from expression*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/expressions.md#11644-better-conversion-from-expression) is updated to prefer certain target types in collection expression conversions.
+[*Better conversion from expression*](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12645-better-conversion-from-expression) is updated to prefer certain target types in collection expression conversions.
 
 In the updated rules:
 * A *span_type* is one of:
@@ -507,7 +507,7 @@ foreach (var x in y)
 }
 ```
 
-The compiler can also [inline arrays](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/inline-arrays.md), if available, when choosing to allocate on the stack.
+The compiler can also use [inline arrays](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/inline-arrays.md), if available, when choosing to allocate on the stack. Note that in C# 12, inline arrays can't be initialized with a collection expression. That feature is an open proposal.
 
 If the compiler decides to allocate on the heap, the translation for `Span<T>` is simply:
 
@@ -896,10 +896,10 @@ class Collection : IEnumerable<int>, IEnumerable<string>
 
 ### Specification of a [*constructible*](#conversions) collection type utilizing a [*create method*](#create-methods) is sensitive to the context at which conversion is classified
 
-An existence of the conversion in this case depends on the notion of an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement)
+An existence of the conversion in this case depends on the notion of an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/statements.md#1395-the-foreach-statement)
 of the *collection type*. If there is a *create method* that takes a `ReadOnlySpan<T>` where `T` is the *iteration type*, the conversion exists. Otherwise, it doesn't.
 
-However, an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1295-the-foreach-statement)
+However, an [*iteration type*](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/statements.md#1395-the-foreach-statement)
 is sensitive to the context at which `foreach` is performed. For the same *collection type* it can be different based on what extension methods
 are in scope, and it can also be undefined.
 

--- a/proposals/csharp-12.0/experimental-attribute.md
+++ b/proposals/csharp-12.0/experimental-attribute.md
@@ -35,7 +35,7 @@ namespace System.Diagnostics.CodeAnalysis
 
 ## Reported diagnostic
 
-Although the diagnostic is technically a warning (so that the compiler allows suppressing it),
+Although the diagnostic is technically a warning, so that the compiler allows suppressing it,
 it is treated as an error for purpose of reporting. This causes the build to fail if the diagnostic
 is not suppressed.  
 
@@ -43,7 +43,7 @@ The diagnostic is reported for any reference to a type or member that is either:
 - marked with the attribute,
 - in an assembly or module marked with the attribute,
 
-except when the reference occurs within `[Experimental]` members (automatic suppression).
+except when the reference occurs within `[Experimental]` members, when it is automatically suppressed.
 
 It is also possible to suppress the diagnostic by usual means, such as an explicit compiler option or `#pragma`.  
 For example, if the API is marked with `[Experimental("DiagID")]` or `[Experimental("DiagID", UrlFormat = "https://example.org/{0}")]`, 
@@ -51,12 +51,12 @@ the diagnostic can be suppressed with `#pragma warning disable DiagID`.
 
 An error is produced if the diagnostic ID given to the experimental attribute is not a [valid C# identifier](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/lexical-structure.md#643-identifiers).  
 
-If value for `Message` property is not provided, the diagnostic message is a specific message, where `'{0}'` is the fully-qualified type or member name.
+If a value for `Message` property is not provided, the diagnostic message is a specific message, where `'{0}'` is the fully-qualified type or member name.
 ```
 '{0}' is for evaluation purposes only and is subject to change or removal in future updates.
 ```
 
-If value for `Message` property is provided, the diagnostic message is a specific message, where `'{0}'` is the fully-qualified type or member name
+If a value for `Message` property is provided, the diagnostic message is a specific message, where `'{0}'` is the fully-qualified type or member name
 and `'{1}'` is the `Message`.
 ```
 '{0}' is for evaluation purposes only and is subject to change or removal in future updates: '{1}'.

--- a/proposals/csharp-12.0/inline-arrays.md
+++ b/proposals/csharp-12.0/inline-arrays.md
@@ -13,7 +13,7 @@ Provide a general-purpose and safe mechanism for declaring inline arrays within 
 
 ## Motivation
 
-This proposal plans to address the many limitations of https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#228-fixed-size-buffers.
+This proposal plans to address the many limitations of https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#238-fixed-size-buffers.
 Specifically it aims to allow:
 - accessing elements of struct types utilizing [InlineArrayAttribute](https://github.com/dotnet/runtime/issues/61135) feature;
 - the declaration of inline arrays for managed and unmanaged types in a `struct`, `class`, or `interface`.
@@ -34,9 +34,9 @@ public struct Buffer
 }
 ```
 
-Runtime provides a special type layout for the ```Buffer``` type:
-- The size of the type is extended to fit 10 (the number comes from the InlineArray attribute) elements of ```object```
-  type (the type comes from the type of the only instance field in the struct, ```_element0``` in this example).
+Runtime provides a special type layout for the `Buffer` type:
+- The size of the type is extended to fit 10 (the number comes from the InlineArray attribute) elements of `object`
+  type (the type comes from the type of the only instance field in the struct, `_element0` in this example).
 - The first element is aligned with the instance field and with the beginning of the struct
 - The elements are laid out sequentially in memory as though they are elements of an array.
 
@@ -55,14 +55,14 @@ For example, a pointer type cannot be used as an element type. Other examples th
 ### Obtaining instances of span types for an inline array type
 
 Since there is a guarantee that the first element in an inline array type is aligned at the beginning of the type (no gap), compiler will use the
-following code to get a ```Span``` value:
+following code to get a `Span` value:
 ``` C#
-MemoryMarshal.CreateSpan(ref Unsafe.As<TBuffer, TElement>(ref buffer), size)
+MemoryMarshal.CreateSpan(ref Unsafe.As<TBuffer, TElement>(ref buffer), size);
 ```
 
-And the following code to get a ```ReadOnlySpan``` value:
+And the following code to get a `ReadOnlySpan` value:
 ``` C#
-MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<TBuffer, TElement>(ref Unsafe.AsRef(in buffer)), size)
+MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<TBuffer, TElement>(ref Unsafe.AsRef(in buffer)), size);
 ```
 
 In order to reduce IL size at use sites compiler should be able to add two generic reusable helpers into private implementation detail type and
@@ -82,7 +82,7 @@ public static System.ReadOnlySpan<TElement> InlineArrayAsReadOnlySpan<TBuffer, T
 
 ### Element access
 
-The [Element access](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12811-element-access) will be extended
+The [Element access](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12821-element-access) will be extended
 to support inline array element access.
 
 An *element_access* consists of a *primary_no_array_creation_expression*, followed by a “`[`” token, followed by an *argument_list*, followed by a “`]`” token. The *argument_list* consists of one or more *argument*s, separated by commas.
@@ -95,44 +95,44 @@ element_access
 
 The *argument_list* of an *element_access* is not allowed to contain `ref` or `out` arguments.
 
-An *element_access* is dynamically bound ([§11.3.3](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#1233-dynamic-binding)) if at least one of the following holds:
+An *element_access* is dynamically bound ([§11.3.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1233-dynamic-binding)) if at least one of the following holds:
 
 - The *primary_no_array_creation_expression* has compile-time type `dynamic`.
 - At least one expression of the *argument_list* has compile-time type `dynamic` and the *primary_no_array_creation_expression* does not have an array type,
   **and the *primary_no_array_creation_expression* does not have an inline array type or there is more than one item in the argument list**.
 
-In this case, the compiler classifies the *element_access* as a value of type `dynamic`. The rules below to determine the meaning of the *element_access* are then applied at run-time, using the run-time type instead of the compile-time type of those of the *primary_no_array_creation_expression* and *argument_list* expressions which have the compile-time type `dynamic`. If the *primary_no_array_creation_expression* does not have compile-time type `dynamic`, then the element access undergoes a limited compile-time check as described in [§11.6.5](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#1265-compile-time-checking-of-dynamic-member-invocation).
+In this case, the compiler classifies the *element_access* as a value of type `dynamic`. The rules below to determine the meaning of the *element_access* are then applied at run-time, using the run-time type instead of the compile-time type of those of the *primary_no_array_creation_expression* and *argument_list* expressions which have the compile-time type `dynamic`. If the *primary_no_array_creation_expression* does not have compile-time type `dynamic`, then the element access undergoes a limited compile-time check as described in [§11.6.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1265-compile-time-checking-of-dynamic-member-invocation).
 
-If the *primary_no_array_creation_expression* of an *element_access* is a value of an *array_type*, the *element_access* is an array access ([§11.7.10.2](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#128112-array-access)). **If the *primary_no_array_creation_expression* of an *element_access* is a variable or value of an inline array type and the *argument_list* consists of a single argument, the *element_access* is an inline array element access.** Otherwise, the *primary_no_array_creation_expression* shall be a variable or value of a class, struct, or interface type that has one or more indexer members, in which case the *element_access* is an indexer access ([§11.7.10.3](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#128113-indexer-access)).
+If the *primary_no_array_creation_expression* of an *element_access* is a value of an *array_type*, the *element_access* is an array access ([§12.8.12.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128122-array-access)). **If the *primary_no_array_creation_expression* of an *element_access* is a variable or value of an inline array type and the *argument_list* consists of a single argument, the *element_access* is an inline array element access.** Otherwise, the *primary_no_array_creation_expression* shall be a variable or value of a class, struct, or interface type that has one or more indexer members, in which case the *element_access* is an indexer access ([§12.8.12.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128123-indexer-access)).
 
 #### Inline array element access
 
 For an inline array element access, the *primary_no_array_creation_expression* of the *element_access* must be a variable or value of an inline array type. Furthermore, the *argument_list* of an inline array element access is not allowed to contain named arguments. The *argument_list* must contain a single expression, and the expression must be 
 - of type `int`, or
 - implicitly convertible to `int`, or
-- implicitly convertible to ```System.Index```, or 
-- implicitly convertible to ```System.Range```. 
+- implicitly convertible to `System.Index`, or 
+- implicitly convertible to `System.Range`. 
 
 ##### When the expression type is int
 
 If *primary_no_array_creation_expression* is a writable variable, the result of evaluating an inline array element access is a writable variable
 equivalent to invoking [`public ref T this[int index] { get; }`](https://learn.microsoft.com/dotnet/api/system.span-1.item) with
-that integer value on an instance of ```System.Span<T>``` returned by ```System.Span<T> InlineArrayAsSpan``` method on *primary_no_array_creation_expression*. For the purpose of ref-safety analysis the *ref-safe-context*/*safe-context*
-of the access are equivalent to the same for an invocation of a method with the signature ```static ref T GetItem(ref InlineArrayType array)```.
+that integer value on an instance of `System.Span<T>` returned by `System.Span<T> InlineArrayAsSpan` method on *primary_no_array_creation_expression*. For the purpose of ref-safety analysis the *ref-safe-context*/*safe-context*
+of the access are equivalent to the same for an invocation of a method with the signature `static ref T GetItem(ref InlineArrayType array)`.
 The resulting variable is considered movable if and only if *primary_no_array_creation_expression* is movable.
 
 If *primary_no_array_creation_expression* is a readonly variable, the result of evaluating an inline array element access is a readonly variable
 equivalent to invoking [`public ref readonly T this[int index] { get; }`](https://learn.microsoft.com/dotnet/api/system.readonlyspan-1.item) with
-that integer value on an instance of ```System.ReadOnlySpan<T>``` returned by ```System.ReadOnlySpan<T> InlineArrayAsReadOnlySpan```
+that integer value on an instance of `System.ReadOnlySpan<T>` returned by `System.ReadOnlySpan<T> InlineArrayAsReadOnlySpan`
 method on *primary_no_array_creation_expression*. For the purpose of ref-safety analysis the *ref-safe-context*/*safe-context*
-of the access are equivalent to the same for an invocation of a method with the signature ```static ref readonly T GetItem(in InlineArrayType array)```.
+of the access are equivalent to the same for an invocation of a method with the signature `static ref readonly T GetItem(in InlineArrayType array)`.
 The resulting variable is considered movable if and only if *primary_no_array_creation_expression* is movable.
 
 If *primary_no_array_creation_expression* is a value, the result of evaluating an inline array element access is a value
 equivalent to invoking [`public ref readonly T this[int index] { get; }`](https://learn.microsoft.com/dotnet/api/system.readonlyspan-1.item) with
-that integer value on an instance of ```System.ReadOnlySpan<T>``` returned by ```System.ReadOnlySpan<T> InlineArrayAsReadOnlySpan```
+that integer value on an instance of `System.ReadOnlySpan<T>` returned by `System.ReadOnlySpan<T> InlineArrayAsReadOnlySpan`
 method on *primary_no_array_creation_expression*. For the purpose of ref-safety analysis the *ref-safe-context*/*safe-context*
-of the access are equivalent to the same for an invocation of a method with the signature ```static T GetItem(InlineArrayType array)```. 
+of the access are equivalent to the same for an invocation of a method with the signature `static T GetItem(InlineArrayType array)`. 
 
 For example:
 ``` C#
@@ -169,35 +169,35 @@ Indexing into an inline array with a constant expression outside of the declared
 
 The expression is converted to int and then the element access is interpreted as described in **When the expression type is int** section.
 
-##### When the expression implicitly convertible to ```System.Index```
+##### When the expression implicitly convertible to `System.Index`
 
-The expression is converted to ```System.Index```, which is then transformed to an int-based index value as described at https://github.com/dotnet/csharplang/blob/main/proposals/csharp-8.0/ranges.md#implicit-index-support, assuming that the
+The expression is converted to `System.Index`, which is then transformed to an int-based index value as described at https://github.com/dotnet/csharplang/blob/main/proposals/csharp-8.0/ranges.md#implicit-index-support, assuming that the
 length of the collection is known at compile time and is equal to the amount of elements in the inline array type of
 the *primary_no_array_creation_expression*. Then the element access is interpreted as described in
 **When the expression type is int** section.
 
-##### When the expression implicitly convertible to ```System.Range```
+##### When the expression implicitly convertible to `System.Range`
 
 If *primary_no_array_creation_expression* is a writable variable, the result of evaluating an inline array element access is a value
 equivalent to invoking [`public Span<T> Slice (int start, int length)`](https://learn.microsoft.com/dotnet/api/system.span-1.slice)
-on an instance of ```System.Span<T>``` returned by ```System.Span<T> InlineArrayAsSpan``` method on *primary_no_array_creation_expression*.
+on an instance of `System.Span<T>` returned by `System.Span<T> InlineArrayAsSpan` method on *primary_no_array_creation_expression*.
 For the purpose of ref-safety analysis the *ref-safe-context*/*safe-context* of the access are equivalent to the same
-for an invocation of a method with the signature ```static System.Span<T> GetSlice(ref InlineArrayType array)```.
+for an invocation of a method with the signature `static System.Span<T> GetSlice(ref InlineArrayType array)`.
 
 If *primary_no_array_creation_expression* is a readonly variable, the result of evaluating an inline array element access is a value
 equivalent to invoking [`public ReadOnlySpan<T> Slice (int start, int length)`](https://learn.microsoft.com/dotnet/api/system.readonlyspan-1.slice)
-on an instance of ```System.ReadOnlySpan<T>``` returned by ```System.ReadOnlySpan<T> InlineArrayAsReadOnlySpan```
+on an instance of `System.ReadOnlySpan<T>` returned by `System.ReadOnlySpan<T> InlineArrayAsReadOnlySpan`
 method on *primary_no_array_creation_expression*.
 For the purpose of ref-safety analysis the *ref-safe-context*/*safe-context* of the access are equivalent to the same
-for an invocation of a method with the signature ```static System.ReadOnlySpan<T> GetSlice(in InlineArrayType array)```.
+for an invocation of a method with the signature `static System.ReadOnlySpan<T> GetSlice(in InlineArrayType array)`.
 
 If *primary_no_array_creation_expression* is a value, an error is reported. 
 
-The arguments for the ```Slice``` method invocation are calculated from the index expression converted to```System.Range``` as described at
+The arguments for the `Slice` method invocation are calculated from the index expression converted to `System.Range` as described at
 https://github.com/dotnet/csharplang/blob/main/proposals/csharp-8.0/ranges.md#implicit-range-support, assuming that the length of the collection
 is known at compile time and is equal to the amount of elements in the inline array type of the *primary_no_array_creation_expression*.
 
-Compiler can omit the ```Slice``` call if it is known at compile time that `start` is 0 and `length` is less or equal to the amount of elements in the
+Compiler can omit the `Slice` call if it is known at compile time that `start` is 0 and `length` is less or equal to the amount of elements in the
 inline array type. Compiler can also report an error if it is known at compile time that slicing goes out of inline array bounds.
 
 For example:
@@ -228,10 +228,10 @@ A new conversion, an inline array conversion, from expression will be added. The
 a [standard conversion](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#104-standard-conversions).
 
 There is an implicit conversion from expression of an inline array type to the following types:
-- ```System.Span<T>```
-- ```System.ReadOnlySpan<T>```
+- `System.Span<T>`
+- `System.ReadOnlySpan<T>`
 
-However, converting a readonly variable to ```System.Span<T>``` or converting a value to either type is an error.
+However, converting a readonly variable to `System.Span<T>` or converting a value to either type is an error.
 
 For example:
 ``` C#
@@ -257,8 +257,8 @@ void M3()
 ```
 
 For the purpose of ref-safety analysis the *safe-context* of the conversion is equivalent to *safe-context*
-for an invocation of a method with the signature ```static System.Span<T> Convert(ref InlineArrayType array)```, or
-```static System.ReadOnlySpan<T> Convert(in InlineArrayType array)```.
+for an invocation of a method with the signature `static System.Span<T> Convert(ref InlineArrayType array)`, or
+`static System.ReadOnlySpan<T> Convert(in InlineArrayType array)`.
 
 
 ### List patterns
@@ -272,8 +272,13 @@ Regular definite assignment rules are applicable to variables that have an inlin
 
 ### Collection literals
 
-An inline array type is a valid *constructible collection* target type for a [collection expression](collection-expressions.md).
+An instance of an inline array type is a valid expression in a [*spread_element*](collection-expressions.md#detailed-design).
 
+The following feature did not ship in C# 12. It remains an open proposal. The code in this example generates **CS9174**:
+
+<details>
+
+An inline array type is a valid *constructible collection* target type for a [collection expression](collection-expressions.md).
 For example:
 ``` C#
 Buffer10<int> b = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]; // initializes user-defined inline array
@@ -283,8 +288,7 @@ The length of the collection literal must match the length of the target inline 
 is known at compile time and it doesn't match the target length, an error is reported. Otherwise, an exception is going
 to be thrown at runtime once the mismatch is encountered. The exact exception type is TBD. Some candidates are:
 System.NotSupportedException, System.InvalidOperationException.
-
-An instance of an inline array type is a valid expression in a [*spread_element*](collection-expressions.md#detailed-design).
+</details>
 
 ### Validation of the InlineArrayAttribute applications
 
@@ -296,8 +300,8 @@ Compiler will validate the following aspects of the InlineArrayAttribute applica
 
 ### Inline Array elements in an object initializer
 
-By default, element initialization will not be supported via *initializer_target* of form ```'[' argument_list ']'```
-(see https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128163-object-initializers):  
+By default, element initialization will not be supported via *initializer_target* of form `'[' argument_list ']'`
+(see https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128173-object-initializers):  
 ``` C#
 static C M2() => new C() { F = {[0] = 111} }; // error CS1913: Member '[0]' cannot be initialized. It is not a field or property.
 
@@ -332,7 +336,7 @@ public struct Buffer10<T>
 
 ### The foreach statement
 
-[The foreach statement](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/statements.md#1295-the-foreach-statement) will be adjusted
+[The foreach statement](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/statements.md#1395-the-foreach-statement) will be adjusted
 to allow usage of an inline array type as a collection in a foreach statement.
 
 For example:
@@ -398,7 +402,7 @@ rank_specifier
 
 The type of the *constant_expression* must be implicitly convertible to type `int`, and the value must be a non-zero positive integer.
 
-The relevant part of the https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/arrays.md#1621-general section will be adjusted as follows.
+The relevant part of the https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/arrays.md#1721-general section will be adjusted as follows.
 
 The grammar productions for array types are provided in https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/types.md#821-general.
 
@@ -424,7 +428,7 @@ In effect, the *rank_specifier*s are read from left to right *before* the final 
 
 At run-time, a value of a regular array type can be `null` or a reference to an instance of that array type.
 
-> *Note*: Following the rules of https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/arrays.md#166-array-covariance,
+> *Note*: Following the rules of https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/arrays.md#176-array-covariance,
 > the value may also be a reference to a covariant array type. *end note*
 
 An anonymous inline array type is a compiler synthesized inline array type with internal accessibility. The element type must be a 
@@ -437,7 +441,7 @@ by using a required custom modifier (exact type TBD) applied to an anonymous inl
 
 #### Array creation expressions
 
-[Array creation expressions](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128165-array-creation-expressions)
+[Array creation expressions](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128175-array-creation-expressions)
 
 ```ANTLR
 array_creation_expression
@@ -465,7 +469,11 @@ new [] {default(int[5]), default(int[5])};
 
 #### Array initializers
 
-The [Array initializers](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/arrays.md#167-array-initializers) section
+Array initializers were not implemented in C# 12. This section remains an active proposal. 
+
+<details>
+
+The [Array initializers](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/arrays.md#177-array-initializers) section
 will be adjusted to allow use of *array_initializer* to initialize inline array types (no changes to the grammar necessary).
 
 ```ANTLR
@@ -494,15 +502,17 @@ var c = new int[][] {{11, 12}, {21, 22}, {31, 32}}; // An error for the nested a
 var d = new int[][2] {{11, 12}, {21, 22}, {31, 32}}; // An error for the nested array initializer
 ```
 
+</details>
+
 ### Detailed Design (Option 2)
 
-Note, that for the purpose of this proposal a term "fixed-size buffer" refers to a the proposed "safe fixed-size buffer" feature rather than to a buffer described at https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#228-fixed-size-buffers.
+Note, that for the purpose of this proposal a term "fixed-size buffer" refers to a the proposed "safe fixed-size buffer" feature rather than to a buffer described at https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#238-fixed-size-buffers.
 
 In this design, fixed-size buffer types do not get general special treatment by the language.
 There is a special syntax to declare members that represent fixed-size buffers and new rules around consuming those members.
 They are not fields from the language point of view.
 
-The grammar for *variable_declarator* in https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#145-fields
+The grammar for *variable_declarator* in https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#155-fields
 will be extended to allow specifying the size of the buffer:
 
 ``` diff antlr
@@ -569,8 +579,8 @@ In a member access of the form `E.I`, if `E` is of a struct type and a member lo
 then `E.I` is evaluated and classified as follows:
 
 - If `E` is classified as a value, then `E.I` can be used only as a *primary_no_array_creation_expression* of
-  an [element access](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12811-element-access)
-  with index of ```System.Index``` type, or of a type implicitly convertible to int. Result of the element access is
+  an [element access](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12812-element-access)
+  with index of `System.Index` type, or of a type implicitly convertible to int. Result of the element access is
   a fixed-size member's element at the specified position, classified as a value.   
 - Otherwise, if `E` is classified as a readonly variable and the result of the expression is classified as a value of type `System.ReadOnlySpan<S>`,
   where S is the element type of `I`. The value can be used to access member's elements.
@@ -599,8 +609,8 @@ This is achieved by the following.
 A member access for a readonly fixed-size buffer is evaluated and classified as follows:
 
 - In a member access of the form `E.I`, if `E` is of a struct type and `E` is classified as a value, then `E.I` can be used only as a
-  *primary_no_array_creation_expression* of an [element access](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12811-element-access)
-  with index of ```System.Index``` type, or of a type implicitly convertible to int. Result of the element access is a fixed-size member's element at the specified
+  *primary_no_array_creation_expression* of an [element access](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12812-element-access)
+  with index of `System.Index` type, or of a type implicitly convertible to int. Result of the element access is a fixed-size member's element at the specified
   position, classified as a value.
 - If access occurs in a context where direct assignments to an element of readonly fixed-size buffer are permitted, the result of the expression
   is classified as a value of type `System.Span<S>`, where S is the element type of the fixed-size buffer. The value can be used to access member's elements.
@@ -617,10 +627,11 @@ When a fixed-size buffer member is static or the outermost containing struct var
 
 ##### Metadata emit and code generation
 
-For metadata encoding compiler will rely on recently added [```System.Runtime.CompilerServices.InlineArrayAttribute```](https://github.com/dotnet/runtime/issues/61135). 
+For metadata encoding compiler will rely on recently added [`System.Runtime.CompilerServices.InlineArrayAttribute`](https://github.com/dotnet/runtime/issues/61135). 
 
-Fixed-size buffers like:
+Fixed-size buffers like the following pseudocode:
 ``` C#
+// Not valid C#
 public partial class C
 {
     public int buffer1[10];
@@ -697,10 +708,10 @@ public partial class C
 ##### Metadata import
 
 When compiler imports a field declaration of type *T* and the following conditions are all met:
-- *T* is a struct type decorated with the ```InlineArray``` attribute, and
+- *T* is a struct type decorated with the `InlineArray` attribute, and
 - The first instance field declared within *T* has type *F*, and
-- There is a ```public System.Span<F> AsSpan()``` within *T*, and 
-- There is a ```public readonly System.ReadOnlySpan<T> AsReadOnlySpan()``` or ```public System.ReadOnlySpan<T> AsReadOnlySpan()``` within *T*. 
+- There is a `public System.Span<F> AsSpan()` within *T*, and 
+- There is a `public readonly System.ReadOnlySpan<T> AsReadOnlySpan()` or `public System.ReadOnlySpan<T> AsReadOnlySpan()` within *T*. 
 
 the field will be treated as C# fixed-size buffer with element type *F*. Otherwise, the field will be treated as a regular field of type *T*.
 
@@ -712,9 +723,9 @@ but can be made into one if necessary. Here’s how that would work:
 - Safe fixed-size buffer accesses have their own classification (just like e.g. method groups and lambdas)
 - They can be indexed directly as a language operation (not via span types) to produce a variable (which is readonly
   if the buffer is in a readonly context, just the same as fields of a struct)
-- They have implicit conversions-from-expression to ```Span<T>``` and ```ReadOnlySpan<T>```, but use of the former is an error if
+- They have implicit conversions-from-expression to `Span<T>` and `ReadOnlySpan<T>`, but use of the former is an error if
   they are in a readonly context
-- Their natural type is ```ReadOnlySpan<T>```, so that’s what they contribute if they participate in type inference (e.g., var, best-common-type or generic)
+- Their natural type is `ReadOnlySpan<T>`, so that’s what they contribute if they participate in type inference (e.g., var, best-common-type or generic)
 
 ### C/C++ fixed-size buffers
 

--- a/proposals/csharp-12.0/primary-constructors.md
+++ b/proposals/csharp-12.0/primary-constructors.md
@@ -18,6 +18,8 @@ The ability of a class or struct in C# to have more than one constructor provide
 Primary constructors put the parameters of one constructor in scope for the whole class or struct to be used for initialization or directly as object state. The trade-off is that any other constructors must call through the primary constructor.
 
 ``` c#
+public class B(bool b) { } // base class
+
 public class C(bool b, int i, string s) : B(b) // b passed to base constructor
 {
     public int I { get; set; } = i; // i used for initialization
@@ -101,15 +103,15 @@ A class or struct with a `parameter_list` has an implicit public constructor who
 
 ### Lookup
 
-The [lookup of simple names](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#1174-simple-names) is augmented to handle primary constructor parameters. The changes are highlighted in **bold** in the following excerpt:
+The [lookup of simple names](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1284-simple-names) is augmented to handle primary constructor parameters. The changes are highlighted in **bold** in the following excerpt:
 
-> - Otherwise, for each instance type `T` ([§14.3.2](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/classes.md#1432-the-instance-type)), starting with the instance type of the immediately enclosing type declaration and continuing with the instance type of each enclosing class or struct declaration (if any):
+> - Otherwise, for each instance type `T` ([§15.3.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#1532-the-instance-type)), starting with the instance type of the immediately enclosing type declaration and continuing with the instance type of each enclosing class or struct declaration (if any):
 >   - **If the declaration of `T` includes a primary constructor parameter `I` and the reference occurs within the `argument_list` of `T`'s `class_base` or within an initializer of a field, property or event of `T`, the result is the primary constructor parameter `I`**
 >   - **Otherwise,** if `e` is zero and the declaration of `T` includes a type parameter with name `I`, then the *simple_name* refers to that type parameter.
->   - Otherwise, if a member lookup ([§11.5](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#115-member-lookup)) of `I` in `T` with `e` type arguments produces a match:
->     - If `T` is the instance type of the immediately enclosing class or struct type and the lookup identifies one or more methods, the result is a method group with an associated instance expression of `this`. If a type argument list was specified, it is used in calling a generic method ([§11.7.8.2](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#11782-method-invocations)).
->     - Otherwise, if `T` is the instance type of the immediately enclosing class or struct type, if the lookup identifies an instance member, and if the reference occurs within the *block* of an instance constructor, an instance method, or an instance accessor ([§11.2.1](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#1121-general)), the result is the same as a member access ([§11.7.6](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#1176-member-access)) of the form `this.I`. This can only happen when `e` is zero.
->     - Otherwise, the result is the same as a member access ([§11.7.6](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#1176-member-access)) of the form `T.I` or `T.I<A₁, ..., Aₑ>`.
+>   - Otherwise, if a member lookup ([§12.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#125-member-lookup)) of `I` in `T` with `e` type arguments produces a match:
+>     - If `T` is the instance type of the immediately enclosing class or struct type and the lookup identifies one or more methods, the result is a method group with an associated instance expression of `this`. If a type argument list was specified, it is used in calling a generic method ([§12.8.10.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128102-method-invocations)).
+>     - Otherwise, if `T` is the instance type of the immediately enclosing class or struct type, if the lookup identifies an instance member, and if the reference occurs within the *block* of an instance constructor, an instance method, or an instance accessor ([§12.2.1](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1221-general)), the result is the same as a member access ([§12.8.7](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1287-member-access)) of the form `this.I`. This can only happen when `e` is zero.
+>     - Otherwise, the result is the same as a member access ([§12.8.7](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1287-member-access)) of the form `T.I` or `T.I<A₁, ..., Aₑ>`.
 >   - **Otherwise, if the declaration of `T` includes a primary constructor parameter `I`, the result is the primary constructor parameter `I`.**
 
 The first addition corresponds to the change incurred by [primary constructors on records](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-9.0/records.md#primary-constructor), and ensures that primary constructor parameters are found before any corresponding fields within initializers and base class arguments. It extends this rule to static initializers as well. However, since records always have an instance member with the same name as the parameter, the extension can only lead to a change in an error message. Illegal access to a parameter vs. illegal access to an instance member.  
@@ -178,7 +180,7 @@ public class C(bool b, int i, string s) : B(b) // b passed to base constructor
     public string S // s used directly in function members
     {
         get => s;
-        set => s = value ?? throw new NullArgumentException(nameof(X));
+        set => s = value ?? throw new ArgumentNullException(nameof(value));
     }
     public C(string s) : this(true, 0, s) { } // must call this(...)
 }
@@ -193,7 +195,7 @@ public class C : B
     public string S
     {
         get => __s;
-        set => __s = value ?? throw new NullArgumentException(nameof(X));
+        set => __s = value ?? throw new ArgumentNullException(nameof(value));
     }
     public C(string s) : this(0, s) { ... } // must call this(...)
     
@@ -217,9 +219,9 @@ Records produce a warning if a primary constructor parameter isn't read within t
 
 ### Identical simple names and type names
 
-There is a special language rule for scenarios often referred to as "Color Color" scenarios - [Identical simple names and type names](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#11762-identical-simple-names-and-type-names). 
+There is a special language rule for scenarios often referred to as "Color Color" scenarios - [Identical simple names and type names](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12872-identical-simple-names-and-type-names). 
 
->In a member access of the form `E.I`, if `E` is a single identifier, and if the meaning of `E` as a *simple_name* ([§11.7.4](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#1174-simple-names)) is a constant, field, property, local variable, or parameter with the same type as the meaning of `E` as a *type_name* ([§7.8.1](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/basic-concepts.md#781-general)), then both possible meanings of `E` are permitted. The member lookup of `E.I` is never ambiguous, since `I` shall necessarily be a member of the type `E` in both cases. In other words, the rule simply permits access to the static members and nested types of `E` where a compile-time error would otherwise have occurred.
+>In a member access of the form `E.I`, if `E` is a single identifier, and if the meaning of `E` as a *simple_name* ([§12.8.4](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1274-simple-names)) is a constant, field, property, local variable, or parameter with the same type as the meaning of `E` as a *type_name* ([§7.8.1](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/basic-concepts.md#781-general)), then both possible meanings of `E` are permitted. The member lookup of `E.I` is never ambiguous, since `I` shall necessarily be a member of the type `E` in both cases. In other words, the rule simply permits access to the static members and nested types of `E` where a compile-time error would otherwise have occurred.
 
 With respect to primary constructors, the rule affects whether an identifier within an instance member should be treated as a type reference, or as a primary constructor parameter reference, which, in turn, captures the parameter into the the state of the enclosing type. Even though "the member lookup of `E.I` is never ambiguous", when lookup yields a member group, in some cases it is impossible to determine whether a member access refers to a static member or an instance member without fully resolving (binding) the member access. At the same time, capturing a primary constructor parameter changes properties of enclosing type in a way that affects semantic analysis. For example, the type might become unmanaged and fail certain constraints because of that. 
 There are even scenarios for which binding can succeed either way, depending on whether the parameter is considered captured or not. For example:
@@ -228,7 +230,7 @@ struct S1(Color Color)
 {
     public void Test()
     {
-        Color.M1(this);
+        Color.M1(this); // Error: ambiguity between parameter and typename
     }
 }
 
@@ -269,7 +271,7 @@ For example:
 ``` c#
 public class Person(string name)
 {
-    public string Name { get; set; } = name;   // initialization
+    public string Name { get; set; } = name;   // warning: initialization
     public override string ToString() => name; // capture
 }
 ```
@@ -333,8 +335,8 @@ A much simpler version of the feature would prohibit primary constructor paramet
 ``` c#
 public class C(string s)
 {
-    public S1 => s; // Nope!
-    public S2 { get; } = s; // Still allowed
+    public string S1 => s; // Nope!
+    public string S2 { get; } = s; // Still allowed
 }
 ```
 
@@ -404,7 +406,7 @@ public class C(bool b, int i, string s) : B(b)
     public string S // s used directly in function members
     {
         get => s;
-        set => s = value ?? throw new NullArgumentException(nameof(X));
+        set => s = value ?? throw new ArgumentNullException(nameof(value));
     }
     public C(string s2) : base(true) // cannot use `string s` because it would shadow
     { 

--- a/proposals/csharp-12.0/ref-readonly-parameters.md
+++ b/proposals/csharp-12.0/ref-readonly-parameters.md
@@ -244,6 +244,8 @@ Also, `in` has been redefined as `ref readonly` + convenience features, hence th
 ### Pending LDM review
 [to-review]: #pending-ldm-review
 
+None of the following options were implemented in C# 12. They remains potential proposals.
+
 #### [Parameter declarations][declarations]
 
 Inverse ordering of modifiers (`readonly ref` instead of `ref readonly`) could be allowed.
@@ -376,7 +378,7 @@ class C
     void Run()
     {
         D1 m1 = this.M;
-        D2 m2 = this.M;
+        D2 m2 = this.M; // currently ambiguous
 
         var i = 5;
         m1(null, in i);


### PR DESCRIPTION
Contributes to #8098

The proposed features that weren't implemented were initializing an inline array using a collection expression, and the updated array initialization syntax as part of the inline arrays feature.

Other edits were small editorial nits, and updating anchors to the C# standard text.