### PR TITLE
Extensions: update metadata name for extensions and rules for receiver parameter

### DIFF
--- a/proposals/extensions.md
+++ b/proposals/extensions.md
@@ -326,7 +326,7 @@ Each skeleton member is accompanied by a top-level static implementation method 
 Each extension container in source is emitted as an extension container in metadata.  
 - Its name is unspeakable and determined based on the lexical order in the program.  
   The name is not guaranteed to remain stable across re-compilation. 
-  Below we use `<Extension>ee_` followed by an index. For example: `<Extension>ee_2`.  
+  Below we use `<>E__` followed by an index. For example: `<>E__2`.  
 - Its type parameters are those declared in source (including attributes).  
 
 Method/property/indexer declarations in an extension container in source are represented as skeleton declarations in metadata.  
@@ -380,14 +380,14 @@ is emitted as
 ```
 static class IEnumerableExtensions
 {
-    private static class <Extension>ee_1<T>
+    private static class <>E__1<T>
     {
         public static <Extension>$(IEnumerable<T> source) => throw null;
         public void Method() => throw null;
         public static int Property { get => throw null; set => throw null; }
     }
 
-    public static class <Extension>ee_2
+    public static class <>E__2
     {
         public static <Extension>$(IAsyncEnumerable<int> values) => throw null;
         public Task<int> SumAsync() => throw null;

--- a/proposals/extensions.md
+++ b/proposals/extensions.md
@@ -98,6 +98,9 @@ public static class Enumerable
 The type in the receiver specification is referred to as the _receiver type_ and the parameter name,
 if present, is referred to as the _receiver parameter_.
 
+If the _receiver parameter_ has an identifier, the _receiver type_ may not be static.  
+The _receiver parameter_ is only allowed to have the refness modifiers listed below and `scoped`.  
+
 ### Extension members
 
 Extension member declarations are syntactically identical to corresponding instance and static members


### PR DESCRIPTION
This naming convention is more consistent with existing ones (see `GeneratedNames`)