### PR TITLE
Don't promote usage of RuntimeHelpers.Equals for INPC

### DIFF
--- a/proposals/field-keyword.md
+++ b/proposals/field-keyword.md
@@ -145,7 +145,7 @@ class SomeViewModel
 
     private bool Set<T>(ref T location, T value)
     {
-        if (RuntimeHelpers.Equals(location, value))
+        if (EqualityComparer<T>.Default.Equals(location, value))
             return false;
 
         location = value;

--- a/proposals/fieldof.md
+++ b/proposals/fieldof.md
@@ -108,7 +108,7 @@ class SomeViewModel
 
     private bool Set<T>(ref T location, T value)
     {
-        if (RuntimeHelpers.Equals(location, value))
+        if (EqualityComparer<T>.Default.Equals(location, value))
             return false;
 
         location = value;


### PR DESCRIPTION
RuntimeHelpers.Equals is not the one-size-fits-all helper that I once thought it to be. For instance, you don't want to compare strings by reference. Otherwise, to avoid stack overflows, code that responds to PropertyChanged or sets the property begins to need to explicitly worry about whether string references are equal.