### PR TITLE
Format meeting note links for collection expressions

### DIFF
--- a/proposals/csharp-12.0/collection-expressions.md
+++ b/proposals/csharp-12.0/collection-expressions.md
@@ -1316,16 +1316,19 @@ See also:
 ## Working group meetings
 [working-group-meetings]: #working-group-meetings
 
-https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2022-10-06.md
-https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2022-10-14.md
-https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2022-10-21.md
-https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-04-05.md
-https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-04-28.md
-https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-05-26.md
-https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-06-12.md
-https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-06-26.md
-https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-08-03.md
-https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-08-10.md
+- [Oct 6, 2022](https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2022-10-06.md): Initial goals, dictionaries
+- [Oct 14, 2022](https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2022-10-14.md): Dictionaries, efficiency
+- [Oct 21, 2022](https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2022-10-21.md): Spans and stack allocation, review
+- [Apr 5, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-04-05.md): Efficient construction for array-backed collections
+- [Apr 28, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-04-28.md): Natural type, spread type inference, dictionary add vs overwrite
+- [May 26, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-05-26.md): Construction API calls, dictionary sigils, C# 12 cut line
+- [Jun 12, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-06-12.md): API shape for BCL collections to participate
+- [Jun 26, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-06-26.md): Lifetimes, BCL APIs, breaking changes, extension methods, syntax disambiguation
+- [Jul 26, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-07-26.md): Create methods with derived type, extension GetEnumerator, synthesized inline arrays
+- [Aug 3, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-08-03.md): Escape scope, blittable data
+- [Aug 10, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-08-10.md): Behavior on runtimes without inline arrays
+- [Aug 11, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2023-08-11.md): Concrete types used when targeting interface types
+- [Jan 23, 2024](https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/collection-literals/CL-2024-01-23.md): Design restart
 
 ## Upcoming agenda items
 

