### PR TITLE
Add the speclet disclaimer for published specs

### DIFF
--- a/proposals/extensions.md
+++ b/proposals/extensions.md
@@ -1,5 +1,7 @@
 # Extension members
 
+[!INCLUDE[Specletdisclaimer](./speclet-disclaimer.md)]
+
 Champion issue: <https://github.com/dotnet/csharplang/issues/8697>
 
 ## Declaration

--- a/proposals/field-keyword.md
+++ b/proposals/field-keyword.md
@@ -1,5 +1,7 @@
 # `field` keyword in properties
 
+[!INCLUDE[Specletdisclaimer](./speclet-disclaimer.md)]
+
 Champion issue: <https://github.com/dotnet/csharplang/issues/8635>
 
 ## Summary

--- a/proposals/first-class-span-types.md
+++ b/proposals/first-class-span-types.md
@@ -1,5 +1,7 @@
 # First-class Span Types
 
+[!INCLUDE[Specletdisclaimer](./speclet-disclaimer.md)]
+
 Champion issue: <https://github.com/dotnet/csharplang/issues/8714>
 
 ## Summary

--- a/proposals/null-conditional-assignment.md
+++ b/proposals/null-conditional-assignment.md
@@ -1,5 +1,7 @@
 # Null-conditional assignment
 
+[!INCLUDE[Specletdisclaimer](./speclet-disclaimer.md)]
+
 Champion issue: <https://github.com/dotnet/csharplang/issues/8677>
 
 ## Summary

--- a/proposals/partial-events-and-constructors.md
+++ b/proposals/partial-events-and-constructors.md
@@ -1,5 +1,7 @@
 # Partial Events and Constructors
 
+[!INCLUDE[Specletdisclaimer](./speclet-disclaimer.md)]
+
 Champion issue: <https://github.com/dotnet/csharplang/issues/9058>
 
 ## Summary

--- a/proposals/simple-lambda-parameters-with-modifiers.md
+++ b/proposals/simple-lambda-parameters-with-modifiers.md
@@ -1,5 +1,7 @@
 # Simple lambda parameters with modifiers
 
+[!INCLUDE[Specletdisclaimer](./speclet-disclaimer.md)]
+
 Champion issue: <https://github.com/dotnet/csharplang/issues/8637>
 
 ## Summary

--- a/proposals/unbound-generic-types-in-nameof.md
+++ b/proposals/unbound-generic-types-in-nameof.md
@@ -1,5 +1,7 @@
 # Unbound generic types in `nameof`
 
+[!INCLUDE[Specletdisclaimer](./speclet-disclaimer.md)]
+
 Champion issue: <https://github.com/dotnet/csharplang/issues/8662>
 
 ## Summary


### PR DESCRIPTION
These are the specifications that are (or will shortly be) published on Learn.

Add the disclaimer that these are the feature specification.