### PR TITLE
Clarify the wording of unsafe type in records

### DIFF
--- a/proposals/csharp-9.0/records.md
+++ b/proposals/csharp-9.0/records.md
@@ -44,7 +44,7 @@ an accessible concrete non-virtual member with a "matching" signature is inherit
 Two members are considered matching if they have the same
 signature or would be considered "hiding" in an inheritance scenario.
 It is an error for a member of a record to be named "Clone".
-It is an error for an instance field of a record to have an unsafe type.
+It is an error for an instance field of a record to have a top-level pointer type. A nested pointer type, such as an array of pointers, is allowed.
 
 The synthesized members are as follows:
 


### PR DESCRIPTION
The spec for records used the phrase "unsafe types". This phrase isn't well-defined and open to interpretation. I've clarified it to be precise and match the intended behavior.
