### PR TITLE
Edit pass on C# 9 speclets

### DIFF
--- a/proposals/csharp-9.0/covariant-returns.md
+++ b/proposals/csharp-9.0/covariant-returns.md
@@ -37,30 +37,30 @@ This is a specification for [covariant return types](https://github.com/dotnet/c
 
 ### Class Method Override
 
-The existing constraint on class override ([§14.6.5](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/classes.md#1465-override-methods)) methods
+The existing constraint on class override ([§15.6.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#1565-override-methods)) methods
 
 > - The override method and the overridden base method have the same return type.
 
 is modified to
 
-> - The override method must have a return type that is convertible by an identity conversion or (if the method has a value return - not a [ref return](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.0/ref-locals-returns.md)) implicit reference conversion to the return type of the overridden base method.
+> - The override method must have a return type that is convertible by an identity conversion or (if the method has a value return - not a [ref return](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.0/ref-locals-returns.md) see [§13.1.0.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/statements.md#13105-the-return-statement) implicit reference conversion to the return type of the overridden base method.
 
 And the following additional requirements are appended to that list:
 
-> - The override method must have a return type that is convertible by an identity conversion or (if the method has a value return - not a [ref return](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.0/ref-locals-returns.md)) implicit reference conversion to the return type of every override of the overridden base method that is declared in a (direct or indirect) base type of the override method.
-> - The override method's return type must be at least as accessible as the override method  (Accessibility domains - [§7.5.3](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/basic-concepts.md#753-accessibility-domains)).
+> - The override method must have a return type that is convertible by an identity conversion or (if the method has a value return - not a [ref return](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.0/ref-locals-returns.md), [§13.1.0.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/statements.md#13105-the-return-statement)) implicit reference conversion to the return type of every override of the overridden base method that is declared in a (direct or indirect) base type of the override method.
+> - The override method's return type must be at least as accessible as the override method  (Accessibility domains - [§7.5.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/basic-concepts.md#753-accessibility-domains)).
 
 This constraint permits an override method in a `private` class to have a `private` return type.  However it requires a `public` override method in a `public` type to have a `public` return type.
 
 ### Class Property and Indexer Override
 
-The existing constraint on class override ([§14.7.6](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/classes.md#1476-virtual-sealed-override-and-abstract-accessors)) properties
+The existing constraint on class override ([§15.7.6](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#1576-virtual-sealed-override-and-abstract-accessors)) properties
 
 > An overriding property declaration shall specify the exact same accessibility modifiers and name as the inherited property, and there shall be an identity conversion ~~between the type of the overriding and the inherited property~~. If the inherited property has only a single accessor (i.e., if the inherited property is read-only or write-only), the overriding property shall include only that accessor. If the inherited property includes both accessors (i.e., if the inherited property is read-write), the overriding property can include either a single accessor or both accessors.
 
 is modified to
 
-> An overriding property declaration shall specify the exact same accessibility modifiers and name as the inherited property, and there shall be an identity conversion **or (if the inherited property is read-only and has a value return - not a [ref return](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.0/ref-locals-returns.md)) implicit reference conversion from the type of the overriding property to the type of the inherited property**. If the inherited property has only a single accessor (i.e., if the inherited property is read-only or write-only), the overriding property shall include only that accessor. If the inherited property includes both accessors (i.e., if the inherited property is read-write), the overriding property can include either a single accessor or both accessors. **The overriding property's type must be at least as accessible as the overriding property (Accessibility domains - [§7.5.3](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/basic-concepts.md#753-accessibility-domains)).**
+> An overriding property declaration shall specify the exact same accessibility modifiers and name as the inherited property, and there shall be an identity conversion **or (if the inherited property is read-only and has a value return - not a [ref return](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.0/ref-locals-returns.md) [§13.1.0.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/statements.md#13105-the-return-statement)) implicit reference conversion from the type of the overriding property to the type of the inherited property**. If the inherited property has only a single accessor (i.e., if the inherited property is read-only or write-only), the overriding property shall include only that accessor. If the inherited property includes both accessors (i.e., if the inherited property is read-write), the overriding property can include either a single accessor or both accessors. **The overriding property's type must be at least as accessible as the overriding property (Accessibility domains - [§7.5.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/basic-concepts.md#753-accessibility-domains)).**
 
 -----------------
 
@@ -78,11 +78,11 @@ is given the corresponding specification for interfaces:
 
 > The method overridden by an override declaration is known as the ***overridden base method***. For an override method `M` declared in an interface `I`, the overridden base method is determined by examining each direct or indirect base interface of `I`, collecting the set of interfaces declaring an accessible method which has the same signature as `M` after substitution of type arguments.  If this set of interfaces has a *most derived type*, to which there is an identity or implicit reference conversion from every type in this set, and that type contains a unique such method declaration, then that is the *overridden base method*.
 
-We similarly permit `override` properties and indexers in interfaces as specified for classes in *15.7.6 Virtual, sealed, override, and abstract accessors*.
+We similarly permit `override` properties and indexers in interfaces as specified for classes in [§15.7.6 Virtual, sealed, override, and abstract accessors](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#1576-virtual-sealed-override-and-abstract-accessors).
 
 ### Name Lookup
 
-Name lookup in the presence of class `override` declarations currently modify the result of name lookup by imposing on the found member details from the most derived `override` declaration in the class hierarchy starting from the type of the identifier's qualifier (or `this` when there is no qualifier).  For example, in *12.6.2.2 Corresponding parameters* we have
+Name lookup in the presence of class `override` declarations currently modify the result of name lookup by imposing on the found member details from the most derived `override` declaration in the class hierarchy starting from the type of the identifier's qualifier (or `this` when there is no qualifier).  For example, in [§12.6.2.2 Corresponding parameters](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12622-corresponding-parameters) we have
 
 > For virtual methods and indexers defined in classes, the parameter list is picked from the first  declaration or override of the function member found when starting with the static type of the receiver, and searching through its base classes.
 
@@ -92,21 +92,21 @@ to this we add
 
 For the result type of a property or indexer access, the existing text
 
-> - If I identifies an instance property, then the result is a property access with an associated instance expression of E and an associated type that is the type of the property. If T is a class type, the associated type is picked from the first declaration or override of the property found when starting with T, and searching through its base classes.
+> - If `I` identifies an instance property, then the result is a property access with an associated instance expression of `E` and an associated type that is the type of the property. If `T` is a class type, the associated type is picked from the first declaration or override of the property found when starting with `T`, and searching through its base classes.
 
 is augmented with
 
-> If T is an interface type, the associated type is picked from the declaration or override of the property found in the most derived of T or its direct or indirect base interfaces.  It is a compile-time error if no unique such type exists.
+> If `T` is an interface type, the associated type is picked from the declaration or override of the property found in the most derived of `T` or its direct or indirect base interfaces.  It is a compile-time error if no unique such type exists.
 
-A similar change should be made in *12.7.7.3 Indexer access*
+A similar change should be made in [§12.8.12.3 Indexer access](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128123-indexer-access)
 
-In *12.7.6 Invocation expressions* we augment the existing text
+In [§12.8.10 Invocation expressions](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12810-invocation-expressions) we augment the existing text
 
-> - Otherwise, the result is a value, with an associated type of the return type of the method or delegate. If the invocation is of an instance method, and the receiver is of a class type T, the associated type is picked from the first declaration or override of the method found when starting with T and searching through its base classes.
+> - Otherwise, the result is a value, with an associated type of the return type of the method or delegate. If the invocation is of an instance method, and the receiver is of a class type `T`, the associated type is picked from the first declaration or override of the method found when starting with `T` and searching through its base classes.
 
 with
 
-> If the invocation is of an instance method, and the receiver is of an interface type T, the associated type is picked from the declaration or override of the method found in the most derived interface from among T and its direct and indirect base interfaces.  It is a compile-time error if no unique such type exists.
+> If the invocation is of an instance method, and the receiver is of an interface type `T`, the associated type is picked from the declaration or override of the method found in the most derived interface from among `T` and its direct and indirect base interfaces.  It is a compile-time error if no unique such type exists.
 
 ### Implicit Interface Implementations
 
@@ -198,6 +198,7 @@ I suggest that we permit implementing either `I1.M` or `I2.M` (but not both), an
 We could relax the language rules slightly to allow, in source,
 
 ```csharp
+// Possible alternative. This was not implemented.
 abstract class Cloneable
 {
     public abstract Cloneable Clone();

--- a/proposals/csharp-9.0/extending-partial-methods.md
+++ b/proposals/csharp-9.0/extending-partial-methods.md
@@ -203,7 +203,8 @@ unnecessary feature creep. Want to solve the immediate problem of expanding
 the feature to work with modern source generators. 
 
 Extending `partial` to support other members will be considered for the C# 10
-release. Seems likely that we will consider this extension. This remains an active proposal, but it has not yet been implemented.
+release. Seems likely that we will consider this extension. This remains an
+active proposal, but it has not yet been implemented.
 
 ### Use abstract instead of partial
 The crux of this proposal is essentially ensuring that a declaration has a

--- a/proposals/csharp-9.0/extending-partial-methods.md
+++ b/proposals/csharp-9.0/extending-partial-methods.md
@@ -8,7 +8,7 @@ methods in C#. The goal being to expand the set of scenarios in which these
 methods can work with source generators as well as being a more general 
 declaration form for C# methods.
 
-See also the original partial methods specification ([§14.6.9](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/classes.md#1469-partial-methods)).
+See also the original partial methods specification ([§15.6.9](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#1569-partial-methods)).
 
 ## Motivation
 C# has limited support for developers splitting methods into declarations and 
@@ -75,7 +75,7 @@ restrictions also serve to limit the set of scenarios in which `partial` methods
 can be applied.
 
 The proposal here is to remove all of the existing restrictions around `partial`
-methods. Essentially let them have `out`, non-void return types or any 
+methods. Essentially let them have `out` parameters, non-void return types or any 
 type of accessibility. Such `partial` declarations would then have the added
 requirement that a definition must exist. That means the language does not
 have to consider the impact of erasing the call sites. 
@@ -116,7 +116,7 @@ explicit accessibility modifier. This means they can be labeled as `private`,
 `public`, etc ... 
 
 When a `partial` method has an explicit accessibility modifier 
-though the language will require that the declaration has a matching
+the language will require that the declaration has a matching
 definition even when the accessibility is `private`:
 
 ```cs
@@ -152,7 +152,7 @@ partial class D
 
 partial class D
 {
-    internal partial bool TryParse(string s, out int i) { }
+    internal partial bool TryParse(string s, out int i) { ... }
 }
 ```
 
@@ -203,7 +203,7 @@ unnecessary feature creep. Want to solve the immediate problem of expanding
 the feature to work with modern source generators. 
 
 Extending `partial` to support other members will be considered for the C# 10
-release. Seems likely that we will consider this extension.
+release. Seems likely that we will consider this extension. This remains an active proposal, but it has not yet been implemented.
 
 ### Use abstract instead of partial
 The crux of this proposal is essentially ensuring that a declaration has a

--- a/proposals/csharp-9.0/extension-getenumerator.md
+++ b/proposals/csharp-9.0/extension-getenumerator.md
@@ -5,22 +5,22 @@
 ## Summary
 [summary]: #summary
 
-Allow foreach loops to recognize an extension method GetEnumerator method that otherwise satisfies the foreach pattern, and loop over the expression when it would otherwise be an error.
+Allow `foreach` loops to recognize an extension method `GetEnumerator` method that otherwise satisfies the foreach pattern, and loop over the expression when it would otherwise be an error.
 
 ## Motivation
 [motivation]: #motivation
 
-This will bring foreach inline with how other features in C# are implemented, including async and pattern-based deconstruction.
+This will bring `foreach` inline with how other features in C# are implemented, including async and pattern-based deconstruction.
 
 ## Detailed design
 [design]: #detailed-design
 
-The spec change is relatively straightforward. We modify `The foreach statement` section to this text:
+The spec change is relatively straightforward. We modify `The foreach statement` [§13.9.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/statements.md#1395-the-foreach-statement) section to this text:
 
 >The compile-time processing of a foreach statement first determines the ***collection type***, ***enumerator type*** and ***element type*** of the expression. This determination proceeds as follows:
 >
 >*  If the type `X` of *expression* is an array type then there is an implicit reference conversion from `X` to the `IEnumerable` interface (since `System.Array` implements this interface). The ***collection type*** is the `IEnumerable` interface, the ***enumerator type*** is the `IEnumerator` interface and the ***element type*** is the element type of the array type `X`.
->*  If the type `X` of *expression* is `dynamic` then there is an implicit conversion from *expression* to the `IEnumerable` interface ([§10.2.10](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/conversions.md#10210-implicit-dynamic-conversions)). The ***collection type*** is the `IEnumerable` interface and the ***enumerator type*** is the `IEnumerator` interface. If the `var` identifier is given as the *local_variable_type* then the ***element type*** is `dynamic`, otherwise it is `object`.
+>*  If the type `X` of *expression* is `dynamic` then there is an implicit conversion from *expression* to the `IEnumerable` interface ([§10.2.10](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#10210-implicit-dynamic-conversions)). The ***collection type*** is the `IEnumerable` interface and the ***enumerator type*** is the `IEnumerator` interface. If the `var` identifier is given as the *local_variable_type* then the ***element type*** is `dynamic`, otherwise it is `object`.
 >*  Otherwise, determine whether the type `X` has an appropriate `GetEnumerator` method:
 >    * Perform member lookup on the type `X` with identifier `GetEnumerator` and no type arguments. If the member lookup does not produce a match, or it produces an ambiguity, or produces a match that is not a method group, check for an enumerable interface as described below. It is recommended that a warning be issued if member lookup produces anything except a method group or no match.
 >    * Perform overload resolution using the resulting method group and an empty argument list. If overload resolution results in no applicable methods, results in an ambiguity, or results in a single best method but that method is either static or not public, check for an enumerable interface as described below. It is recommended that a warning be issued if overload resolution produces anything except an unambiguous public instance method or no applicable methods.

--- a/proposals/csharp-9.0/function-pointers.md
+++ b/proposals/csharp-9.0/function-pointers.md
@@ -13,7 +13,7 @@ need an efficient way to access them.
 The motivations and background for this feature are described in the following issue (as is a
 potential implementation of the feature):
 
-https://github.com/dotnet/csharplang/issues/191
+[dotnet/csharplang#191](https://github.com/dotnet/csharplang/issues/191)
 
 This is an alternate design proposal to [compiler intrinsics](https://github.com/dotnet/csharplang/blob/master/proposals/intrinsics.md)
 
@@ -25,8 +25,10 @@ The language will allow for the declaration of function pointers using the `dele
 in detail in the next section but it is meant to resemble the syntax used by `Func` and `Action` type declarations.
 
 ``` csharp
-unsafe class Example {
-    void Example(Action<int> a, delegate*<int, void> f) {
+unsafe class Example
+{
+    void M(Action<int> a, delegate*<int, void> f)
+    {
         a(42);
         f(42);
     }
@@ -166,7 +168,7 @@ delegate*<delegate* managed<string, int>, delegate*<string, int>>;
 ### Function pointer conversions
 
 In an unsafe context, the set of available implicit conversions (Implicit conversions) is extended to include the following implicit pointer conversions:
-- _Existing conversions_ - ([§22.5](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/unsafe-code.md#225-pointer-conversions))
+- _Existing conversions_ - ([§23.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#235-pointer-conversions))
 - From _funcptr\_type_ `F0` to another _funcptr\_type_ `F1`, provided all of the following are true:
     - `F0` and `F1` have the same number of parameters, and each parameter `D0n` in `F0` has the same `ref`, `out`, or `in` modifiers as the corresponding parameter `D1n` in `F1`.
     - For each value parameter (a parameter with no `ref`, `out`, or `in` modifier), an identity conversion, implicit reference conversion, or implicit pointer conversion exists from the parameter type in `F0` to the corresponding parameter type in `F1`.
@@ -219,7 +221,7 @@ address-of operator:
 unsafe class Util {
     public static void Log() { }
     public static void Log(string p1) { }
-    public static void Log(int i) { };
+    public static void Log(int i) { }
 
     void Use() {
         delegate*<void> a1 = &Log; // Log()
@@ -228,6 +230,7 @@ unsafe class Util {
         // Error: ambiguous conversion from method group Log to "void*"
         void* v = &Log;
     }
+}
 ```
 
 The address-of operator will be implemented using the `ldftn` instruction.
@@ -242,29 +245,29 @@ Restrictions of this feature:
 
 ### Operators on Function Pointer Types
 
-The section in unsafe code on operators is modified as such:
+The section in unsafe code on expressions is modified as such:
 
 > In an unsafe context, several constructs are available for operating on all _pointer\_type_s that are not _funcptr\_type_s:
 >
-> *  The `*` operator may be used to perform pointer indirection ([§22.6.2](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/unsafe-code.md#2262-pointer-indirection)).
-> *  The `->` operator may be used to access a member of a struct through a pointer ([§22.6.3](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/unsafe-code.md#2263-pointer-member-access)).
-> *  The `[]` operator may be used to index a pointer ([§22.6.4](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/unsafe-code.md#2264-pointer-element-access)).
-> *  The `&` operator may be used to obtain the address of a variable ([§22.6.5](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/unsafe-code.md#2265-the-address-of-operator)).
-> *  The `++` and `--` operators may be used to increment and decrement pointers ([§22.6.6](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/unsafe-code.md#2266-pointer-increment-and-decrement)).
-> *  The `+` and `-` operators may be used to perform pointer arithmetic ([§22.6.7](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/unsafe-code.md#2267-pointer-arithmetic)).
-> *  The `==`, `!=`, `<`, `>`, `<=`, and `=>` operators may be used to compare pointers ([§22.6.8](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/unsafe-code.md#2268-pointer-comparison)).
-> *  The `stackalloc` operator may be used to allocate memory from the call stack ([§22.8](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/unsafe-code.md#228-fixed-size-buffers)).
-> *  The `fixed` statement may be used to temporarily fix a variable so its address can be obtained ([§22.7](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/unsafe-code.md#227-the-fixed-statement)).
+> *  The `*` operator may be used to perform pointer indirection ([§23.6.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#2362-pointer-indirection)).
+> *  The `->` operator may be used to access a member of a struct through a pointer ([§23.6.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#2363-pointer-member-access)).
+> *  The `[]` operator may be used to index a pointer ([§23.6.4](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#2364-pointer-element-access)).
+> *  The `&` operator may be used to obtain the address of a variable ([§23.6.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#2365-the-address-of-operator)).
+> *  The `++` and `--` operators may be used to increment and decrement pointers ([§23.6.6](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#2366-pointer-increment-and-decrement)).
+> *  The `+` and `-` operators may be used to perform pointer arithmetic ([§23.6.7](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#2367-pointer-arithmetic)).
+> *  The `==`, `!=`, `<`, `>`, `<=`, and `=>` operators may be used to compare pointers ([§23.6.8](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#2368-pointer-comparison)).
+> *  The `stackalloc` operator may be used to allocate memory from the call stack ([§23.8](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#238-fixed-size-buffers)).
+> *  The `fixed` statement may be used to temporarily fix a variable so its address can be obtained ([§23.7](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#237-the-fixed-statement)).
 > 
 > In an unsafe context, several constructs are available for operating on all _funcptr\_type_s:
 > *  The `&` operator may be used to obtain the address of static methods ([Allow address-of to target methods](#allow-address-of-to-target-methods))
-> *  The `==`, `!=`, `<`, `>`, `<=`, and `=>` operators may be used to compare pointers ([§22.6.8](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/unsafe-code.md#2268-pointer-comparison)).
+> *  The `==`, `!=`, `<`, `>`, `<=`, and `=>` operators may be used to compare pointers ([§23.6.8](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#2368-pointer-comparison)).
 
 Additionally, we modify all the sections in `Pointers in expressions` to forbid function pointer types, except `Pointer comparison` and `The sizeof operator`.
 
 ### Better function member
 
-The better function member specification will be changed to include the following line:
+[§12.6.4.3 Better function member](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12643-better-function-member)  will be changed to include the following line:
 
 > A `delegate*` is more specific than `void*`
 
@@ -276,7 +279,7 @@ In unsafe code, the following changes are made to the type inference algorithms:
 
 #### Input types
 
-[§11.6.3.4](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11634-input-types)
+[§12.6.3.4](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12634-input-types)
 
 The following is added:
 
@@ -284,7 +287,7 @@ The following is added:
 
 #### Output types
 
-[§11.6.3.5](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11635-output-types)
+[§12.6.3.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12635-output-types)
 
 The following is added:
 
@@ -292,7 +295,7 @@ The following is added:
 
 #### Output type inferences
 
-[§11.6.3.7](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11637-output-type-inferences)
+[§12.6.3.7](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12637-output-type-inferences)
 
 The following bullet is added between bullets 2 and 3:
 
@@ -301,7 +304,7 @@ of `E` with the types `T1..Tk` yields a single method with return type `U`, then
 
 #### Better conversion from expression
 
-[§11.6.4.4](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11644-better-conversion-from-expression)
+[§12.6.4.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12645-better-conversion-from-expression)
 
 The following sub-bullet is added as a case to bullet 2:
 
@@ -310,7 +313,7 @@ is identical to `U`, and the refness of `Vi` is identical to `Ui`.
 
 #### Lower-bound inferences
 
-[§11.6.3.10](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#116310-lower-bound-inferences)
+[§12.6.3.10](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#126310-lower-bound-inferences)
 
 The following case is added to bullet 3:
 
@@ -334,7 +337,7 @@ Then, added after the 3rd bullet of inference from `Ui` to `Vi`:
 
 #### Upper-bound inferences
 
-[§11.6.3.11](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#116311-upper-bound-inferences)
+[§12.6.3.11](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#126311-upper-bound-inferences)
 
 The following case is added to bullet 2:
 
@@ -599,7 +602,7 @@ class NamedTupleExample {
 
 After discussion we decided to not allow named declaration of `delegate*` types. If we find there is significant need for
 this based on customer usage feedback then we will investigate a naming solution that works for function pointers,
-tuples, generics, etc ... This is likely to be similar in form to other suggestions like full `typedef` support in
+tuples, generics, etc. This is likely to be similar in form to other suggestions like full `typedef` support in
 the language.
 
 ## Future Considerations

--- a/proposals/csharp-9.0/init.md
+++ b/proposals/csharp-9.0/init.md
@@ -137,7 +137,7 @@ class Complex
 {
     readonly int Field1;
     int Field2;
-    int Prop1 { get; init ; }
+    int Prop1 { get; init; }
     int Prop2
     {
         get => 42;
@@ -536,7 +536,7 @@ class Name
 ### IL verification
 When .NET Core decides to re-implement IL verification, the rules will need to be 
 adjusted to account for `init` members. This will need to be included in the 
-rule changes for non-mutating acess to `readonly` data.
+rule changes for non-mutating access to `readonly` data.
 
 The IL verification rules will need to be broken into two parts: 
 
@@ -567,7 +567,7 @@ var student = new Student()
 };
 ```
 
-Here the result of `new Student()` will be hoised into a state machine as a 
+Here the result of `new Student()` will be hoisted into a state machine as a 
 field before the set of `Name` occurs. The compiler will need to mark such
 hoisted fields in a way that the IL verifier understands they're not user 
 accessible and hence doesn't violate the intended semantics of `init`.
@@ -575,10 +575,10 @@ accessible and hence doesn't violate the intended semantics of `init`.
 ### init members
 The `init` modifier could be extended to apply to all instance members. This 
 would generalize the concept of `init` during object construction and allow
-types to declare helper methods that could partipate in the construction 
+types to declare helper methods that could participate in the construction 
 process to initialize `init` fields and properties.
 
-Such members would have all the restricions that an `init` accessor does
+Such members would have all the restrictions that an `init` accessor does
 in this design. The need is questionable though and this can be safely added
 in a future version of the language in a compatible manner.
 

--- a/proposals/csharp-9.0/lambda-discard-parameters.md
+++ b/proposals/csharp-9.0/lambda-discard-parameters.md
@@ -15,19 +15,19 @@ Unused parameters do not need to be named. The intent of discards is clear, i.e.
 
 ## Detailed design
 
-Method parameters - [§14.6.2](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/classes.md#1462-method-parameters)
+Method parameters - [§15.6.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#1562-method-parameters)
 In the parameter list of a lambda or anonymous method with more than one parameter named `_`, such parameters are discard parameters.
 Note: if a single parameter is named `_` then it is a regular parameter for backwards compatibility reasons.
 
 Discard parameters do not introduce any names to any scopes.
 Note this implies they do not cause any `_` (underscore) names to be hidden.
 
-Simple names ([§11.7.4](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1174-simple-names))
-If `K` is zero and the *simple_name* appears within a *block* and if the *block*'s (or an enclosing *block*'s) local variable declaration space (Declarations - [§7.3](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/basic-concepts.md#73-declarations)) contains a local variable, parameter (with the exception of discard parameters) or constant with name `I`, then the *simple_name* refers to that local variable, parameter or constant and is classified as a variable or value.
+Simple names ([§12.8.4](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1284-simple-names))
+If `K` is zero and the *simple_name* appears within a *block* and if the *block*'s (or an enclosing *block*'s) local variable declaration space (Declarations - [§7.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/basic-concepts.md#73-declarations)) contains a local variable, parameter (with the exception of discard parameters) or constant with name `I`, then the *simple_name* refers to that local variable, parameter or constant and is classified as a variable or value.
 
-Scopes - [§7.7](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/basic-concepts.md#77-scopes)
-With the exception of discard parameters, the scope of a parameter declared in a *lambda_expression* ([§11.16](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1116-anonymous-function-expressions)) is the *anonymous_function_body* of that *lambda_expression*
-With the exception of discard parameters, the scope of a parameter declared in an *anonymous_method_expression* ([§11.16](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1116-anonymous-function-expressions)) is the *block* of that *anonymous_method_expression*.
+Scopes - [§7.7](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/basic-concepts.md#77-scopes)
+With the exception of discard parameters, the scope of a parameter declared in a *lambda_expression* ([§12.19](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1219-anonymous-function-expressions)) is the *anonymous_function_body* of that *lambda_expression*
+With the exception of discard parameters, the scope of a parameter declared in an *anonymous_method_expression* ([§12.19](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1219-anonymous-function-expressions)) is the *block* of that *anonymous_method_expression*.
 
 ## Related spec sections
-- Corresponding parameters - [§11.6.2.2](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11622-corresponding-parameters)
+- Corresponding parameters - [§12.6.2.2](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12622-corresponding-parameters)

--- a/proposals/csharp-9.0/local-function-attributes.md
+++ b/proposals/csharp-9.0/local-function-attributes.md
@@ -4,15 +4,15 @@
 
 ## Attributes
 
-Local function declarations are now permitted to have attributes ([§21](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/attributes.md#21-attributes)). Parameters and type parameters on local functions are also allowed to have attributes.
+Local function declarations are now permitted to have attributes ([§22](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/attributes.md#22-attributes)). Parameters and type parameters on local functions are also allowed to have attributes.
 
 Attributes with a specified meaning when applied to a method, its parameters, or its type parameters will have the same meaning when applied to a local function, its parameters, or its type parameters, respectively.
 
-A local function can be made conditional in the same sense as a conditional method ([§21.5.3](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/attributes.md#2153-the-conditional-attribute)) by decorating it with a `[ConditionalAttribute]`. A conditional local function must also be `static`. All restrictions on conditional methods also apply to conditional local functions, including that the return type must be `void`.
+A local function can be made conditional in the same sense as a conditional method ([§22.5.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/attributes.md#2253-the-conditional-attribute)) by decorating it with a `[ConditionalAttribute]`. A conditional local function must also be `static`. All restrictions on conditional methods also apply to conditional local functions, including that the return type must be `void`.
 
 ## Extern
 
-The `extern` modifier is now permitted on local functions. This makes the local function external in the same sense as an external method ([§14.6.8](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/classes.md#1468-external-methods)).
+The `extern` modifier is now permitted on local functions. This makes the local function external in the same sense as an external method ([§15.6.8](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#1468-external-methods)).
 
 Similarly to an external method, the *local-function-body* of an external local function must be a semicolon. A semicolon *local-function-body* is only permitted on an external local function. 
 
@@ -20,7 +20,8 @@ An external local function must also be `static`.
 
 ## Syntax
 
-The [local functions grammar](../csharp-7.0/local-functions.md#syntax-grammar) is modified as follows:
+The [§13.6.4](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/statements.md#1364-local-function-declarations), or [local functions grammar](../csharp-7.0/local-functions.md#syntax-grammar) is modified as follows:
+
 ```
 local-function-header
     : attributes? local-function-modifiers? return-type identifier type-parameter-list?

--- a/proposals/csharp-9.0/native-integers.md
+++ b/proposals/csharp-9.0/native-integers.md
@@ -16,7 +16,6 @@ The identifiers `nint` and `nuint` are new contextual keywords that represent na
 The identifiers are only treated as keywords when name lookup does not find a viable result at that program location.
 ```C#
 nint x = 3;
-string y = nameof(nuint);
 _ = nint.Equals(x, 3);
 ```
 
@@ -214,7 +213,7 @@ Compound assignment operations `x op= y` where `x` or `y` are native ints follow
 Specifically the expression is bound as `x = (T)(x op y)` where `T` is the type of `x` and where `x` is only evaluated once.
 
 The shift operators should mask the number of bits to shift - to 5 bits if `sizeof(nint)` is 4, and to 6 bits if `sizeof(nint)` is 8.
-(see [§11.10](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#1110-shift-operators)) in C# spec).
+(see [§12.11](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1211-shift-operators)) in C# spec).
 
 The C#9 compiler will report errors binding to predefined native integer operators when compiling with an earlier language version,
 but will allow use of predefined conversions to and from native integers.
@@ -252,7 +251,7 @@ static T* SubRightU(T* x, nuint y) => x - y; // T* operator -(T* left, ulong rig
 ```
 
 ### Binary numeric promotions
-The _binary numeric promotions_ informative text (see [§11.4.7.3](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11473-binary-numeric-promotions)) in C# spec) is updated as follows:
+The _binary numeric promotions_ informative text (see [§12.4.7.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12473-binary-numeric-promotions)) in C# spec) is updated as follows:
 
 > -   …
 > -   Otherwise, if either operand is of type `ulong`, the other operand is converted to type `ulong`, or a binding-time error occurs if the other operand is of type `sbyte`, `short`, `int`, **`nint`**, or `long`.

--- a/proposals/csharp-9.0/nullable-reference-types-specification.md
+++ b/proposals/csharp-9.0/nullable-reference-types-specification.md
@@ -2,7 +2,18 @@
 
 [!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
 
-***This is a work in progress - several parts are missing or incomplete.***
+> ***The portions of this feature that were part of C# 8 have been incorporated into the standard. See:***
+>
+> - [§6.5.9 Nullable directive](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/lexical-structure.md#659-nullable-directive)
+> - [§8.4.5 Satisfying constraints](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/types.md#845-satisfying-constraints)
+> - [§8.9 Reference Types and nullability](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/types.md#89-reference-types-and-nullability)
+> - [§10.2.6 Implicit nullable conversions](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#1026-implicit-nullable-conversions)
+> - [§10.3.4 Explicit nullable conversions](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#1034-explicit-nullable-conversions)
+> - [§12.8.9 Null-forgiving expressions](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1289-null-forgiving-expressions)
+> - [§15.2.5 Type parameter constraints](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/classes.md#1525-type-parameter-constraints)
+> - [§22.5.7 Code analysis attributes](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/attributes.md#2257-code-analysis-attributes)
+>
+> Those areas include the majority of this feature. The notable exception is the [`default` constraint](#default-constraint). This document contains much more detail on the implementation of nullable analysis provided by the roslyn compiler.
 
 This feature adds two new kinds of nullable types (nullable reference types and nullable generic types) to the existing nullable value types, and introduces a static flow analysis for purpose of null-safety.
 

--- a/proposals/csharp-9.0/patterns3.md
+++ b/proposals/csharp-9.0/patterns3.md
@@ -139,9 +139,9 @@ primary_pattern
     ;
 ```
 
-## Change to 7.5.4.2 Grammar Ambiguities
+## Change to 6.2.5 Grammar Ambiguities
 
-Due to the introduction of the *type pattern*, it is possible for a generic type to appear before the token `=>`.  We therefore add `=>` to the set of tokens listed in *7.5.4.2 Grammar Ambiguities* to permit disambiguation of the `<` that begins the type argument list.  See also https://github.com/dotnet/roslyn/issues/47614.
+Due to the introduction of the *type pattern*, it is possible for a generic type to appear before the token `=>`.  We therefore add `=>` to the set of tokens listed in [§6.2.5 Grammar ambiguities](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/lexical-structure.md#625-grammar-ambiguities) to permit disambiguation of the `<` that begins the type argument list.  See also https://github.com/dotnet/roslyn/issues/47614.
 
 ## Open Issues with Proposed Changes
 
@@ -172,6 +172,8 @@ bool IsValidPercentage(object x) => x is
     >= 0D and <= 100D;    // double tests
 ```
 
+Result: The relational does include an implicit type test to the type of the constant on the right-hand-side of the relational.
+
 ### Flowing type information from the left to the right of `and`
 
 It has been suggested that when you write an `and` combinator, type information learned on the left about the top-level type could flow to the right.  For example
@@ -190,6 +192,8 @@ Here, the *input type* to the second pattern is narrowed by the *type narrowing*
 7. If `P` is an `or` pattern, the *narrowed type* is the common type of the *narrowed type* of the subpatterns if such a common type exists. For this purpose, the common type algorithm considers only identity, boxing, and implicit reference conversions, and it considers all subpatterns of a sequence of `or` patterns (ignoring parenthesized patterns).
 8. If `P` is an `and` pattern, the *narrowed type* is the *narrowed type* of the right pattern. Moreover, the *narrowed type* of the left pattern is the *input type* of the right pattern.
 9. Otherwise the *narrowed type* of `P` is `P`'s input type.
+
+Result: The above narrowing semantics have been implemented.
 
 ### Variable definitions and definite assignment
 
@@ -240,6 +244,8 @@ Should we elect to defer such work until later (which I advise), we could say in
 - beneath a `not` or `or`, pattern variables may not be declared.
 
 Then, we would have time to develop some experience that would provide insight into the possible value of relaxing that later.
+
+Result: Pattern variables can't be declared beneath a `not` or `or` pattern.
 
 ### Diagnostics, subsumption, and exhaustiveness
 

--- a/proposals/csharp-9.0/records.md
+++ b/proposals/csharp-9.0/records.md
@@ -217,8 +217,7 @@ The sole presence of a copy constructor, whether explicit or implicit, doesn't p
 addition of a default instance constructor.
 
 If a virtual "clone" method is present in the base record, the synthesized "clone" method overrides it and
-the return type of the method is the current containing type if the "covariant returns" feature is supported
-and the override return type otherwise. An error is produced if the base record clone method is sealed.
+the return type of the method is the current containing type. An error is produced if the base record clone method is sealed.
 If a virtual "clone" method is not present in the base record, the return type of the clone method
 is the containing type and the method is virtual, unless the record is sealed or abstract.
 If the containing record is abstract, the synthesized clone method is also abstract.
@@ -288,7 +287,7 @@ class R1 : IEquatable<R1>
     {
         builder.Append(nameof(P1));
         builder.Append(" = ");
-        builder.Append(this.P1); // or builder.Append(this.P1.ToString()); if P1 has a value type
+        builder.Append(this.P1); // or builder.Append(this.P1.ToString()); if T1 is a value type
         
         return true;
     }
@@ -319,13 +318,13 @@ class R2 : R1, IEquatable<R2>
             
         builder.Append(nameof(P2));
         builder.Append(" = ");
-        builder.Append(this.P2); // or builder.Append(this.P2); if P2 has a value type
+        builder.Append(this.P2); // or builder.Append(this.P2); if T2 is a value type
         
         builder.Append(", ");
         
         builder.Append(nameof(P3));
         builder.Append(" = ");
-        builder.Append(this.P3); // or builder.Append(this.P3); if P3 has a value type
+        builder.Append(this.P3); // or builder.Append(this.P3); if T3 is a value type
         
         return true;
     }
@@ -397,8 +396,8 @@ For a record:
 
 A positional record with at least one parameter synthesizes a public void-returning instance method called Deconstruct with an out
 parameter declaration for each parameter of the primary constructor declaration. Each parameter
-of the Deconstruct method has the same type as the corresponding parameter of the primary
-constructor declaration. The body of the method assigns to each parameter of the Deconstruct method, 
+of the `Deconstruct` method has the same type as the corresponding parameter of the primary
+constructor declaration. The body of the method assigns to each parameter of the `Deconstruct` method, 
 the value of the instance property of the same name.
 The method can be declared explicitly. It is an error if the explicit declaration does not match
 the expected signature or accessibility, or is static.

--- a/proposals/csharp-9.0/target-typed-conditional-expression.md
+++ b/proposals/csharp-9.0/target-typed-conditional-expression.md
@@ -19,8 +19,8 @@ We change
 > 
 > Given an implicit conversion `C1` that converts from an expression `E` to a type `T1`, and an implicit conversion `C2` that converts from an expression `E` to a type `T2`, `C1` is a ***better conversion*** than `C2` if `E` does not exactly match `T2` and at least one of the following holds:
 > 
-> * `E` exactly matches `T1` ([§11.6.4.4](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11644-better-conversion-from-expression))
-> * `T1` is a better conversion target than `T2` ([§11.6.4.6](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11646-better-conversion-target))
+> * `E` exactly matches `T1` ([§12.6.4.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12645-better-conversion-from-expression))
+> * `T1` is a better conversion target than `T2` ([§12.6.4.7](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1264-better-conversion-target))
 
 to
 
@@ -28,15 +28,15 @@ to
 > 
 > Given an implicit conversion `C1` that converts from an expression `E` to a type `T1`, and an implicit conversion `C2` that converts from an expression `E` to a type `T2`, `C1` is a ***better conversion*** than `C2` if `E` does not exactly match `T2` and at least one of the following holds:
 > 
-> * `E` exactly matches `T1` ([§11.6.4.4](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11644-better-conversion-from-expression))
+> * `E` exactly matches `T1` ([§12.6.4.5](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12645-better-conversion-from-expression))
 > * **`C1` is not a *conditional expression conversion* and `C2` is a *conditional expression conversion***.
-> * `T1` is a better conversion target than `T2` ([§11.6.4.6](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/expressions.md#11646-better-conversion-target)) **and either `C1` and `C2` are both *conditional expression conversions* or neither is a *conditional expression conversion***.
+> * `T1` is a better conversion target than `T2` ([§12.6.4.7](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#12647-better-conversion-target)) **and either `C1` and `C2` are both *conditional expression conversions* or neither is a *conditional expression conversion***.
 
 ## Cast Expression
 
 The current C# language specification says
 
-> A *cast_expression* of the form `(T)E`, where `T` is a *type* and `E` is a *unary_expression*, performs an explicit conversion ([§10.3](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/conversions.md#103-explicit-conversions)) of the value of `E` to type `T`.
+> A *cast_expression* of the form `(T)E`, where `T` is a *type* and `E` is a *unary_expression*, performs an explicit conversion ([§10.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md#103-explicit-conversions)) of the value of `E` to type `T`.
 
 In the presence of the *conditional expression conversion* there may be more than one possible conversion from `E` to `T`. With the addition of *conditional expression conversion*, we prefer any other conversion to a *conditional expression conversion*, and use the *conditional expression conversion* only as a last resort.
 

--- a/proposals/csharp-9.0/top-level-statements.md
+++ b/proposals/csharp-9.0/top-level-statements.md
@@ -88,7 +88,7 @@ The method is designated as the entry point of the program. Explicitly declared 
 could be considered as an entry point candidates are ignored. A warning is reported when that happens. It is
 an error to specify `-main:<type>` compiler switch when there are top-level statements.
 
-The entry point method always has one formal parameter, ```string[] args```. The execution environment creates and passes a ```string[]``` argument containing the command-line arguments that were specified when the application was started. The ```string[]``` argument is never null, but it may have a length of zero if no command-line arguments were specified. The ‘args’ parameter is in scope  within top-level statements and is not in scope outside of them. Regular name conflict/shadowing rules apply.
+The entry point method always has one formal parameter, `string[] args`. The execution environment creates and passes a `string[]` argument containing the command-line arguments that were specified when the application was started. The `string[]` argument is never null, but it may have a length of zero if no command-line arguments were specified. The ‘args’ parameter is in scope  within top-level statements and is not in scope outside of them. Regular name conflict/shadowing rules apply.
 
 Async operations are allowed in top-level statements to the degree they are allowed in statements within
 a regular async entry point method. However, they are not required, if `await` expressions and other async
@@ -99,8 +99,8 @@ statements as follows:
 
 | **Async-operations\Return-with-expression** | **Present** | **Absent** |
 |----------------------------------------|-------------|-------------|
-| **Present** | ```static Task<int> Main(string[] args)```| ```static Task Main(string[] args)``` |
-| **Absent**  | ```static int Main(string[] args)``` | ```static void Main(string[] args)``` |
+| **Present** | `static Task<int> Main(string[] args)`| `static Task Main(string[] args)` |
+| **Absent**  | `static int Main(string[] args)` | `static void Main(string[] args)` |
 
 The example above would yield the following `$Main` method declaration:
 


### PR DESCRIPTION
Review the C# 9 speclets, perform an edit pass.

Contributes to #8098

Note for reviewers:  The spec for Nullable Reference Types has mostly been incorporated into the draft v8 standard. I added links at the beginning of the speclet to point to those sections. The only feature section not in the standard yet is the `default` generic constraint.

Other changes were primarily small typos, and updating links to the referenced sections in the standard.