### PR TITLE
Add extension doc review to LDM schedule

### DIFF
--- a/meetings/2025/README.md
+++ b/meetings/2025/README.md
@@ -8,6 +8,7 @@ All schedule items must have a public issue or checked-in proposal that can be l
 
 - [Target-typed static member lookup](https://github.com/dotnet/csharplang/blob/main/proposals/target-typed-static-member-lookup.md) (jnm2)
 - Triage (working set)
+- [#9133](https://github.com/dotnet/csharplang/pull/9133) - Specify how [extensions](../../proposals/extensions.md) are displayed in API reference (@billwagner, @gewarren).
 
 ## Recurring topics
 


### PR DESCRIPTION
Add a review of the doc specification for extension members. 

See #9133 for specification