### PR TITLE
Edit pass on C# 11 speclets

### DIFF
--- a/proposals/csharp-11.0/auto-default-structs.md
+++ b/proposals/csharp-11.0/auto-default-structs.md
@@ -180,14 +180,14 @@ For example, if a struct has 100 fields, and just one of them is explicitly init
 
 We adjust the following section of the standard:
 
-https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11712-this-access
+https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12814-this-access
 > If the constructor declaration has no constructor initializer, the `this` variable behaves exactly the same as an `out` parameter of the struct type. In particular, this means that the variable shall be definitely assigned in every execution path of the instance constructor.
 
 We adjust this language to read:
 
-If the constructor declaration has no constructor initializer, the `this` variable behaves similarly to an `out` parameter of the struct type, except that it is not an error when the definite assignment requirements ([§9.4.1](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/variables.md#941-general)) are not met. Instead, we introduce the following behaviors:
+If the constructor declaration has no constructor initializer, the `this` variable behaves similarly to an `out` parameter of the struct type, except that it is not an error when the definite assignment requirements ([§9.4.1](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/variables.md#941-general)) are not met. Instead, we introduce the following behaviors:
 
-  1. When the `this` variable itself does not meet the requirements, then all unassigned instance variables within `this` at all points where requirements are violated are implicitly initialized to the default value ([§9.3](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/variables.md#93-default-values)) in an *initialization* phase before any other code in the constructor runs.
+  1. When the `this` variable itself does not meet the requirements, then all unassigned instance variables within `this` at all points where requirements are violated are implicitly initialized to the default value ([§9.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/variables.md#93-default-values)) in an *initialization* phase before any other code in the constructor runs.
 2. When an instance variable *v* within `this` does not meet the requirements, or any instance variable at any level of nesting within *v* does not meet the requirements, then *v* is implicitly initialized to the default value in an *initialization* phase before any other code in the constructor runs.
 
 ## Design meetings

--- a/proposals/csharp-11.0/checked-user-defined-operators.md
+++ b/proposals/csharp-11.0/checked-user-defined-operators.md
@@ -6,9 +6,9 @@
 [summary]: #summary
 
 C# should support defining `checked` variants of the following user-defined operators so that users can opt into or out of overflow behavior as appropriate:
-*  The `++` and `--` unary operators [§11.7.14](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11714-postfix-increment-and-decrement-operators) and [§11.8.6](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1186-prefix-increment-and-decrement-operators).
-*  The `-` unary operator [§11.8.3](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1183-unary-minus-operator).
-*  The `+`, `-`, `*`, and `/` binary operators [§11.9](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#119-arithmetic-operators).
+*  The `++` and `--` unary operators [§12.8.16](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12816-postfix-increment-and-decrement-operators) and [§12.9.6](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1296-prefix-increment-and-decrement-operators).
+*  The `-` unary operator [§12.9.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1293-unary-minus-operator).
+*  The `+`, `-`, `*`, and `/` binary operators [§12.10](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1210-arithmetic-operators).
 *  Explicit conversion operators.
 
 ## Motivation
@@ -21,7 +21,7 @@ There is no way for a user to declare a type and support both checked and unchec
 
 ### Syntax
 
-Grammar at operators ([§14.10](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/classes.md#1410-operators)) will be adjusted to allow
+Grammar at operators ([§15.10](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#1510-operators)) will be adjusted to allow
 `checked` keyword after the `operator` keyword right before the operator token:
 ```antlr
 overloadable_unary_operator
@@ -88,7 +88,7 @@ implementing checked explicit conversion operator.
 
 ### Unary operators
 
-Unary `checked operators` follow the rules from [§14.10.2](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/classes.md#14102-unary-operators).
+Unary `checked operators` follow the rules from [§15.10.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#15102-unary-operators).
 
 Also, a `checked operator` declaration requires a pair-wise declaration of a `regular operator` (the return type should match as well). A compile-time error occurs otherwise. 
 
@@ -109,7 +109,7 @@ public struct Int128
 
 ### Binary operators
 
-Binary `checked operators` follow the rules from [§14.10.3](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/classes.md#14103-binary-operators).
+Binary `checked operators` follow the rules from [§15.10.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#15103-binary-operators).
 
 Also, a `checked operator` declaration requires a pair-wise declaration of a `regular operator` (the return type should match as well). A compile-time error occurs otherwise. 
 
@@ -130,7 +130,7 @@ public struct Int128
 
 ### Candidate user-defined operators
 
-The https://github.com/dotnet/csharplang/blob/main/spec/expressions.md#candidate-user-defined-operators section will be adjusted as follows (additions/changes are in bold).
+The Candidate user operators ([§12.4.6](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1246-candidate-user-operators)) section will be adjusted as follows (additions/changes are in bold).
 
 Given a type `T` and an operation `operator op(A)`, where `op` is an overloadable operator and `A` is an argument list, the set of candidate user-defined operators provided by `T` for `operator op(A)` is determined as follows:
 
@@ -138,13 +138,13 @@ Given a type `T` and an operation `operator op(A)`, where `op` is an overloadabl
 *  **Find the set of user-defined operators, `U`. This set consists of:**
     *  **In `unchecked` evaluation context, all regular `operator op` declarations in `T0`.**
     *  **In `checked` evaluation context, all checked and regular `operator op` declarations in `T0` except regular declarations that have pair-wise matching `checked operator` declaration.**
-*  For all `operator op` declarations in **`U`** and all lifted forms of such operators, if at least one operator is applicable ([Applicable function member](https://github.com/dotnet/csharplang/blob/main/spec/expressions.md#applicable-function-member)) with respect to the argument list `A`, then the set of candidate operators consists of all such applicable operators in `T0`.
+*  For all `operator op` declarations in **`U`** and all lifted forms of such operators, if at least one operator is applicable ([§12.4.6 - Applicable function member](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1246-candidate-user-operators)) with respect to the argument list `A`, then the set of candidate operators consists of all such applicable operators in `T0`.
 *  Otherwise, if `T0` is `object`, the set of candidate operators is empty.
 *  Otherwise, the set of candidate operators provided by `T0` is the set of candidate operators provided by the direct base class of `T0`, or the effective base class of `T0` if `T0` is a type parameter.
 
 Similar rules will be applied while determining the set of candidate operators in interfaces https://github.com/dotnet/csharplang/blob/main/meetings/2017/LDM-2017-06-27.md#shadowing-within-interfaces.
 
-The section [§11.7.18](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11718-the-checked-and-unchecked-operators) will be adjusted to reflect the effect that the checked/unchecked context has on unary and binary operator overload resolution.
+The section [§12.8.20](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12820-the-checked-and-unchecked-operators) will be adjusted to reflect the effect that the checked/unchecked context has on unary and binary operator overload resolution.
 
 #### Example #1:
 ``` C#
@@ -185,10 +185,9 @@ public struct Int128
 
     public static Int128 operator -(Int128 lhs, Int128 rhs);
 
-    // Cannot be declared in C#, but could be declared by some other language
+    // Cannot be declared in C# - missing unchecked operator, but could be declared by some other language
     public static Int128 operator checked *(Int128 lhs, Int128 rhs);
 
-    // Cannot be declared in C#, but could be declared by some other language
     public static Int128 operator checked /(Int128 lhs, int rhs);
 
     public static Int128 operator /(Int128 lhs, byte rhs);
@@ -213,7 +212,7 @@ class C
 
 class C1
 {
-    // Cannot be declared in C#, but could be declared by some other language
+    // Cannot be declared in C# - missing unchecked operator, but could be declared by some other language
     public static C1 operator checked + (C1 x, C3 y) => new C3();
 }
 
@@ -250,7 +249,7 @@ class C1
 
 class C2 : C1
 {
-    // Cannot be declared in C#, but could be declared by some other language
+    // Cannot be declared in C# - missing unchecked operator, but could be declared by some other language
     public static C2 operator checked + (C2 x, C1 y) => new C2();
 }
 
@@ -261,7 +260,7 @@ class C3 : C1
 
 ### Conversion operators
 
-Conversion `checked operators` follow the rules from [§14.10.4](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/classes.md#14104-conversion-operators).
+Conversion `checked operators` follow the rules from [§15.10.4](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#15104-conversion-operators).
 
 However, a `checked operator` declaration requires a pair-wise declaration of a `regular operator`. A compile-time error occurs otherwise. 
 
@@ -273,7 +272,7 @@ A type will not be allowed to declare both an implicit and a checked explicit co
 
 ### Processing of user-defined explicit conversions 
 
-The third bullet in [§10.5.5](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/conversions.md#1055-user-defined-explicit-conversions):
+The third bullet in [§10.5.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#1055-user-defined-explicit-conversions):
 >*  Find the set of applicable user-defined and lifted conversion operators, `U`. This set consists of the user-defined and lifted implicit or explicit conversion operators declared by the classes or structs in `D` that convert from a type encompassing or encompassed by `S` to a type encompassing or encompassed by `T`. If `U` is empty, the conversion is undefined and a compile-time error occurs.
 
 will be replaced with the following bullet points:
@@ -282,7 +281,7 @@ will be replaced with the following bullet points:
     *  **In `checked` evaluation context, the user-defined implicit or regular/checked explicit conversion operators declared by the classes or structs in `D` except regular explicit conversion operators that have pair-wise matching `checked operator` declaration within the same declaring type.**
 *  Find the set of applicable user-defined and lifted conversion operators, `U`. This set consists of the user-defined and lifted implicit or explicit conversion operators **in `U0`** that convert from a type encompassing or encompassed by `S` to a type encompassing or encompassed by `T`. If `U` is empty, the conversion is undefined and a compile-time error occurs.
 
-The Checked and unchecked operators [§11.7.18](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11718-the-checked-and-unchecked-operators) section will be adjusted to reflect the effect that the checked/unchecked context has on processing of user-defined explicit conversions.
+The Checked and unchecked operators [§11.8.20](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12820-the-checked-and-unchecked-operators) section will be adjusted to reflect the effect that the checked/unchecked context has on processing of user-defined explicit conversions.
 
 ### Implementing operators
 
@@ -290,7 +289,7 @@ A `checked operator` does not implement a `regular operator` and vice versa.
 
 ### Linq Expression Trees 
 
-`Checked operators` will be supported in Linq Expression Trees. A UnaryExpression/BinaryExpression node will be created with corresponding `MethodInfo`.
+`Checked operators` will be supported in Linq Expression Trees. A `UnaryExpression`/`BinaryExpression` node will be created with corresponding `MethodInfo`.
 The following factory methods will be used:
 ``` C#
 public static UnaryExpression NegateChecked (Expression expression, MethodInfo? method);
@@ -320,6 +319,10 @@ This adds additional complexity to the language and allows users to introduce mo
 [alternatives]: #alternatives
 
 The generic math interfaces that the libraries plans to expose could expose named methods (such as `AddChecked`). The primary drawback is that this is less readable/maintainable and doesn't get the benefit of the language precedence rules around operators.
+
+This section lists alternatives discussed, but not implemented
+
+<details>
 
 ### Placement of the `checked` keyword
 
@@ -460,22 +463,22 @@ public struct Int128
 #### Unary operator overload resolution
 
 Assuming that `regular operator` matches `unchecked` evaluation context, `checked operator` matches `checked` evaluation context
-and an operator that doesn't have `checked` form (for example, `+`) matches either context, the first bullet in https://github.com/dotnet/csharplang/blob/main/spec/expressions.md#unary-operator-overload-resolution:
->*  The set of candidate user-defined operators provided by `X` for the operation `operator op(x)` is determined using the rules of [Candidate user-defined operators](https://github.com/dotnet/csharplang/blob/main/spec/expressions.md#candidate-user-defined-operators).
+and an operator that doesn't have `checked` form (for example, `+`) matches either context, the first bullet in [§12.4.4 - Unary operator overload resolution](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1244-unary-overload-resolution):
+>*  The set of candidate user-defined operators provided by `X` for the operation `operator op(x)` is determined using the rules of [§12.4.6 - Candidate user-defined operators](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1246-candidate-user-defined-operators).
 
 will be replaced with the following two bullet points:
-*  The set of candidate user-defined operators provided by `X` for the operation `operator op(x)` **matching the current checked/unchecked context** is determined using the rules of [Candidate user-defined operators](https://github.com/dotnet/csharplang/blob/main/spec/expressions.md#candidate-user-defined-operators).
-*  If the set of candidate user-defined operators is not empty, then this becomes the set of candidate operators for the operation. Otherwise, the set of candidate user-defined operators provided by `X` for the operation `operator op(x)` **matching the opposite checked/unchecked context** is determined using the rules of [Candidate user-defined operators](https://github.com/dotnet/csharplang/blob/main/spec/expressions.md#candidate-user-defined-operators).
+*  The set of candidate user-defined operators provided by `X` for the operation `operator op(x)` **matching the current checked/unchecked context** is determined using the rules of [Candidate user-defined operators](https://github.com/dotnet/csharpstandard/blob/draft-v8/expressions.md#1246-candidate-user-defined-operators).
+*  If the set of candidate user-defined operators is not empty, then this becomes the set of candidate operators for the operation. Otherwise, the set of candidate user-defined operators provided by `X` for the operation `operator op(x)` **matching the opposite checked/unchecked context** is determined using the rules of [§12.4.6 - Candidate user-defined operators](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1246-candidate-user-defined-operators).
 
 #### Binary operator overload resolution
 
 Assuming that `regular operator` matches `unchecked` evaluation context, `checked operator` matches `checked` evaluation context
-and an operator that doesn't have a `checked` form (for example, `%`) matches either context, the first bullet in https://github.com/dotnet/csharplang/blob/main/spec/expressions.md#binary-operator-overload-resolution:
->*  The set of candidate user-defined operators provided by `X` and `Y` for the operation `operator op(x,y)` is determined. The set consists of the union of the candidate operators provided by `X` and the candidate operators provided by `Y`, each determined using the rules of [Candidate user-defined operators](https://github.com/dotnet/csharplang/blob/main/spec/expressions.md#candidate-user-defined-operators). If `X` and `Y` are the same type, or if `X` and `Y` are derived from a common base type, then shared candidate operators only occur in the combined set once.
+and an operator that doesn't have a `checked` form (for example, `%`) matches either context, the first bullet in [§12.4.5 - Binary operator overload resolution](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1245-binary-overload-resolution):
+>*  The set of candidate user-defined operators provided by `X` and `Y` for the operation `operator op(x,y)` is determined. The set consists of the union of the candidate operators provided by `X` and the candidate operators provided by `Y`, each determined using the rules of [§12.4.6 - Candidate user-defined operators](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1246-candidate-user-defined-operators). If `X` and `Y` are the same type, or if `X` and `Y` are derived from a common base type, then shared candidate operators only occur in the combined set once.
 
 will be replaced with the following two bullet points:
-*  The set of candidate user-defined operators provided by `X` and `Y` for the operation `operator op(x,y)` **matching the current checked/unchecked context** is determined. The set consists of the union of the candidate operators provided by `X` and the candidate operators provided by `Y`, each determined using the rules of [Candidate user-defined operators](https://github.com/dotnet/csharplang/blob/main/spec/expressions.md#candidate-user-defined-operators). If `X` and `Y` are the same type, or if `X` and `Y` are derived from a common base type, then shared candidate operators only occur in the combined set once.
-*  If the set of candidate user-defined operators is not empty, then this becomes the set of candidate operators for the operation. Otherwise, the set of candidate user-defined operators provided by `X` and `Y` for the operation `operator op(x,y)` **matching the opposite checked/unchecked context** is determined. The set consists of the union of the candidate operators provided by `X` and the candidate operators provided by `Y`, each determined using the rules of [Candidate user-defined operators](https://github.com/dotnet/csharplang/blob/main/spec/expressions.md#candidate-user-defined-operators). If `X` and `Y` are the same type, or if `X` and `Y` are derived from a common base type, then shared candidate operators only occur in the combined set once.
+*  The set of candidate user-defined operators provided by `X` and `Y` for the operation `operator op(x,y)` **matching the current checked/unchecked context** is determined. The set consists of the union of the candidate operators provided by `X` and the candidate operators provided by `Y`, each determined using the rules of [§12.4.6 - Candidate user-defined operators](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1246-candidate-user-defined-operators). If `X` and `Y` are the same type, or if `X` and `Y` are derived from a common base type, then shared candidate operators only occur in the combined set once.
+*  If the set of candidate user-defined operators is not empty, then this becomes the set of candidate operators for the operation. Otherwise, the set of candidate user-defined operators provided by `X` and `Y` for the operation `operator op(x,y)` **matching the opposite checked/unchecked context** is determined. The set consists of the union of the candidate operators provided by `X` and the candidate operators provided by `Y`, each determined using the rules of [§12.4.6 - Candidate user-defined operators](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1246-candidate-user-defined-operators). If `X` and `Y` are the same type, or if `X` and `Y` are derived from a common base type, then shared candidate operators only occur in the combined set once.
 
 ##### Example #1:
 ``` C#
@@ -664,7 +667,7 @@ class C2 : C1
 #### Processing of user-defined explicit conversions 
 
 Assuming that `regular operator` matches `unchecked` evaluation context and `checked operator` matches `checked` evaluation context,
-the third bullet in https://github.com/dotnet/csharplang/blob/main/spec/conversions.md#processing-of-user-defined-explicit-conversions:
+the third bullet in [§10.5.3 Evaluation of user-defined conversions](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#1053-evaluation-of-user-defined-conversions):
 >*  Find the set of applicable user-defined and lifted conversion operators, `U`. This set consists of the user-defined and lifted implicit or explicit conversion operators declared by the classes or structs in `D` that convert from a type encompassing or encompassed by `S` to a type encompassing or encompassed by `T`. If `U` is empty, the conversion is undefined and a compile-time error occurs.
 
 will be replaced with the following bullet points:
@@ -676,32 +679,32 @@ will be replaced with the following bullet points:
 
 #### Unary operator overload resolution
 
-The first bullet in section [§11.4.4](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1144-unary-operator-overload-resolution) will be adjusted as follows (additions are in bold).
+The first bullet in section [§12.4.4](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1244-unary-operator-overload-resolution) will be adjusted as follows (additions are in bold).
 *  The set of candidate user-defined operators provided by `X` for the operation `operator op(x)` is determined using the rules of "Candidate user-defined operators" section below. **If the set contains at least one operator in checked form, all operators in regular form are removed from the set.**
 
-The section [§11.7.18](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11718-the-checked-and-unchecked-operators) will be adjusted to reflect the effect that the checked/unchecked context has on unary operator overload resolution.
+The section [§12.8.20](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12820-the-checked-and-unchecked-operators) will be adjusted to reflect the effect that the checked/unchecked context has on unary operator overload resolution.
 
 #### Binary operator overload resolution
 
-The first bullet in section [§11.4.5](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1145-binary-operator-overload-resolution) will be adjusted as follows (additions are in bold).
+The first bullet in section [§12.4.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1245-binary-operator-overload-resolution) will be adjusted as follows (additions are in bold).
 *  The set of candidate user-defined operators provided by `X` and `Y` for the operation `operator op(x,y)` is determined. The set consists of the union of the candidate operators provided by `X` and the candidate operators provided by `Y`, each determined using the rules of "Candidate user-defined operators" section below. If `X` and `Y` are the same type, or if `X` and `Y` are derived from a common base type, then shared candidate operators only occur in the combined set once. **If the set contains at least one operator in checked form, all operators in regular form are removed from the set.**
 
-The Checked and unchecked operators [§11.7.18](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11718-the-checked-and-unchecked-operators) section will be adjusted to reflect the effect that the checked/unchecked context has on binary operator overload resolution.
+The Checked and unchecked operators [§12.8.20](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12820-the-checked-and-unchecked-operators) section will be adjusted to reflect the effect that the checked/unchecked context has on binary operator overload resolution.
 
 #### Candidate user-defined operators
 
-The https://github.com/dotnet/csharplang/blob/main/spec/expressions.md#candidate-user-defined-operators section will be adjusted as follows (additions are in bold).
+The [§12.4.6 - Candidate user-defined operators](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1246-candidate-user-defined-operators) section will be adjusted as follows (additions are in bold).
 
 Given a type `T` and an operation `operator op(A)`, where `op` is an overloadable operator and `A` is an argument list, the set of candidate user-defined operators provided by `T` for `operator op(A)` is determined as follows:
 
 *  Determine the type `T0`. If `T` is a nullable type, `T0` is its underlying type, otherwise `T0` is equal to `T`.
-*  For all `operator op` declarations **in their checked and regular forms in `checked` evaluation context and only in their regular form in `unchecked` evaluation context** in `T0` and all lifted forms of such operators, if at least one operator is applicable ([Applicable function member](https://github.com/dotnet/csharplang/blob/main/spec/expressions.md#applicable-function-member)) with respect to the argument list `A`, then the set of candidate operators consists of all such applicable operators in `T0`.
+*  For all `operator op` declarations **in their checked and regular forms in `checked` evaluation context and only in their regular form in `unchecked` evaluation context** in `T0` and all lifted forms of such operators, if at least one operator is applicable ([§12.6.4.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12642-applicable-function-member)) with respect to the argument list `A`, then the set of candidate operators consists of all such applicable operators in `T0`.
 *  Otherwise, if `T0` is `object`, the set of candidate operators is empty.
 *  Otherwise, the set of candidate operators provided by `T0` is the set of candidate operators provided by the direct base class of `T0`, or the effective base class of `T0` if `T0` is a type parameter.
 
 Similar filtering will be applied while determining the set of candidate operators in interfaces https://github.com/dotnet/csharplang/blob/main/meetings/2017/LDM-2017-06-27.md#shadowing-within-interfaces.
 
-The https://github.com/dotnet/csharplang/blob/main/spec/expressions.md#the-checked-and-unchecked-operators section will be adjusted to reflect the effect that the checked/unchecked context has on unary and binary operator overload resolution.
+The [§12.8.20](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12820-the-checked-and-unchecked-operators) section will be adjusted to reflect the effect that the checked/unchecked context has on unary and binary operator overload resolution.
 
 ##### Example #1:
 ``` C#
@@ -888,7 +891,7 @@ class C2 : C1
 ```
 #### Processing of user-defined explicit conversions 
 
-The third bullet in [§10.5.5](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/conversions.md#1055-user-defined-explicit-conversions):
+The third bullet in [§10.5.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#1055-user-defined-explicit-conversions):
 >*  Find the set of applicable user-defined and lifted conversion operators, `U`. This set consists of the user-defined and lifted implicit or explicit conversion operators declared by the classes or structs in `D` that convert from a type encompassing or encompassed by `S` to a type encompassing or encompassed by `T`. If `U` is empty, the conversion is undefined and a compile-time error occurs.
 
 will be replaced with the following bullet points:
@@ -896,11 +899,13 @@ will be replaced with the following bullet points:
 *  If `U0` contains at least one operator in checked form, all operators in regular form are removed from the set.
 *  Find the set of applicable user-defined and lifted conversion operators, `U`. This set consists of operators from `U0`, and the user-defined and lifted implicit conversion operators declared by the classes or structs in `D` that convert from a type encompassing or encompassed by `S` to a type encompassing or encompassed by `T`. If `U` is empty, the conversion is undefined and a compile-time error occurs.
 
-The Checked and unchecked operators [§11.7.18](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11718-the-checked-and-unchecked-operators) section will be adjusted to reflect the effect that the checked/unchecked context has on processing of user-defined explicit conversions.
+The Checked and unchecked operators [§12.8.20](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12820-the-checked-and-unchecked-operators) section will be adjusted to reflect the effect that the checked/unchecked context has on processing of user-defined explicit conversions.
 
 ### Checked vs. unchecked context within a `checked operator`
 
 The compiler could treat the default context of a `checked operator` as checked. The developer would need to explicitly use `unchecked` if part of their algorithm should not participate in the `checked context`. However, this might not work well in the future if we start allowing `checked`/`unchecked` tokens as modifiers on operators to set the context within the body. The modifier and the keyword could contradict each other. Also, we wouldn't be able to do the same (treat default context as unchecked) for a `regular operator` because that would be a breaking change.
+
+</details>
 
 ## Unresolved questions
 [unresolved]: #unresolved-questions
@@ -910,14 +915,14 @@ This would allow removing nesting levels for methods that require it.
 
 ### Checked division in Linq Expression Trees
 
-There is no factory method to create a checked division node and there is no ```ExpressionType.DivideChecked``` member.
-We could still use the following factory method to create regular divide node with ```MethodInfo``` pointing to the `op_CheckedDivision` method.
+There is no factory method to create a checked division node and there is no `ExpressionType.DivideChecked` member.
+We could still use the following factory method to create regular divide node with `MethodInfo` pointing to the `op_CheckedDivision` method.
 Consumers will have to check the name to infer the context.
 ``` C#
 public static BinaryExpression Divide (Expression left, Expression right, MethodInfo? method);
 ```
 
-Note, even though [§11.7.18](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11718-the-checked-and-unchecked-operators) section
+Note, even though [§12.8.20](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12820-the-checked-and-unchecked-operators) section
 lists `/` operator as one of the operators affected by checked/unchecked evaluation context, IL doesn't have a special op code to perform checked division.
 Compiler always uses the factory method reardless of the context today.
 

--- a/proposals/csharp-11.0/extended-nameof-scope.md
+++ b/proposals/csharp-11.0/extended-nameof-scope.md
@@ -29,11 +29,11 @@ A method declaration creates a separate declaration space for parameters, type p
 Within the block of a method, formal parameters can be referenced by their identifiers in simple_name expressions (Simple names).
 **Within a `nameof` expression in attributes placed on the method or its parameters, formal parameters can be referenced by their identifiers in *simple_name* expressions.**
 
-[Anonymous function signatures](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11162-anonymous-function-signatures)
+[Anonymous function signatures](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12192-anonymous-function-signatures)
 
 The scope of the parameters of the anonymous function is the anonymous_function_body (§7.7) **and `nameof` expressions in attributes placed on the anonymous function or its parameters**.
 
-[Delegate declarations](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/delegates.md#192-delegate-declarations)
+[Delegate declarations](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/delegates.md#202-delegate-declarations)
 
 **The scope of the parameters of the delegate is `nameof` expressions in attributes placed on the declaration, its type parameters or its parameters**.
 

--- a/proposals/csharp-11.0/file-local-types.md
+++ b/proposals/csharp-11.0/file-local-types.md
@@ -39,11 +39,11 @@ Our primary motivation is from source generators. Source generators work by addi
 [design]: #detailed-design
 
 - We add the `file` modifier to the following modifier sets:
-  - [class](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/classes.md#1422-class-modifiers)
-  - [struct](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/structs.md#1522-struct-modifiers)
-  - [interface](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/interfaces.md#1722-interface-modifiers)
-  - [enum](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/enums.md#183-enum-modifiers)
-  - [delegate](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/delegates.md#192-delegate-declarations)
+  - [class](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#1536-class-modifiers)
+  - [struct](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/structs.md#1622-struct-modifiers)
+  - [interface](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/interfaces.md#1822-interface-modifiers)
+  - [enum](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/enums.md#193-enum-modifiers)
+  - [delegate](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/delegates.md#202-delegate-declarations)
   - record
   - record struct.
 - The `file` modifier can only be used on a top-level type.
@@ -51,7 +51,7 @@ Our primary motivation is from source generators. Source generators work by addi
 When a type has the `file` modifier, it is said to be a *file-local* type.
 
 ### Accessibility
-No accessibility modifiers can be used in combination with `file` on a type. `file` is treated as an independent concept from accessibility. Since file-local types can't be nested, only the default accessibility `internal` is usable with `file` types.
+The `file` modifier is not classified as an accessibility modifier. No accessibility modifiers can be used in combination with `file` on a type. `file` is treated as an independent concept from accessibility. Since file-local types can't be nested, only the default accessibility `internal` is usable with `file` types.
 
 ```cs
 public file class C1 { } // error
@@ -63,9 +63,9 @@ file class C3 { } // ok
 The implementation guarantees that file-local types in different files with the same name will be distinct to the runtime. The type's accessibility and name in metadata is implementation-defined. The intention is to permit the compiler to adopt any future access-limitation features in the runtime which are suited to the feature. It's expected that in the initial implementation, an `internal` accessibility would be used and an unspeakable generated name will be used which depends on the file the type is declared in.
 
 ### Lookup
-We amend the [member lookup](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#115-member-lookup) section as follows (new text in **bold**):
+We amend the [member lookup](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#125-member-lookup) section as follows (new text in **bold**):
 
-> - Next, if `K` is zero, all nested types whose declarations include type parameters are removed. If `K` is not zero, all members with a different number of type parameters are removed. When `K` is zero, methods having type parameters are not removed, since the type inference process ([§11.6.3](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#1163-type-inference)) might be able to infer the type arguments.
+> - Next, if `K` is zero, all nested types whose declarations include type parameters are removed. If `K` is not zero, all members with a different number of type parameters are removed. When `K` is zero, methods having type parameters are not removed, since the type inference process ([§11.6.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1263-type-inference)) might be able to infer the type arguments.
 > - **Next, let *F* be the compilation unit which contains the expression where member lookup is occurring. All members which are file-local types and are not declared in *F* are removed from the set.**
 > - **Next, if the set of accessible members contains file-local types, all members which are not file-local types are removed from the set.**
 
@@ -97,7 +97,7 @@ class Program
 }
 ```
 
-Note that we don't update the [scopes](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/basic-concepts.md#77-scopes) section of the spec. This is because, as the spec states:
+Note that we don't update the [scopes](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/basic-concepts.md#77-scopes) section of the spec. This is because, as the spec states:
 
 > The ***scope*** of a name is the region of program text within which it is possible to refer to the entity declared by the name without qualification of the name.
 
@@ -180,7 +180,7 @@ public class Derived : FileBase // error
 
 file class FileDerived : FileBase // ok
 {
-    private FileBase M2() => new FileBase() // ok
+    private FileBase M2() => new FileBase(); // ok
 }
 ```
 

--- a/proposals/csharp-11.0/generic-attributes.md
+++ b/proposals/csharp-11.0/generic-attributes.md
@@ -15,10 +15,10 @@ Currently attribute authors can take a `System.Type` as a parameter and have use
 ## Detailed design
 [design]: #detailed-design
 
-The following section is amended: [§14.2.4.2](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/classes.md#14242-base-classes)
+The following section is amended: [§15.2.4.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#15242-base-classes)
 > The direct base class of a class type must not be any of the following types: System.Array, System.Delegate, System.MulticastDelegate, System.Enum, or System.ValueType. ~~Furthermore, a generic class declaration cannot use System.Attribute as a direct or indirect base class.~~
 
-One important note is that the following section of the spec is *unaffected* when referencing the point of usage of an attribute, i.e. within an attribute list: Type parameters - [§8.5](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/types.md#85-type-parameters).
+One important note is that the following section of the spec is *unaffected* when referencing the point of usage of an attribute, i.e. within an attribute list: Type parameters - [§8.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/types.md#85-type-parameters).
 
 > A type parameter cannot be used anywhere within an attribute.
 

--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -9,7 +9,6 @@ This proposal is an aggregation of several different proposals for `struct` perf
 
 Not all the features outlined in this document have been implemented in C# 11. C# 11 includes:
 
-
 1. `ref` fields and `scoped`
 1. `[UnscopedRef]`
 

--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -7,6 +7,17 @@ This proposal is an aggregation of several different proposals for `struct` perf
 
 > Note: Previous versions of this spec used the terms "ref-safe-to-escape" and "safe-to-escape", which were introduced in the [Span safety](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-7.2/span-safety.md) feature specification. The [ECMA standard committee](https://www.ecma-international.org/task-groups/tc49-tg2/) changed the names to ["ref-safe-context"](https://learn.microsoft.com/dotnet/csharp/language-reference/language-specification/variables#972-ref-safe-contexts) and ["safe-context"](https://learn.microsoft.com/dotnet/csharp/language-reference/language-specification/structs#16412-safe-context-constraint), respectively. The values of the safe context have been refined to use "declaration-block", "function-member", and "caller-context" consistently. The speclets had used different phrasing for these terms, and also used "safe-to-return" as a synonym for "caller-context". This speclet has been updated to use the terms in the C# 7.3 standard.
 
+Not all the features outlined in this document have been implemented in C# 11. C# 11 includes:
+
+
+1. `ref` fields and `scoped`
+1. `[UnscopedRef]`
+
+These features remain open proposals for a future version of C#:
+
+1. `ref` fields to `ref struct`
+1. Sunset restricted types
+
 ## Motivation
 Earlier versions of C# added a number of low level performance features to the language: `ref` returns, `ref struct`, function pointers, etc. ... These enabled .NET developers to write highly performant code while continuing to leverage the C# language rules for type and memory safety.  It also allowed the creation of fundamental performance types in the .NET libraries like `Span<T>`.
 
@@ -310,7 +321,7 @@ Together these changes mean the argument to an `out` parameter does not contribu
 The *safe-context* of a declaration variable from an `out` argument (`M(x, out var y)`) or deconstruction (`(var x, var y) = M()`) is the *narrowest* of the following:
 * caller-context
 * if out variable is marked `scoped`, then *declaration-block* (i.e. function-member or narrower).
-* if out variable's type is ref struct, consider all arguments to the containing invocation, including the receiver:
+* if out variable's type is `ref struct`, consider all arguments to the containing invocation, including the receiver:
   * *safe-context* of any argument where its corresponding parameter is not `out` and has *safe-context* of *return-only* or wider
   * *ref-safe-context* of any argument where its corresponding parameter has *ref-safe-context* of *return-only* or wider
     
@@ -429,7 +440,7 @@ var x = new S(ref heapSpan)
 }
 
 // Can be modeled as 
-var x = new S(ref heapSpan, stackSpan)
+var x = new S(ref heapSpan, stackSpan);
 ```
 
 This modeling is important because it demonstrates that our [MAMM](#rules-method-arguments-must-match) need to account specially for member initializers. Consider that this particular case needs to be illegal as it allows for a value with a narrower *safe-context* to be assigned to a higher one.
@@ -500,7 +511,7 @@ Detailed Notes:
     - The `langversion` value is 11 or higher
 
 ### Syntax
-[12.6.2 Local variable declarations](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/statements.md#1262-local-variable-declarations): added `'scoped'?`.
+[13.6.2 Local variable declarations](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/statements.md#1362-local-variable-declarations): added `'scoped'?`.
 ```antlr
 local_variable_declaration
     : 'scoped'? local_variable_mode_modifier? local_variable_type local_variable_declarators
@@ -511,9 +522,9 @@ local_variable_mode_modifier
     ;
 ```
 
-[12.9.4 The `for` statement](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/statements.md#1294-the-for-statement): added `'scoped'?` _indirectly_ from `local_variable_declaration`.
+[13.9.4 The `for` statement](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/statements.md#1394-the-for-statement): added `'scoped'?` _indirectly_ from `local_variable_declaration`.
 
-[12.9.5 The `foreach` statement](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/statements.md#1295-the-foreach-statement): added `'scoped'?`.
+[13.9.5 The `foreach` statement](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/statements.md#1395-the-foreach-statement): added `'scoped'?`.
 ```antlr
 foreach_statement
     : 'foreach' '(' 'scoped'? local_variable_type identifier 'in' expression ')'
@@ -521,7 +532,7 @@ foreach_statement
     ;
 ```
 
-[11.6.2 Argument lists](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#1162-argument-lists): added `'scoped'?` for `out` declaration variable.
+[12.6.2 Argument lists](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1262-argument-lists): added `'scoped'?` for `out` declaration variable.
 ```antlr
 argument_value
     : expression
@@ -531,12 +542,12 @@ argument_value
     ;
 ```
 
-[--.-.- Deconstruction expressions](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md):
+[12.7 Deconstruction expressions](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#127-deconstruction):
 ```antlr
 [TBD]
 ```
 
-[14.6.2 Method parameters](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/classes.md#1462-method-parameters): added `'scoped'?` to `parameter_modifier`.
+[15.6.2 Method parameters](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#1562-method-parameters): added `'scoped'?` to `parameter_modifier`.
 ```antlr
 fixed_parameter
     : attributes? parameter_modifier? type identifier default_argument?
@@ -555,9 +566,9 @@ parameter_mode_modifier
     ;
 ```
 
-[19.2 Delegate declarations](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/delegates.md#192-delegate-declarations): added `'scoped'?` _indirectly_ from `fixed_parameter`.
+[20.2 Delegate declarations](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/delegates.md#202-delegate-declarations): added `'scoped'?` _indirectly_ from `fixed_parameter`.
 
-[11.16 Anonymous function expressions](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#1116-anonymous-function-expressions): added `'scoped'?`.
+[12.19 Anonymous function expressions](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1219-anonymous-function-expressions): added `'scoped'?`.
 ```antlr
 explicit_anonymous_function_parameter
     : 'scoped'? anonymous_function_parameter_modifier? type identifier
@@ -731,6 +742,8 @@ namespace System.Runtime.CompilerServices
 
 Safe fixed size buffers was not delivered in C# 11. This feature may be implemented in a future version of C#.
 
+<details>
+
 The language will relax the restrictions on fixed sized arrays such that they can be declared in safe code and the element type can be managed or unmanaged.  This will make types like the following legal:
 
 ```c#
@@ -764,9 +777,11 @@ This also has the added benefit that it will make `fixed` buffers easier to cons
 
 The backing storage for the buffer will be generated using the `[InlineArray]` attribute. This is a mechanism discussed in [issue 12320](https://github.com/dotnet/runtime/issues/12320) which allows specifically for the case of efficiently declaring sequence of fields of the same type. This particular issue is still under active discussion and the expectation is that the implementation of this feature will follow however that discussion goes.
 
+</details>
+
 ### Initializers with `ref` values in `new` and `with` expressions
 
-In section [11.7.15.3 Object initializers](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#117153-object-initializers), we update the grammar to:
+In section [12.8.17.3 Object initializers](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128173-object-initializers), we update the grammar to:
 
 ```antlr
 initializer_value
@@ -803,14 +818,14 @@ For a `new` expression with initializers, the initializer expressions count as a
 
 ## Changes in unsafe context
 
-Pointer types ([section 22.3](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/unsafe-code.md#223-pointer-types)) are extended to allow managed types as referent type.
+Pointer types ([section 23.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#233-pointer-types)) are extended to allow managed types as referent type.
 Such pointer types are written as a managed type followed by a `*` token. They produce a warning.
 
-The address-of operator ([section 22.6.5](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/unsafe-code.md#2265-the-address-of-operator)) is relaxed to accept a variable with a managed type as its operand.
+The address-of operator ([section 23.6.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#2365-the-address-of-operator)) is relaxed to accept a variable with a managed type as its operand.
 
-The `fixed` statement ([section 22.7](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/unsafe-code.md#227-the-fixed-statement)) is relaxed to accept _fixed_pointer_initializer_ that is the address of a variable of managed type `T` or that is an expression of an _array_type_ with elements of a managed type `T`.
+The `fixed` statement ([section 23.7](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#237-the-fixed-statement)) is relaxed to accept _fixed_pointer_initializer_ that is the address of a variable of managed type `T` or that is an expression of an _array_type_ with elements of a managed type `T`.
 
-The stack allocation initializer ([section 22.9](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/unsafe-code.md#229-stack-allocation)) is similarly relaxed.
+The stack allocation initializer ([section 12.8.22](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12822-stack-allocation)) is similarly relaxed.
 
 ## Considerations
 There are considerations other parts of the development stack should consider when evaluating this feature.
@@ -818,7 +833,7 @@ There are considerations other parts of the development stack should consider wh
 ### Compat Considerations
 <a name="compat-considerations">
 
-The challenge in this proposal is the compatibility implications this design has to our existing [span safety rules](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-7.2/span-safety.md), or [§9.7.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/variables.md#972-ref-safe-contexts). While those rules fully support the concept of a `ref struct` having `ref` fields they do not allow for APIs, other than `stackalloc`, to capture `ref` state that refers to the stack. The ref safe cpmtext rules have a [hard assumption](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-7.2/span-safety.md#span-constructor), or [§16.4.12.8](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/structs.md#164128-constructor-invocations) that a constructor of the form `Span(ref T value)` does not exist. That means the safety rules do not account for a `ref` parameter being able to escape as a `ref` field hence it allows for code like the following.
+The challenge in this proposal is the compatibility implications this design has to our existing [span safety rules](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-7.2/span-safety.md), or [§9.7.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/variables.md#972-ref-safe-contexts). While those rules fully support the concept of a `ref struct` having `ref` fields they do not allow for APIs, other than `stackalloc`, to capture `ref` state that refers to the stack. The ref safe context rules have a [hard assumption](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-7.2/span-safety.md#span-constructor), or [§16.4.12.8](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/structs.md#164128-constructor-invocations) that a constructor of the form `Span(ref T value)` does not exist. That means the safety rules do not account for a `ref` parameter being able to escape as a `ref` field hence it allows for code like the following.
 
 ```c#
 Span<int> CreateSpanOfInt()
@@ -1276,7 +1291,7 @@ ref struct Sneaky
 
     public void SelfAssign()
     {
-        // This pattern of ref reassign to fields on this inside instance methods is now
+        // This pattern of ref reassign to fields on this inside instance methods would now
         // completely legal.
         RefField = ref Field;
     }
@@ -1321,7 +1336,7 @@ Some thought was given to the idea of having `this` have different defaults base
 
  This minimizes compat breaks and maximizes flexibility but at the cost of complicating the story for customers. It also doesn't fully solve the problem because future features, like safe `fixed` buffers, require that a mutable `ref struct` have `ref` returns for fields which don't work by this design alone as it would fall into the `scoped ref` category. 
 
-**Decision** Keep `this` as `scoped ref`
+**Decision** Keep `this` as `scoped ref`. That means the preceding sneaky examples produce compiler errors.
 
 ### ref fields to ref struct
 This feature opens up a new set of ref safe context rules because it allows for a `ref` field to refer to a `ref struct`. This generic nature of `ByReference<T>` meant that up until now the runtime could not have such a construct. As a result all of our rules are written under the assumption this is not possible. The `ref` field feature is largely not about making new rules but codifying the existing rules in our system. Allowing `ref` fields to `ref struct` requires us to codify new rules because there are several new scenarios to consider.
@@ -1383,7 +1398,7 @@ Third the rules for ref reassignment need to be updated to ensure that we don't 
 
 These problems are very solvable. The compiler team has sketched out a few versions of these rules and they largely fall out from our existing analysis. The problem is there is no consuming code for such rules that helps prove out there correctness and usability. This makes us very hesitant to add support because of the fear we'll pick wrong defaults and back the runtime into usability corner when it does take advantage of this. This concern is particularly strong because .NET 8 likely pushes us in this direction with `allow T: ref struct` and `Span<Span<T>>`. The rules would be better written if it's done in conjunction with consumption code.
 
-**Decision** Delay allowing `ref` field to `ref struct` until .NET 8 where we have scenarios that will help drive the rules around these scenarios.
+**Decision** Delay allowing `ref` field to `ref struct` until .NET 8 where we have scenarios that will help drive the rules around these scenarios. This has not been implemented as of .NET 9
 
 ### What will make C# 11.0?
 The features outlined in this document don't need to be implemented in a single pass. Instead they can be implemented in phases across several language releases in the following buckets:
@@ -1585,6 +1600,7 @@ void Example(ref Span<int> p)
     Span<int> local = stackalloc int[42];
     ref Span<int> refLocal = ref local;
 
+    // Error:
     // The safe-context of refLocal is narrower than p. For a non-ref reassignment 
     // this would be allowed as its safe to assign wider lifetimes to narrower ones.
     // In the case of ref reassignment though this rule prevents it as the 
@@ -1758,6 +1774,7 @@ readonly ref struct S
     public S()
     {
         i = 0;
+        // Error: `i` has a narrower scope than `r`
         r = ref i;
     }
 
@@ -1765,6 +1782,7 @@ readonly ref struct S
     {
         r++;
     }
+}
 ```
 
 The proposal prevents this though because it violates the ref safe context rules. Consider the following:
@@ -1788,6 +1806,7 @@ ref struct S
 
     static void SelfAssign(ref S s)
     {
+        // Error: s.field can only escape the current method through a return statement
         s.refField = ref s.field;
     }
 }
@@ -1929,7 +1948,7 @@ One subtle design question is: How are constructors bodies modeled for ref safet
 ```c#
 ref struct S
 {
-    int field;
+    ref int field;
 
     public S(ref int f)
     {

--- a/proposals/csharp-11.0/new-line-in-interpolation.md
+++ b/proposals/csharp-11.0/new-line-in-interpolation.md
@@ -9,7 +9,7 @@
 ## Summary
 [summary]: #summary
 
-The language today non-verbatim and verbatim interpolated strings (`$""` and `$@""` respectively).  The primary *sensible* difference for these is that a non-verbatim interpolated string works like a normal string and cannot contain newlines in its text segments, and must instead use escapes (like `\r\n`).  Conversely, a verbatim interpolated string can contain newlines in its text segments (like a verbatim string), and doesn't escape newlines or other character (except for `""` to escape a quote itself).
+The language today treats non-verbatim and verbatim interpolated strings (`$""` and `$@""` respectively) differently.  The primary *sensible* difference for these is that a non-verbatim interpolated string works like a normal string and cannot contain newlines in its text segments, and must instead use escapes (like `\r\n`).  Conversely, a verbatim interpolated string can contain newlines in its text segments (like a verbatim string), and doesn't escape newlines or other character (except for `""` to escape a quote itself).
 
 This is all reasonable and will not change with this proposal.
 

--- a/proposals/csharp-11.0/numeric-intptr.md
+++ b/proposals/csharp-11.0/numeric-intptr.md
@@ -102,7 +102,7 @@ The explicit enumeration conversions are:
 - From any *enum_type* to `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, **`nint`, `nuint`**, `long`, `ulong`, `char`, `float`, `double`, or `decimal`.
 - From any *enum_type* to any other *enum_type*.
 
-#### 11.6.4.6 Better conversion target
+#### 12.6.4.7 Better conversion target
 
 Given two types `T₁` and `T₂`, `T₁` is a ***better conversion target*** than `T₂` if one of the following holds:
 
@@ -110,11 +110,11 @@ Given two types `T₁` and `T₂`, `T₁` is a ***better conversion target*** th
 - `T₁` is `Task<S₁>`, `T₂` is `Task<S₂>`, and `S₁` is a better conversion target than `S₂`
 - `T₁` is `S₁` or `S₁?` where `S₁` is a signed integral type, and `T₂` is `S₂` or `S₂?` where `S₂` is an unsigned integral type. Specifically: \[...]
 
-### 11.7.10 Element access
+### 12.8.12 Element access
 
 \[...] The number of expressions in the *argument_list* shall be the same as the rank of the *array_type*, and each expression shall be of type `int`, `uint`, **`nint`, `nuint`**, `long`, or `ulong,` or shall be implicitly convertible to one or more of these types.
 
-#### 11.7.10.2 Array access
+#### 11.8.12.2 Array access
 
 \[...] The number of expressions in the *argument_list* shall be the same as the rank of the *array_type*, and each expression shall be of type `int`, `uint`, **`nint`, `nuint`**, `long`, or `ulong,` or shall be implicitly convertible to one or more of these types.
 
@@ -122,11 +122,11 @@ Given two types `T₁` and `T₂`, `T₁` is a ***better conversion target*** th
 \[...]
 - The index expressions of the *argument_list* are evaluated in order, from left to right. Following evaluation of each index expression, an implicit conversion to one of the following types is performed: `int`, `uint`, **`nint`, `nuint`**, `long`, `ulong`. The first type in this list for which an implicit conversion exists is chosen. \[...]
 
-### 11.7.14 Postfix increment and decrement operators
+### 12.8.16 Postfix increment and decrement operators
 
 Unary operator overload resolution is applied to select a specific operator implementation. Predefined `++` and `--` operators exist for the following types: `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, **`nint`, `nuint`,** `long`, `ulong`, `char`, `float`, `double`, `decimal`, and any enum type.
 
-### 11.8.2 Unary plus operator
+### 12.9.2 Unary plus operator
 
 The predefined unary plus operators are:
 
@@ -136,7 +136,7 @@ nint operator +(nint x);
 nuint operator +(nuint x);
 ```
 
-### 11.8.3 Unary minus operator
+### 12.9.3 Unary minus operator
 
 The predefined unary minus operators are:
 
@@ -147,7 +147,7 @@ The predefined unary minus operators are:
   nint operator –(nint x);
   ```  
 
-### 11.7.14 Postfix increment and decrement operators
+### 12.8.16 Postfix increment and decrement operators
 
 Predefined `++` and `--` operators exist for the following types: `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, **`nint`, `nuint`**, `long`, `ulong`, `char`, `float`, `double`, `decimal`, and any enum type.
 
@@ -155,7 +155,7 @@ Predefined `++` and `--` operators exist for the following types: `sbyte`, `byte
 
 In addition, a *default_value_expression* is a constant expression if the type is one of the following value types: `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, **`nint`, `nuint`**, `long`, `ulong`, `char`, `float`, `double`, `decimal`, `bool,` or any enumeration type.
 
-### 11.8.5 Bitwise complement operator
+### 12.9.5 Bitwise complement operator
 
 The predefined bitwise complement operators are:
 
@@ -165,13 +165,13 @@ nint operator ~(nint x);
 nuint operator ~(nuint x);
 ```
 
-### 11.8.6 Prefix increment and decrement operators
+### 12.9.6 Prefix increment and decrement operators
 
 Predefined `++` and `--` operators exist for the following types: `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, **`nint`, `nuint`**, `long`, `ulong`, `char`, `float`, `double`, `decimal`, and any enum type.
 
-## 11.9 Arithmetic operators
+## 12.10 Arithmetic operators
 
-### 11.9.2 Multiplication operator
+### 12.10.2 Multiplication operator
 
 The predefined multiplication operators are listed below. The operators all compute the product of `x` and `y`.
 
@@ -183,7 +183,7 @@ The predefined multiplication operators are listed below. The operators all comp
   nuint operator *(nuint x, nuint y);
   ```
 
-### 11.9.3 Division operator
+### 12.10.3 Division operator
 
 The predefined division operators are listed below. The operators all compute the quotient of `x` and `y`.
 
@@ -195,7 +195,7 @@ The predefined division operators are listed below. The operators all compute th
   nuint operator /(nuint x, nuint y);
   ```
 
-### 11.9.4 Remainder operator
+### 12.10.4 Remainder operator
 
 The predefined remainder operators are listed below. The operators all compute the remainder of the division between `x` and `y`.
 
@@ -207,7 +207,7 @@ The predefined remainder operators are listed below. The operators all compute t
   nuint operator %(nuint x, nuint y);
   ```
 
-### 11.9.5 Addition operator
+### 12.10.5 Addition operator
 
 - Integer addition:
 
@@ -217,7 +217,7 @@ The predefined remainder operators are listed below. The operators all compute t
   nuint operator +(nuint x, nuint y);
   ```
 
-### 11.9.6 Subtraction operator
+### 12.10.6 Subtraction operator
 
 - Integer subtraction:
 
@@ -227,7 +227,7 @@ The predefined remainder operators are listed below. The operators all compute t
   nuint operator –(nuint x, nuint y);
   ```
 
-## 11.10 Shift operators
+## 12.11 Shift operators
 
 The predefined shift operators are listed below.
 
@@ -266,9 +266,9 @@ For the predefined operators, the number of bits to shift is computed as follows
 - When the type of `x` is `nint` or `nuint`, the shift count is given by the low-order five bits of `count` on a 32 bit platform, or the lower-order six bits of `count` on a 64 bit platform.  
 
 
-## 11.11 Relational and type-testing operators
+## 12.12 Relational and type-testing operators
 
-### 11.11.2 Integer comparison operators
+### 12.12.2 Integer comparison operators
 
 The predefined integer comparison operators are:
 
@@ -293,9 +293,9 @@ bool operator >=(nint x, nint y);
 bool operator >=(nuint x, nuint y);
 ```
 
-## 11.12 Logical operators
+## 12.12 Logical operators
 
-### 11.12.2 Integer logical operators
+### 12.12.2 Integer logical operators
 
 The predefined integer logical operators are:
 
@@ -311,7 +311,7 @@ nint operator ^(nint x, nint y);
 nuint operator ^(nuint x, nuint y);
 ```
 
-## 11.20 Constant expressions
+## 12.22 Constant expressions
 
 A constant expression may be either a value type or a reference type. If a constant expression is a value type, it must be one of the following types: `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, **`nint`, `nuint`**, `long`, `ulong`, `char`, `float`, `double`, `decimal`, `bool,` or any enumeration type.
 
@@ -319,13 +319,13 @@ A constant expression may be either a value type or a reference type. If a const
 
 An implicit constant expression conversion permits a constant expression of type `int` to be converted to `sbyte`, `byte`, `short`, `ushort`, `uint`, **`nint`, `nuint`,** or `ulong`, provided the value of the constant expression is within the range of the destination type.
 
-## 16.4 Array element access
+## 17.4 Array element access
 
 Array elements are accessed using *element_access* expressions of the form `A[I₁, I₂, ..., Iₓ]`, where `A` is an expression of an array type and each `Iₑ` is an expression of type `int`, `uint`, **`nint`, `nuint`,** `long`, `ulong`, or can be implicitly converted to one or more of these types. The result of an array element access is a variable, namely the array element selected by the indices.
 
-## 22.5 Pointer conversions
+## 23.5 Pointer conversions
 
-### 22.5.1 General
+### 23.5.1 General
 
 \[...]
 
@@ -335,12 +335,12 @@ Additionally, in an unsafe context, the set of available explicit conversions is
 - From `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, **`nint`, `nuint`,** `long`, or `ulong` to any *pointer_type*.
 - From any *pointer_type* to `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, **`nint`, `nuint`,** `long`, or `ulong`.
 
-### 22.6.4 Pointer element access
+### 23.6.4 Pointer element access
 
 \[...]
 In a pointer element access of the form `P[E]`, `P` shall be an expression of a pointer type other than `void*`, and `E` shall be an expression that can be implicitly converted to `int`, `uint`, **`nint`, `nuint`,** `long`, or `ulong`.
 
-### 22.6.7 Pointer arithmetic
+### 23.6.7 Pointer arithmetic
 
 In an unsafe context, the `+` operator and `–` operator can be applied to values of all pointer types except `void*`. Thus, for every pointer type `T*`, the following operators are implicitly defined:
 

--- a/proposals/csharp-11.0/pattern-match-span-of-char-on-string.md
+++ b/proposals/csharp-11.0/pattern-match-span-of-char-on-string.md
@@ -109,6 +109,8 @@ None
 
     _Recommendation: No implicit runtime type test for constant pattern. (`IsABC<T>()` example is allowed because the type test is explicit.)_
 
+    **This recommendation was not implemented. All of the preceding samples produce a compiler error.**
+
 4. Should subsumption consider constant string patterns, list patterns, and `Length` property pattern?
     ```csharp
     static int ToNum(ReadOnlySpan<char> s)

--- a/proposals/csharp-11.0/raw-string-literal.md
+++ b/proposals/csharp-11.0/raw-string-literal.md
@@ -66,14 +66,14 @@ var json = $$"""
                 "summary": "text",
                 "length" : {{value.Length}},
              };
-             """
+             """;
 ```
 
 ## Motivation
 
 C# lacks a general way to create simple string literals that can contain effectively any arbitrary text.  All C# string literal forms today need some form of escaping in case the contents use some special character (always if a delimiter is used).  This prevents easily having literals containing other languages in them (for example, an XML, HTML or JSON literal).  
 
-All current approaches to form these literals in C# today always force the user to manually escape the contents.  Editing at that point can be highly annoying as the escaping cannot be avoided and must be dealt with whenever it arises in the contents.  This is particularly painful for regexes, especially when they contain quotes or backslashes.  Even with a `@""` string, quotes themselves must be escaped leading to a mix of C# and regex interspersed. `{` and `}` are similarly frustrating in `$""` strings.
+All current approaches to form these literals in C# today always force the user to manually escape the contents.  Editing at that point can be highly annoying as the escaping cannot be avoided and must be dealt with whenever it arises in the contents.  This is particularly painful for regexes, especially when they contain quotes or backslashes.  Even with a verbatim (`@""`) string, quotes themselves must be escaped leading to a mix of C# and regex interspersed. `{` and `}` are similarly frustrating in interpolated (`$""`) strings.
 
 The crux of the problem is that all our strings have a fixed start/end delimiter.   As long as that is the case, we will always have to have an escaping mechanism as the string contents may need to specify that end delimiter in their contents.  This is particularly problematic as that delimiter `"` is exceedingly common in many languages.
 
@@ -82,7 +82,7 @@ To address this, this proposal allows for flexible start and end delimiters so t
 ## Goals
 
 1. Provide a mechanism that will allow *all* string values to be provided by the user without the need for *any* escape-sequences whatsoever.  Because all strings must be representable without escape-sequences, it must always be possible for the user to specify delimiters that will be guaranteed to not collide with any text contents.
-2. Support interpolations in the same fashion.  As above, because *all* strings must be representable without escapes, it must always be possible for the user to specify an `interpolation` delimiter that will be guaranteed to not collide with any text contents.  Importantly, languages that use our `interpolation` delimiter characters (`{` and `}`) should feel first-class and not painful to use.
+2. Support interpolations in the same fashion.  As above, because *all* strings must be representable without escapes, it must always be possible for the user to specify an `interpolation` delimiter that will be guaranteed to not collide with any text contents.  Importantly, languages that use our *interpolation* delimiter characters (`{` and `}`) should feel first-class and not painful to use.
 3. Multiline string literals should look pleasant in code and should not make indentation within the compilation unit look strange.  Importantly, literal values that themselves have no indentation should not be forced to occupy the first column of the file as that can break up the flow of code and will look unaligned with the rest of the code that surrounds it.
     * This behavior should be easy to override while keeping literals clear and easy to read.
 4. For all strings that do not themselves contain a `new_line` or start or end with a quote (`"`) character, it should be possible to represent the string literal itself on a single line.
@@ -163,7 +163,7 @@ The portions between the starting and ending `raw_string_literal_delimiter` are 
 ```
 var v1 = """
          This is the entire content of the string.
-         """
+         """;
 ```
 
 This maintains symmetry with how the starting `new_line` is ignored, and it also provides a uniform way to ensure the 'indentation whitespace' can always be adjusted. To represent a string with a terminal `new_line` an extra line must be provided like so:
@@ -172,7 +172,7 @@ This maintains symmetry with how the starting `new_line` is ignored, and it also
 var v1 = """
          This string ends with a new line.
 
-         """
+         """;
 ```
 
 3. A `single_line_raw_string_literal` cannot represent a string value that starts or ends with a quote (`"`) though an augmentation to this proposal is provided in the `Drawbacks` section that shows how that could be supported.
@@ -182,7 +182,7 @@ var v1 = """
 ```
 var v1 = """
          "The content of this string starts with a quote
-         """
+         """;
 ```
 
 5. A `raw_string_literal` can also represent content that end with a quote (`"`).  This is supported as the terminating delimiter must be on its own line. For example:
@@ -190,13 +190,13 @@ var v1 = """
 ```
 var v1 = """
          "The content of this string starts and ends with a quote"
-         """
+         """;
 ```
 
 ```
 var v1 = """
          ""The content of this string starts and ends with two quotes""
-         """
+         """;
 ```
 
 5. The requirement that a 'blank' `raw_content` be either a prefix of the 'indentation whitespace' or the 'indentation whitespace' must be a prefix of it helps ensure confusing scenarios with mixed whitespace do not occur, especially as it would be unclear what should happen with that line.  For example, the following case is illegal:
@@ -206,7 +206,7 @@ var v1 = """
          Start
 <tab>
          End
-         """
+         """;
 ```
 
 6. Here the 'indentation whitespace' is nine space characters, but the 'blank' `raw_content` does not start with a prefix of that.  There is no clear answer as to how that `<tab>` line should be treated at all.  Should it be ignored?  Should it be the same as `.........<tab>`?  As such, making it illegal seems the clearest for avoiding confusion.
@@ -218,7 +218,7 @@ var v1 = """
          Start
 <four spaces>
          End
-         """
+         """;
 ```
 
 ```
@@ -226,7 +226,7 @@ var v1 = """
          Start
 <nine spaces>
          End
-         """
+         """;
 ```
 
 In both these cases, the 'indentation whitespace' will be nine spaces.  And in both cases, we will remove as much of that prefix as possible, leading the 'blank' `raw_content` in each case to be empty (not counting every `new_line`).  This allows users to not have to see and potentially fret about whitespace on these lines when they copy/paste or edit these lines.
@@ -238,7 +238,7 @@ var v1 = """
          Start
 <ten spaces>
          End
-         """
+         """;
 ```
 
 The 'indentation whitespace' will still be nine spaces.  Here though, we will remove as much of the 'indentation whitespace' as possible, and the 'blank' `raw_content` will contribute a single space to the final content.  This allows for cases where the content does need whitespace on these lines that should be preserved.
@@ -247,7 +247,7 @@ The 'indentation whitespace' will still be nine spaces.  Here though, we will re
 
 ```
 var v1 = """
-         """
+         """;
 ```
 
 This is because the start of the raw string must have a `new_line` (which it does) but the end must have a `new_line` as well (which it does not).  The minimal legal `raw_string_literal` is:
@@ -255,14 +255,14 @@ This is because the start of the raw string must have a `new_line` (which it doe
 ```
 var v1 = """
 
-         """
+         """;
 ```
 
 However, this string is decidedly uninteresting as it is equivalent to `""`.
 
 ## Indentation examples
 
-The 'indentation whitespace' algorithm can be visualized on several inputs like so:
+The 'indentation whitespace' algorithm can be visualized on several inputs like so. The following examples use the vertical bar character `|` to illustrate the first column in the resultant raw string:
 
 ### Example 1 - Standard case
 ```
@@ -357,7 +357,7 @@ var xml = """
 ```
 
 
-### Example 5 - Blank line with less whitespace than prefix (dots represent spaces)
+### Example 6 - Blank line with less whitespace than prefix (dots represent spaces)
 ```
 var xml = """
           <element attr="content">
@@ -382,7 +382,7 @@ var xml = """
 
 
 
-### Example 5 - Blank line with more whitespace than prefix (dots represent spaces)
+### Example 7 - Blank line with more whitespace than prefix (dots represent spaces)
 ```
 var xml = """
           <element attr="content">
@@ -490,11 +490,11 @@ The above is similar to the definition of `raw_string_literal` but with some imp
     - A content line is any text except a `new_line`.
     - A content line can contain multiple `raw_interpolation` occurrences at any position.  The `raw_interpolation` must start with an equal number of open braces (`{`) as the number of dollar signs at the start of the literal.
     - If 'indentation whitespace' is not-empty, a `raw_interpolation` cannot immediately follow a `new_line`.
-    - The `raw_interpolation` will following the normal rules specified at [§11.7.3](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1173-interpolated-string-expressions).  Any `raw_interpolation` must end with the same number of close braces (`}`) as dollar signs and open braces.
+    - The `raw_interpolation` will following the normal rules specified at [§12.8.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1283-interpolated-string-expressions).  Any `raw_interpolation` must end with the same number of close braces (`}`) as dollar signs and open braces.
     - Any `interpolation` can itself contain new-lines within in the same manner as an `interpolation` in a normal `verbatim_string_literal` (`@""`).
     - It then ends with a `new_line` some number (possibly zero) of `whitespace` and the same number of quotes that the literal started with.
 
-Computation of the interpolated string value follows the same rules as a normal `raw_string_literal` except updated to handle lines containing `raw_interpolation`s.  Building the string value happens in the same fashion, just with the interpolation holes replaced with whatever values those expressions produce at runtime.  If the `interpolated_raw_string_literal` is converted to a `FormattableString` then the values of the interpolations are passed in their respective order to the `arguments` array to `FormattableString.Create`.  The rest of the content of the `interpolated_raw_string_literal` *after* the 'indentation whitespace' has been stripped from all lines will be used to generate `format` string passed to `FormattableString.Create`, except with appropriately numbered `{N}` contents in each location where a `raw_interpolation` occurred (or `{N,constant}` in the case if its `interpolation` is of the form `expression ',' constant_expression`).
+Computation of the interpolated string value follows the same rules as a normal `raw_string_literal` except updated to handle lines containing `raw_interpolation`s.  Building the string value happens in the same fashion, just with the interpolation holes replaced with whatever values those expressions produce at runtime.  If the `interpolated_raw_string_literal` is converted to a `FormattableString` then the values of the interpolations are passed in their respective order to the `arguments` array to `FormattableString.Create`.  The rest of the content of the `interpolated_raw_string_literal` *after* the 'indentation whitespace' has been stripped from all lines will be used to generate the `format` string passed to `FormattableString.Create`, except with appropriately numbered `{N}` contents in each location where a `raw_interpolation` occurred (or `{N,constant}` in the case if its `interpolation` is of the form `expression ',' constant_expression`).
 
 There is an ambiguity in the above specification.  Specifically when a section of `{` in text and `{` of an interpolation abut. For example:
 
@@ -506,13 +506,11 @@ var v1 = $$"""
 
 This could be interpreted as: `{{ {order_number } }}` or `{ {{order_number}} }`.  However, as the former is illegal (no C# expression could start with `{`) it would be pointless to interpret that way.  So we interpret in the latter fashion, where the innermost `{` and `}` braces form the interpolation, and any outermost ones form the text.  In the future this might be an issue if the language ever supports any expressions that are surrounded by braces.  However, in that case, the recommendation would be to write such a case like so: `{{({some_new_expression_form})}}`.  Here, parentheses would help designate the expression portion from the rest of the literal/interpolation.  This has precedence already with how ternary conditional expressions need to be wrapped to not conflict with the formatting/alignment specifier of an interpolation (e.g. `{(x ? y : z)}`).
 
-Examples: (upcoming)
-
 ## Drawbacks
 
 Raw string literals add more complexity to the language.  We already have many string literal forms already for numerous purposes.  `""` strings, `@""` strings, and `$""` strings already have a lot of power and flexibility.  But they all lack a way to provide raw contents that never need escaping.
 
-The above rules do not support the case of 4.a:
+The above rules do not support the case of [4.a](#goals):
 
 4. ...
     - Optionally, with extra complexity, we could refine this to state that: For all strings that do not themselves contain a `new_line` (but can start or end with a quote `"` character), it should be possible to represent the string literal itself on a single line.

--- a/proposals/csharp-11.0/relaxing_shift_operator_requirements.md
+++ b/proposals/csharp-11.0/relaxing_shift_operator_requirements.md
@@ -23,7 +23,7 @@ as the type is not well known and so the conversion to `int` may not be possible
 
 ### Shift operators
 
-[§11.10](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1110-shift-operators) should be reworded as follows:
+[§12.11](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1211-shift-operators) should be reworded as follows:
 ```diff
 - When declaring an overloaded shift operator, the type of the first operand must always be the class or struct containing the operator declaration,
 and the type of the second operand must always be int.
@@ -35,7 +35,7 @@ While the restriction that the second operand must be `int` is removed.
 
 ### Binary operators
 
-[§14.10.3](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/classes.md#14103-binary-operators) should be reworded as follows:
+[§14.10.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#15103-binary-operators) should be reworded as follows:
 ```diff
 -*  A binary `<<` or `>>` operator must take two parameters, the first of which must have type `T` or `T?` and the second of which must have type `int` or `int?`, and can return any type.
 +*  A binary `<<` or `>>` operator must take two parameters, the first of which must have type `T` or `T?`, and can return any type.
@@ -46,10 +46,10 @@ While the restriction that the second operand must be `int` or `int?` is removed
 
 ### Binary operator overload resolution
 
-The first bullet point at [§11.4.5](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1145-binary-operator-overload-resolution)
+The first bullet point at [§11.4.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1245-binary-operator-overload-resolution)
 should be reworded as follows:
 
-*  The set of candidate user-defined operators provided by `X` and `Y` for the operation `operator op(x,y)` is determined. The set consists of the union of the candidate operators provided by `X` and **, unless the operator is a shift operator,** the candidate operators provided by `Y`, each determined using the rules of Candidate user-defined operators [§11.4.6](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1146-candidate-user-defined-operators). If `X` and `Y` are the same type, or if `X` and `Y` are derived from a common base type, then shared candidate operators only occur in the combined set once.
+*  The set of candidate user-defined operators provided by `X` and `Y` for the operation `operator op(x,y)` is determined. The set consists of the union of the candidate operators provided by `X` and **, unless the operator is a shift operator,** the candidate operators provided by `Y`, each determined using the rules of Candidate user-defined operators [§11.4.6](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1246-candidate-user-defined-operators). If `X` and `Y` are the same type, or if `X` and `Y` are derived from a common base type, then shared candidate operators only occur in the combined set once.
 
 That is, for shift operators, candidate operators are only those provided by type `X`.
 

--- a/proposals/csharp-11.0/required-members.md
+++ b/proposals/csharp-11.0/required-members.md
@@ -61,7 +61,7 @@ As a workaround to avoid this duplication, we have long seen consumers embracing
 major downsides:
 
 1. The object hierarchy has to be fully mutable, with `set` accessors on every property.
-2. There is no way to ensure that every instantation of an object from the graph sets every member.
+2. There is no way to ensure that every instantiation of an object from the graph sets every member.
 
 C# 9 again addressed the first issue here, by introducing the `init` accessor: with it, these properties can be set on object creation/initialization, but not subsequently. However,
 we again still have the second issue: properties in C# have been optional since C# 1.0. Nullable reference types, introduced in C# 8.0, addressed part of this issue: if a constructor
@@ -346,7 +346,11 @@ _ = new Range { Start = new Location { Column = 0, Line = 0 }, End = new Locatio
 
 ### Level of enforcement for `init` clauses
 
-Do we strictly enforce that members specified in a `init` clause without an initializer must initialize all members? It seems likely that we do, otherwise we create an
+The `init` clause feature wasn't implemented in C# 11. It remains an active proposal.
+
+<details>
+
+Do we strictly enforce that members specified in an `init` clause without an initializer must initialize all members? It seems likely that we do, otherwise we create an
 easy pit-of-failure. However, we also run the risk of reintroducing the same problems we solved with `MemberNotNull` in C# 9. If we want to strictly enforce this, we
 will likely need a way for a helper method to indicate that it sets a member. Some possible syntaxes we've discussed for this:
 
@@ -362,6 +366,8 @@ to the init clause to indicate the compiler should not check for initialization.
 around init methods and annotating every method as setting members X or Y. `!` was chosen because we already use it for suppressing nullable warnings, and using it to
 tell the compiler "I'm smarter than you" in another place is a natural extension of the syntax form.
 
+</details>
+
 ### Required interface members
 
 This proposal does not allow interfaces to mark members as required. This protects us from having to figure out complex scenarios around `new()` and interface
@@ -370,6 +376,10 @@ forbid `required` in interfaces, and forbid types with _required\_member\_lists_
 take a broader look at generic construction scenarios with factories, we can revisit this issue.
 
 ### Syntax questions
+
+The `init` clause feature wasn't implemented in C# 11. It remains an active proposal.
+
+<details>
 
 * Is `init` the right word? `init` as a postfix modifier on the constructor might interfere if we ever want to reuse it for factories and also enable `init`
 methods with a prefix modifier. Other possibilities:
@@ -390,7 +400,13 @@ methods with a prefix modifier. Other possibilities:
 
 **Conclusion**: We have removed the `init` constructor clause for now, and are proceeding with `required` as the property modifier.
 
+</details>
+
 ### Init clause restrictions
+
+The `init` clause feature wasn't implemented in C# 11. It remains an active proposal.
+
+<details>
 
 Should we allow access to `this` in the init clause? If we want the assignment in `init` to be a shorthand for assigning the member in the constructor itself, it seems
 like we should.
@@ -400,7 +416,13 @@ functions, which the init clause may want to access, or for name shadowing, if a
 
 **Conclusion**: `init` clause has been removed.
 
+</details>
+
 ### Accessibility requirements and `init`
+
+The `init` clause feature wasn't implemented in C# 11. It remains an active proposal.
+
+<details>
 
 In versions of this proposal with the `init` clause, we talked about being able to have the following scenario:
 
@@ -433,6 +455,8 @@ only ever created via static `Create` methods or similar builders, but the utili
 previously.
 
 **Conclusion**: Option 1, all required members must be at least as visible as their containing type.
+
+</details>
 
 ### Override rules
 

--- a/proposals/csharp-11.0/static-abstracts-in-interfaces.md
+++ b/proposals/csharp-11.0/static-abstracts-in-interfaces.md
@@ -25,7 +25,7 @@ interface IAddable<T> where T : IAddable<T>
 // Classes and structs (including built-ins) can implement interface
 struct Int32 : …, IAddable<Int32>
 {
-    static Int32 I.operator +(Int32 x, Int32 y) => x + y; // Explicit
+    static Int32 IAddable.operator +(Int32 x, Int32 y) => x + y; // Explicit
     public static int Zero => 0;                          // Implicit
 }
 
@@ -47,8 +47,8 @@ int sixtyThree = AddAll(new [] { 1, 2, 4, 8, 16, 32 });
 
 The feature would allow static interface members to be declared virtual. 
 
-#### Today's rules
-Today, instance members in interfaces are implicitly abstract (or virtual if they have a default implementation), but can optionally have an `abstract` (or `virtual`) modifier. Non-virtual instance members must be explicitly marked as `sealed`. 
+#### Rules before C# 11
+Before C# 11, instance members in interfaces are implicitly abstract (or virtual if they have a default implementation), but can optionally have an `abstract` (or `virtual`) modifier. Non-virtual instance members must be explicitly marked as `sealed`. 
 
 Static interface members today are implicitly non-virtual, and do not allow `abstract`, `virtual` or `sealed` modifiers.
 
@@ -85,7 +85,7 @@ interface I<T> where T : I<T>
 ```
 
 ##### Explicitly non-virtual static members
-For symmetry with non-virtual instance members, static members should be allowed an optional `sealed` modifier, even though they are non-virtual by default:
+For symmetry with non-virtual instance members, static members (except fields) should be allowed an optional `sealed` modifier, even though they are non-virtual by default:
 
 ``` c#
 interface I0
@@ -125,7 +125,11 @@ class C : I<C>
     public C(string s) => _s = s;
     static void I<C>.M() => Console.WriteLine("Implementation");
     static C I<C>.P { get; set; }
-    static event Action I<C>.E;
+    static event Action I<C>.E // event declaration must use field accessor syntax
+    {
+        add { ... }
+        remove { ... }
+    }
     static C I<C>.operator +(C l, C r) => new C($"{l._s} {r._s}");
     static bool I<C>.operator ==(C l, C r) => l._s == r._s;
     static bool I<C>.operator !=(C l, C r) => l._s != r._s;
@@ -142,7 +146,7 @@ Today all unary and binary operator declarations have some requirement involving
 
 These requirements need to be relaxed so that a restricted operand is allowed to be of a type parameter that counts as "the instance type of the enclosing type".
 
-In order for a type parameter `T` to count as " the instance type of the enclosing type", it must meet the following requirements:
+In order for a type parameter `T` to count as "the instance type of the enclosing type", it must meet the following requirements:
 - `T` is a direct type parameter on the interface in which the operator declaration occurs, and
 - `T` is *directly* constrained by what the spec calls the "instance type" - i.e. the surrounding interface with its own type parameters used as type arguments.
 
@@ -187,7 +191,7 @@ C c = M<C>(); // The static members of C get called
 Since query expressions are spec'ed as a syntactic rewrite, C# actually lets you use a *type* as the query source, as long as it has static members for the query operators you use! In other words, if the *syntax* fits, we allow it!
 We think this behavior was not intentional or important in the original LINQ, and we don't want to do the work to support it on type parameters. If there are scenarios out there we will hear about them, and can choose to embrace this later.
 
-### Variance safety [§17.2.3.2](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/interfaces.md#17232-variance-safety)
+### Variance safety [§18.2.3.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/interfaces.md#18232-variance-safety)
 
 Variance safety rules should apply to signatures of static abstract members. The addition proposed in
 https://github.com/dotnet/csharplang/blob/main/proposals/variance-safety-for-static-interface-members.md#variance-safety
@@ -199,7 +203,7 @@ to
 
 *These restrictions do not apply to occurrences of types within declarations of **non-virtual, non-abstract** static members.*
 
-### [§10.5.4](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/conversions.md#1054-user-defined-implicit-conversions) User defined implicit conversions
+### [§10.5.4](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#1054-user-defined-implicit-conversions) User defined implicit conversions
 
 The following bullet points
 
@@ -225,7 +229,7 @@ are adjusted as follows:
     - If `U2` is not empty, then `U` is `U2`
 - If `U` is empty, the conversion is undefined and a compile-time error occurs.
 
-### [§10.5.5](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/conversions.md#1055-user-defined-explicit-conversions)  User-defined explicit conversions
+### [§10.3.9](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#1039-user-defined-explicit-conversions)  User-defined explicit conversions
 
 The following bullet points
 
@@ -263,18 +267,19 @@ At https://github.com/dotnet/csharplang/blob/main/meetings/2022/LDM-2022-01-24.m
 
 ### Pattern matching
 
-Given the following code, a user might reasonably expect it to print True (as it would if the constant pattern was written inline):
+Given the following code, a user might reasonably expect it to print "True" (as it would if the constant pattern was written inline):
 
 ```cs
 M(1.0);
 
 static void M<T>(T t) where T : INumberBase<T>
 {
-    Console.WriteLine(t is 1);
+    Console.WriteLine(t is 1); // Error. Cannot use a numeric constant
+    Console.WriteLine((t is int i) && (i is 1)); 
 }
 ```
 
-However, because the input type of the pattern is not `double`, the constant `1` pattern will first type check the incoming `T` against `int`. This is unintuitive, so we will block it until a future C# version adds better handling for numeric matching against types derived from `INumberBase<T>`. To do so, we will say that, we will explicitly recognize `INumberBase<T>` as the type that all "numbers" will derive from, and block the pattern if we're trying to match a numeric constant pattern against a number type that we can't represent the pattern in (ie, a type parameter constrained to `INumberBase<T>`, or a user-defined number type that inherits from `INumberBase<T>`).
+However, because the input type of the pattern is not `double`, the constant `1` pattern will first type check the incoming `T` against `int`. This is unintuitive, so it is blocked until a future C# version adds better handling for numeric matching against types derived from `INumberBase<T>`. To do so, we will say that, we will explicitly recognize `INumberBase<T>` as the type that all "numbers" will derive from, and block the pattern if we're trying to match a numeric constant pattern against a number type that we can't represent the pattern in (ie, a type parameter constrained to `INumberBase<T>`, or a user-defined number type that inherits from `INumberBase<T>`).
 
 Formally, we add an exception to the definition of *pattern-compatible* for constant patterns:
 

--- a/proposals/csharp-11.0/unsigned-right-shift-operator.md
+++ b/proposals/csharp-11.0/unsigned-right-shift-operator.md
@@ -22,7 +22,7 @@ yet an algorithm might rely on ability to perform an unsigned right shift operat
 
 ### Operators and punctuators
 
-Section [§6.4.6](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/lexical-structure.md#646-operators-and-punctuators) will be adjusted
+Section [§6.4.6](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/lexical-structure.md#646-operators-and-punctuators) will be adjusted
 to include `>>>` operator - the unsigned right shift operator:
 
 ```antlr
@@ -39,7 +39,7 @@ No characters of any kind (not even whitespace) are allowed between the tokens i
 
 ### Shift operators
 
-Section [§11.10](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1110-shift-operators) will be adjusted
+Section [§12.11](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1211-shift-operators) will be adjusted
 to include `>>>` operator - the unsigned right shift operator:
 
 The `<<`, `>>` and `>>>` operators are used to perform bit shifting operations.
@@ -53,7 +53,7 @@ shift_expression
     ;
 ```
 
-For an operation of the form `x << count` or `x >> count` or `x >>> count`, binary operator overload resolution ([§11.4.5](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1145-binary-operator-overload-resolution)) is applied to select a specific operator implementation. The operands are converted to the parameter types of the selected operator, and the type of the result is the return type of the operator.
+For an operation of the form `x << count` or `x >> count` or `x >>> count`, binary operator overload resolution ([§12.4.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1245-binary-operator-overload-resolution)) is applied to select a specific operator implementation. The operands are converted to the parameter types of the selected operator, and the type of the result is the return type of the operator.
 
 The predefined unsigned shift operators will support the same set of signatures
 that predefined signed shift operators support today in the current implementation.
@@ -84,7 +84,7 @@ Shift operations never cause overflows and produce the same results in `checked`
 
 ### Assignment operators
 
-Section [§11.18](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1118-assignment-operators) will be adjusted to include
+Section [§12.21](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1221-assignment-operators) will be adjusted to include
 *unsigned_right_shift_assignment* as follows:
 
 ```antlr
@@ -106,34 +106,34 @@ assignment_operator
 
 ### Integral types
 
-The Integral types [§8.3.6](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/types.md#836-integral-types) section will be adjusted to include information about `>>>` operator. The relevant bullet point is the following:
+The Integral types [§8.3.6](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/types.md#836-integral-types) section will be adjusted to include information about `>>>` operator. The relevant bullet point is the following:
 
 *  For the binary `<<`, `>>` and `>>>` operators, the left operand is converted to type `T`, where `T` is the first of `int`, `uint`, `long`, and `ulong` that can fully represent all possible values of the operand. The operation is then performed using the precision of type `T`, and the type of the result is `T`.
 
 ### Constant expressions
 
 Operator `>>>` will be added to the set of constructs permitted in constant expressions at
-[§11.20](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1120-constant-expressions).
+[§12.23](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1223-constant-expressions).
 
 ### Operator overloading
 
-Operator `>>>` will be added to the set of overloadable binary operators at [§11.4.3](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1143-operator-overloading).
+Operator `>>>` will be added to the set of overloadable binary operators at [§12.4.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1243-operator-overloading).
 
 ### Lifted operators
 
-Operator `>>>` will be added to the set of binary operators permitting a lifted form at [§11.4.8](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1148-lifted-operators).
+Operator `>>>` will be added to the set of binary operators permitting a lifted form at [§12.4.8](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1248-lifted-operators).
 
 ### Operator precedence and associativity
 
-Section [§11.4.2](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1142-operator-precedence-and-associativity) will be adjusted to add `>>>` operator to the "Shift" category and `>>>=` operator to the "Assignment and lambda expression" category.
+Section [§12.4.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1242-operator-precedence-and-associativity) will be adjusted to add `>>>` operator to the "Shift" category and `>>>=` operator to the "Assignment and lambda expression" category.
 
 ### Grammar ambiguities
 
-The `>>>` operator is subject to the same grammar ambiguities described at [§6.2.5](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/lexical-structure.md#625-grammar-ambiguities) as a regular `>>` operator.
+The `>>>` operator is subject to the same grammar ambiguities described at [§6.2.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/lexical-structure.md#625-grammar-ambiguities) as a regular `>>` operator.
 
 ### Operators
 
-The [§14.10](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/classes.md#1410-operators) section will be adjusted to include `>>>` operator.
+The [§15.10](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#1510-operators) section will be adjusted to include `>>>` operator.
 
 ```antlr
 overloadable_binary_operator
@@ -144,7 +144,7 @@ overloadable_binary_operator
 
 ### Binary operators
 
-The signature of a `>>>` operator is subject to the same rules as those at [§14.10.3](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/classes.md#14103-binary-operators)
+The signature of a `>>>` operator is subject to the same rules as those at [§15.10.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#15103-binary-operators)
 for the signature of a `>>` operator.
 
 ### Metadata name
@@ -160,7 +160,7 @@ The `>>>` operator will not be supported in Linq Expression Trees because semant
 It looks like dynamic binding uses values of System.Linq.Expressions.ExpressionType enum to communicate
 binary operator kind to the runtime binder. Since we don't have a member specifically representing
 an unsigned right shift operator, dynamic binding for `>>>` operator will not be supported and the
-static and dynamic binding ([§11.3](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#113-static-and-dynamic-binding)) section 
+static and dynamic binding ([§12.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#123-static-and-dynamic-binding)) section 
 will be adjusted to reflect that.
 
 ## Drawbacks

--- a/proposals/csharp-11.0/utf8-string-literals.md
+++ b/proposals/csharp-11.0/utf8-string-literals.md
@@ -35,8 +35,8 @@ To fix this we will allow for UTF8 literals in the language and encode them into
 The language will provide the `u8` suffix on string literals to force the type to be UTF8.
 The suffix is case-insensitive, `U8` suffix will be supported and will have the same meaning as `u8` suffix.
 
-When the `u8` suffix is used, the value of the literal is a ```ReadOnlySpan<byte>``` containing a UTF-8 byte representation of the string.
-A null terminator is placed beyond the last byte in memory (and outside the length of the ```ReadOnlySpan<byte>```) in order to handle some
+When the `u8` suffix is used, the value of the literal is a `ReadOnlySpan<byte>` containing a UTF-8 byte representation of the string.
+A null terminator is placed beyond the last byte in memory (and outside the length of the `ReadOnlySpan<byte>`) in order to handle some
 interop scenarios where the call expects null terminated strings.
 
 ```c#
@@ -50,8 +50,8 @@ Span<byte> s6 = "hello"u8;         // Error - Cannot implicitly convert type 'Sy
 
 Since the literals would be allocated as global constants, the lifetime of the resulting `ReadOnlySpan<byte>` would not prevent it from being returned or passed around to elsewhere. However, certain contexts, most notably within async functions, do not allow locals of ref struct types, so there would be a usage penalty in those situations, with a `ToArray()` call or similar being required.
 
-A `u8` literal doesn't have a constant value. That is because ```ReadOnlySpan<byte>``` cannot be type of a constant today. If the definition of `const` is expanded
-in the future to consider ```ReadOnlySpan<byte>```, then this value should also be considered a constant. Practically though this means a `u8`
+A `u8` literal doesn't have a constant value. That is because `ReadOnlySpan<byte>` cannot be the type of a constant today. If the definition of `const` is expanded
+in the future to consider `ReadOnlySpan<byte>`, then this value should also be considered a constant. Practically though this means a `u8`
 literal cannot be used as the default value of an optional parameter.
 
 ```c#
@@ -62,12 +62,14 @@ void Write(ReadOnlySpan<byte> message = "missing"u8) { ... }
 When the input text for the literal is a malformed UTF16 string, then the language will emit an error:
 
 ```c#
-var bytes = "hello \uD801\uD802"u8; // Error: the input string is not valid UTF16
+var bytes = "hello \uD8\uD8"u8; // Error: malformed UTF16 input string
+
+var bytes2 = "hello \uD801\uD802"u8; // Allowed: invalid UTF16 values, but it's correctly formed.
 ```
 
 ### Addition operator
 
-A new bullet point will be added to [§11.9.5 Addition operator](https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/expressions.md#1195-addition-operator) as follows.
+A new bullet point will be added to [§12.10.5 Addition operator](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12105-addition-operator) as follows.
 
 - UTF8 byte representation concatenation:
 
@@ -78,7 +80,7 @@ A new bullet point will be added to [§11.9.5 Addition operator](https://github.
   This binary `+` operator performs byte sequences concatenation and is applicable if and only if both operands are semantically UTF8 byte representations.
   An operand is semantically a UTF8 byte representation when it is either a value of a `u8` literal, or a value produced by the UTF8 byte representation concatenation operator. 
 
-  The result of the UTF8 byte representation concatenation is a ```ReadOnlySpan<byte>``` that consists of the bytes of the left operand followed by the bytes of the right operand. A null terminator is placed beyond the last byte in memory (and outside the length of the ```ReadOnlySpan<byte>```) in order to handle some
+  The result of the UTF8 byte representation concatenation is a `ReadOnlySpan<byte>` that consists of the bytes of the left operand followed by the bytes of the right operand. A null terminator is placed beyond the last byte in memory (and outside the length of the `ReadOnlySpan<byte>`) in order to handle some
 interop scenarios where the call expects null terminated strings.
 
 ### Lowering
@@ -130,7 +132,7 @@ The `u8` suffix exists primarily to support two scenarios: `var` and overload re
 ```c# 
 void Write(ReadOnlySpan<byte> span) { ... } 
 void Write(string s) {
-    var bytes = Encoding.Utf8.GetBytes(s);
+    var bytes = Encoding.UTF8.GetBytes(s);
     Write(bytes.AsSpan());
 }
 ```
@@ -150,8 +152,12 @@ It seems more likely that we'd regret the `u8` suffix pointing to `ReadOnlySpan<
 
 ### Conversions between `string` constants and `byte` sequences
 
+The conversions in this section have not been implemented. These conversions remain active proposals.
+
+<details>
+
 The language will allow conversions between `string` constants and `byte` sequences where the text is converted into the equivalent UTF8 byte representation. Specifically the compiler will allow _string_constant_to_UTF8_byte_representation_conversion_ - implicit conversions from `string` constants to `byte[]`, `Span<byte>`, and `ReadOnlySpan<byte>`.
-A new bullet point will be added to the implicit conversions [§10.2](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/conversions.md#102-implicit-conversions) section. This conversion is not a standard conversion [§10.4](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/conversions.md#104-standard-conversions).
+A new bullet point will be added to the implicit conversions [§10.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#102-implicit-conversions) section. This conversion is not a standard conversion [§10.4](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#104-standard-conversions).
 
 ```c# 
 byte[] array = "hello";             // new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f }
@@ -196,7 +202,13 @@ void Write(ReadOnlySpan<byte> message = "missing") { ... }
 
 Once implemented string literals will have the same problem that other literals have in the language: what type they represent depends on how they are used. C# provides a literal suffix to disambiguate the meaning for other literals. For example developers can write `3.14f` to force the value to be a `float` or `1l` to force the value to be a `long`.
 
+</details>
+
 ## Unresolved questions
+
+The first three design questions relate to string to `Span<byte>` / `ReadOnlySpan<byte>` conversions.They haven't been implemented.
+
+<details>
 
 ### (Resolved) Conversions between a `string` constant with `null` value and `byte` sequences
 
@@ -212,11 +224,11 @@ The proposal is approved - https://github.com/dotnet/csharplang/blob/main/meetin
 
 ### (Resolved) Where does _string_constant_to_UTF8_byte_representation_conversion_ belong?
 
-Is _string_constant_to_UTF8_byte_representation_conversion_ a bullet point in the implicit conversions [§10.2](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/conversions.md#102-implicit-conversions) section on its own, or is it part of [§10.2.11](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/conversions.md#10211-implicit-constant-expression-conversions), or does it belong to some other existing implicit conversions group?
+Is _string_constant_to_UTF8_byte_representation_conversion_ a bullet point in the implicit conversions [§10.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#102-implicit-conversions) section on its own, or is it part of [§10.2.11](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#10211-implicit-constant-expression-conversions), or does it belong to some other existing implicit conversions group?
 
 *Proposal:* 
 
-It is a new bullet point in implicit conversions [§10.2](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/conversions.md#102-implicit-conversions), similar to "Implicit interpolated string conversions" or "Method group conversions". It doesn't feel like it belongs to "Implicit constant expression conversions" because, even though the source is a constant expression, the result is never a constant expression. Also, "Implicit constant expression conversions" are considered to be "Standard implicit conversions" [§10.4.2](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/conversions.md#1042-standard-implicit-conversions), which is likely to lead to non-trivial behavior changes involving user-defined conversions.
+It is a new bullet point in implicit conversions [§10.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#102-implicit-conversions), similar to "Implicit interpolated string conversions" or "Method group conversions". It doesn't feel like it belongs to "Implicit constant expression conversions" because, even though the source is a constant expression, the result is never a constant expression. Also, "Implicit constant expression conversions" are considered to be "Standard implicit conversions" [§10.4.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#1042-standard-implicit-conversions), which is likely to lead to non-trivial behavior changes involving user-defined conversions.
 
 *Resolution:*
 
@@ -249,6 +261,8 @@ The new conversion is not a standard conversion. This will avoid non-trivial beh
 *Resolution:*
 
 Not a standard conversion, for now - https://github.com/dotnet/csharplang/blob/main/meetings/2022/LDM-2022-01-26.md#implicit-standard-conversion.
+
+</details>
 
 ### (Resolved) Linq Expression Tree conversion
 
@@ -311,6 +325,8 @@ The proposal is approved - https://github.com/dotnet/csharplang/blob/main/meetin
 We will likely want to have a deeper debate about whether `u8` string literals should have a type of a mutable array, but we don't
 think that debate is necessary for now.
 
+Only the explicit conversion operator has been implemented.
+
 ### (Resolved) Depth of the conversion
 Will it also work anywhere that a byte[] could work? Consider: 
 
@@ -329,7 +345,7 @@ Don't do anything special.
 
 *Resolution:*
 
-No new conversion targets added for now https://github.com/dotnet/csharplang/blob/main/meetings/2022/LDM-2022-01-26.md#conversion-depth.
+No new conversion targets added for now https://github.com/dotnet/csharplang/blob/main/meetings/2022/LDM-2022-01-26.md#conversion-depth. Neither conversion compiles.
 
 ### (Resolved) Overload resolution breaks
 
@@ -345,7 +361,7 @@ What should we do to address this?
 
 *Proposal:* 
 
-Similar to https://github.com/dotnet/csharplang/blob/main/proposals/csharp-10.0/lambda-improvements.md#overload-resolution, Better function member ([§11.6.4.3](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11643-better-function-member)) is updated to prefer members where none of the conversions involved require converting `string` constants to UTF8 `byte` sequences.
+Similar to https://github.com/dotnet/csharplang/blob/main/proposals/csharp-10.0/lambda-improvements.md#overload-resolution, Better function member ([§11.6.4.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12643-better-function-member)) is updated to prefer members where none of the conversions involved require converting `string` constants to UTF8 `byte` sequences.
 
 > #### Better function member
 > ...


### PR DESCRIPTION
Contributes to #8098

- Clarify any proposed features that weren't implemented. In most cases, hide those behind `<details>` tags.
- Update all links to the C# spec from both the old Microsoft spec in csharplang and the outdated C# 7 standard from csharpstandard.
- Fix any typos as I found them.