### PR TITLE
Allow using `/main` with top-level statements

### DIFF
--- a/proposals/csharp-9.0/top-level-statements.md
+++ b/proposals/csharp-9.0/top-level-statements.md
@@ -88,7 +88,7 @@ source code.
 
 The method is designated as the entry point of the program. Explicitly declared methods that by convention 
 could be considered as an entry point candidates are ignored. A warning is reported when that happens. It is
-an error to specify `-main:<type>` compiler switch when there are top-level statements.
+possible to specify a different entry point via the `-main:<type>` compiler switch.
 
 The entry point method always has one formal parameter, `string[] args`. The execution environment creates and passes a `string[]` argument containing the command-line arguments that were specified when the application was started. The `string[]` argument is never null, but it may have a length of zero if no command-line arguments were specified. The ‘args’ parameter is in scope  within top-level statements and is not in scope outside of them. Regular name conflict/shadowing rules apply.
 


### PR DESCRIPTION
Implementation: https://github.com/dotnet/roslyn/pull/79577
Motivation: https://github.com/dotnet/csharplang/discussions/9544