--- a/proposals/csharp-12.0/collection-expressions.md
+++ b/proposals/csharp-12.0/collection-expressions.md
@@ -1279,11 +1279,39 @@ Approved with modifications [LDM-2024-01-10](https://github.com/dotnet/csharplan
 ## Design meetings
 [design-meetings]: #design-meetings
 
-https://github.com/dotnet/csharplang/blob/main/meetings/2021/LDM-2021-11-01.md#collection-literals
-https://github.com/dotnet/csharplang/blob/main/meetings/2022/LDM-2022-03-09.md#ambiguity-of--in-collection-expressions
-https://github.com/dotnet/csharplang/blob/main/meetings/2022/LDM-2022-09-28.md#collection-literals
-https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-01-08.md
-https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-01-10.md
+- [Nov 1, 2021](https://github.com/dotnet/csharplang/blob/main/meetings/2021/LDM-2021-11-01.md#collection-literals): First look
+- [Feb 9, 2022](https://github.com/dotnet/csharplang/blob/main/meetings/2022/LDM-2022-02-09.md#collection-literals): Triage
+- [Mar 9, 2022](https://github.com/dotnet/csharplang/blob/main/meetings/2022/LDM-2022-03-09.md#ambiguity-of--in-collection-expressions): Ambiguity of `..`
+- [Sep 28, 2022](https://github.com/dotnet/csharplang/blob/main/meetings/2022/LDM-2022-09-28.md#collection-literals): Triage
+- [Apr 3, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-04-03.md#collection-literals): Spreads and compiler optimizations
+- [Apr 26, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-04-26.md#collection-literals): Review, targeting `IEnumerable<T>`, and dictionary elements
+- [May 3, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-05-03.md#collection-literal-natural-type): Natural type
+- [May 31, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-05-31.md): Review, construction strategies
+- [Jun 19, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-06-19.md#collection-literals): Type inference
+- [Jul 12, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-07-12.md#collection-literals): Create methods, extension methods
+- [Jul 17, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-07-17.md): Compiler check-in
+- [Aug 9, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-08-09.md#target-typing-of-collection-expressions-to-core-interfaces): Targeting interfaces, loosening Create return type requirements
+- [Aug 14, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-08-14.md): Span betterness, type inference, targeting interfaces or `Memory<T>` or inline arrays
+- [Aug 16, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-08-16.md#ref-safety-scope-for-collection-expressions): Ref-safety scope
+- [Sep 18, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-09-18.md): Capacity optimization, buffering when length is known
+- [Sep 20, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-09-20.md): Spread type inference, overload resolution
+- [Sep 25, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-09-25.md#defining-well-defined-behavior-for-collection-expression-types): Well-defined behavior
+- [Sep 27, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-09-27.md): Allowed optimizations
+- [Oct 2, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-10-02.md): Conversions requiring Add, non-generic interfaces, strings
+- [Oct 11, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-10-11.md#collection-expressions): Preferring ReadOnlySpan over Span
+- [Nov 15, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-11-15.md#nullability-analysis-of-collection-expressions): Nullability analysis
+- [Jan 8, 2024](https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-01-08.md): Determining iteration type
+- [Jan 10, 2024](https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-01-10.md): Requiring construction APIs for convertibility
+- [Jan 31, 2024](https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-01-31.md#relax-enumerable-requirement-for-collection-expressions): Relax enumerable requirement
+- [Feb 5, 2024](https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-02-05.md#collection-expressions-inline-collections): Inline collections
+- [Feb 26, 2024](https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-02-26.md#collection-expressions): Collections with iteration type of object with more specific Add
+- [Apr 15, 2024](https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-04-15.md): Non-enumerable collections, relax Add requirement
+- [Apr 17, 2024](https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-04-17.md#relax-add-requirement-for-collection-expression-conversions-to-types-implementing-ienumerable): Relax Add requirement
+
+See also:
+
+- [Design meetings for **Better Conversion from Collection Expression Element**](../csharp-13.0/collection-expressions-better-conversion.md#design-meetings)
+- [Design meetings for **Dictionary Expressions**](../dictionary-expressions.md#design-meetings)
 
 ## Working group meetings
 [working-group-meetings]: #working-group-meetings

--- a/proposals/csharp-13.0/collection-expressions-better-conversion.md
+++ b/proposals/csharp-13.0/collection-expressions-better-conversion.md
@@ -116,3 +116,11 @@ class MyList<T> : List<T> {}
 
 How far do we want to go here? The `List<T>` variant seems reasonable, and subtypes of `List<T>` exist aplenty. But the `HashSet` version has very different semantics, how sure are we that it's actually "worse"
 than `ReadOnlySpan` in this API?
+
+## Design meetings
+
+- [Jul 17, 2024](https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-07-17.md#better-conversion-from-collection-expression-with-readonlyspant-overloads): Ambiguity between `ReadOnlySpan<T>` overloads
+- [ Jul 24, 2024](https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-07-24.md#better-conversion-from-collection-expression-with-readonlyspant-overloads): Narrow fix versus recursive approach
+- [Aug 19, 2024](https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-08-19.md): Preferring element type
+- [Aug 21, 2024](https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-08-21.md#better-conversion-from-collection-expression): Review, prefering span types
+- [Sep 11, 2024](https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-09-11.md#better-conversion-from-collection-expression-and-params-collections): Review

--- a/proposals/dictionary-expressions.md
+++ b/proposals/dictionary-expressions.md
@@ -554,3 +554,9 @@ Resolution: TBD.  Working group recommendation: Use applicable instance indexer 
 Parsing ambiguity around: `[a ? [b] : c]`
 
 Working group recommendation: Use normal parsing here.  So this would be the same as `[a ? ([b]) : (c)]` (a collection expression containing a conditional expression).  If the user wants a `key_value_pair_element` here, they can write: `[(a?[b]) : c]`
+
+## Design meetings
+
+- [Jun 5, 2023](https://github.com/dotnet/csharplang/blob/main/meetings/2023/LDM-2023-06-05.md): Syntax, add vs overwrite
+- [Mar 11, 2024](https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-03-11.md): KeyValuePair elements, add vs overwrite
+- [May 15, 2024](https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-05-15.md#dictionary-expressions): KeyValuePair elements


### PR DESCRIPTION
Improving this, and providing a handy index now that my memory is fading of which dates corresponded to which topics.

![image](https://github.com/user-attachments/assets/ea43bb2c-732c-4b29-9c7e-8c16d95c73b7)
