### PR TITLE
Use space as separator in ignored directives

### DIFF
--- a/proposals/ignored-directives.md
+++ b/proposals/ignored-directives.md
@@ -9,9 +9,9 @@ Add `#:` directive prefix to be used by tooling, but ignored by the language.
 ```cs
 #!/usr/bin/dotnet run
 #:sdk      Microsoft.NET.Sdk.Web
-#:property TargetFramework=net11.0
-#:property LangVersion=preview
-#:package  System.CommandLine=2.0.0-*
+#:property TargetFramework net11.0
+#:property LangVersion preview
+#:package  System.CommandLine 2.0.0-*
 
 Console.WriteLine("Hello, World!");
 ```
@@ -82,9 +82,9 @@ We could add each ignored directive to the language instead of introducing one i
 ```cs
 #!/usr/bin/dotnet run
 #sdk      Microsoft.NET.Sdk.Web
-#property TargetFramework=net11.0
-#property LangVersion=preview
-#package  System.CommandLine=2.0.0-*
+#property TargetFramework net11.0
+#property LangVersion preview
+#package  System.CommandLine 2.0.0-*
 #something // unrecognized directives would still be required by the language spec to be an error
 
 Console.WriteLine("Hello, World!");


### PR DESCRIPTION
It's not part of the language spec but it's what we ended up doing in sdk, so updating the examples here to avoid confusing people that read this.