### PR TITLE
Add custom union mini-proposals

### DIFF
--- a/meetings/working-groups/discriminated-unions/Custom Unions.md
+++ b/meetings/working-groups/discriminated-unions/Custom Unions.md
@@ -1,0 +1,66 @@
+# Custom Unions
+
+## Summary
+
+[Nominal Type Unions](https://github.com/dotnet/csharplang/blob/main/meetings/working-groups/discriminated-unions/Nominal%20Type%20Unions.md) allow the compiler to generate union types that have special behavior when consumed.
+
+This proposal specifies a pattern that a class or struct declaration can follow in order to get the same special behavior when consumed.
+
+## Motivation
+
+The declaration syntax for nominal unions is intended to cover most green-field situations where people want to specify a union. However, for some scenarios the generated outcome is not optimal or even usable:
+
+- There is already an existing widely consumed library type representing a "union", and the author wants to imbue it with "union powers" without breaking existing usage.
+- For e.g. performance, architectural or interop reasons, the contents of the union need to be stored differently than the default boxed object field used in compiler-generated unions.
+
+## Specification
+
+A type is considered a "custom union type" if it implements the [`IUnion` interface](https://github.com/dotnet/csharplang/tree/main/meetings/working-groups/discriminated-unions). Every constructor on the type that is at least as accessible as the type and takes exactly one parameter contributes the type of that parameter as a case type of the custom union type.
+
+The consumption of such a type as a custom union type is enabled in the following ways:
+
+- **Implicit conversion**: There is an implicit union conversion from each case type to the custom union type. It is implemented by calling the corresponding constructor.
+- **Pattern matching**: Patterns applied to a value of the custom union type (other than always-succeeding patterns such as `_` and `var`) are instead applied to the `IUnion.Value` property.
+- **Exhaustiveness**: Switch expressions covering all the case types of the custom union type are considered exhaustive.
+
+## Example
+
+Say the following type already exists:
+
+```csharp
+public sealed class Result<T>
+{
+    internal Result(object? outcome) => (Value, Error) = outcome switch
+    {
+        Exception error => (default!, error),
+        T value => (value, null),
+        null when default(T) is null => (default!, null);
+        _ => throw new InvalidOperationException(...);
+    };
+    
+    public Result(T value) => (Value, Error) = (value, null);
+    public Result(Exception error) => (Value, Error) = (default!, error);
+    
+    public T Value { get; }
+    public Exception? Error { get; }
+    public bool Succeeded => Error is null;
+}
+```
+
+It can be made a union type simply by implementing the `IUnion` interface:
+
+```csharp
+public sealed class Result<T> : IUnion
+{
+    object? IUnion.Value => Error ?? Value;
+    ... // Existing members
+}
+```
+
+Note that in this example the existing type already has a public `Value` property with a different meaning than the one on the `IUnion` interface, so `IUnion.Value` gets implemented explicitly, and that's the one the compiler will consume for pattern matching purposes.
+
+Note also that the type is only considered to have two case types, `T` and `Exception`, even though it has a third single-parameter constructor. That's because the `object?` constructor is less accessible than the type itself and doesn't count.
+
+## Drawbacks
+
+Not every existing type may be enhanced in a non-breaking way to become a custom union type using these rules. For instance, it may not be able to expose the right set of constructors to establish the desired set of case types - e.g. it relies on factory methods for creating values. It is possible that we need to refine or enhance the mechanism by which a type is interpreted as a custom union type.

--- a/meetings/working-groups/discriminated-unions/Non-boxing Access Pattern for Custom Unions.md
+++ b/meetings/working-groups/discriminated-unions/Non-boxing Access Pattern for Custom Unions.md
@@ -6,7 +6,7 @@ A custom union can provide an alternative, non-boxing means to access its value 
 
 ## Motivation
 
-A motivating scenario to manually implement a [custom union type](Custom%20Unions.md) is to customize how the value is stored to hopefully either match an existing interop layout or to avoid allocations.
+A motivating scenario for manually implementing a [custom union type](Custom%20Unions.md) is to customize how the value is stored to hopefully either match an existing interop layout or to avoid allocations.
 
 However, this goal is hampered by the limitation of the compiler only understanding how to access the value via the `Value` property, resulting in struct values being boxed regardless of layout.
 

--- a/meetings/working-groups/discriminated-unions/Non-boxing Access Pattern for Custom Unions.md
+++ b/meetings/working-groups/discriminated-unions/Non-boxing Access Pattern for Custom Unions.md
@@ -6,7 +6,7 @@ A custom union can provide an alternative, non-boxing means to access its value 
 
 ## Motivation
 
-A motivating scenario to manually implement a [custom union type](https://github.com/dotnet/csharplang/tree/main/meetings/working-groups/discriminated-unions/Custom%20Unions.md) is to customize how the value is stored to hopefully either match an existing interop layout or to avoid allocations.
+A motivating scenario to manually implement a [custom union type](Custom%20Unions.md) is to customize how the value is stored to hopefully either match an existing interop layout or to avoid allocations.
 
 However, this goal is hampered by the limitation of the compiler only understanding how to access the value via the `Value` property, resulting in struct values being boxed regardless of layout.
 

--- a/meetings/working-groups/discriminated-unions/Non-boxing Access Pattern for Custom Unions.md
+++ b/meetings/working-groups/discriminated-unions/Non-boxing Access Pattern for Custom Unions.md
@@ -1,0 +1,127 @@
+# Non-boxing Access Pattern for Custom Unions
+
+## Summary
+
+A custom union can provide an alternative, non-boxing means to access its value by implementing a `TryGetValue` method overload for each case type, as well as a `HasValue` property to check for null.
+
+## Motivation
+
+A motivating scenario to manually implement a [custom union type](https://github.com/dotnet/csharplang/tree/main/meetings/working-groups/discriminated-unions/Custom%20Unions.md) is to customize how the value is stored to hopefully either match an existing interop layout or to avoid allocations.
+
+However, this goal is hampered by the limitation of the compiler only understanding how to access the value via the `Value` property, resulting in struct values being boxed regardless of layout.
+
+This proposal allows custom union types that support non-allocation scenarios, opening the way to possible future first-class syntax for non-allocating unions and to the development of special union types like `Option` and `Result` that would benefit from minimizing or eliminating extra allocations.
+
+## Specification
+
+### Pattern
+
+A custom union may offer non-boxing access to its value by implementing `TryGetValue` methods that accept each of its case types, plus a `HasValue` property to check for null:
+
+```csharp
+public struct MyUnion : IUnion
+{
+    public bool HasValue => ...;
+    public bool TryGetValue(out Case1 value) {...}
+    public bool TryGetValue(out Case2 value) {...}
+    
+    object? IUnion.Value => ...;
+}
+```
+
+### Lowering
+
+When the compiler lowers a type pattern match, and the type involved corresponds to a `TryGetValue` overload, the compiler uses this overload instead of the `Value` property to implement the pattern match.
+
+```csharp
+if (u is Case1 c1) {...}
+```
+
+lowers to:
+
+```csharp
+if (u.TryGetValue(out Case1 c1)) {...}
+```
+
+If multiple `TryGetValue` overloads apply, and overload resolution fails to pick a unique best overload, the compiler will pick one arbitrarily rather than yield an ambiguity error.
+
+When the compiler lowers a `null` constant pattern match, and a `HasValue` property is available, the compiler uses this property instead of the `Value` property to implement the pattern match:
+
+```csharp
+if (u is null) {...}
+```
+
+lowers to:
+
+```csharp
+if (!u.HasValue) {...}
+```
+
+### Well-formedness
+
+It is up to the author of a custom union with non-boxing access to ensure that the behavior of the access methods is functionally equivalent to the behavior of using the `Value` property:
+
+- `u.HasValue` yields true if and only if `u.Value is not null` would yield true
+- `u.TryGetValue(out T value1)` yields true if and only if `u.Value is T value2` would yield true, and `value1` is equal to `value2`.
+
+## Example
+
+Here is an example of a custom union employing a strategy of using separate fields for each case, and an additional field acting as a discriminator.
+
+```csharp
+public record struct Point(double X, double Y);
+public record struct Rectangle(Point TopLeft, Point BottomRight);
+
+public struct PointOrRectangle : IUnion
+{
+    private enum Kind { Null = 0, Point, Rectangle }
+
+    private readonly Kind _kind;
+    private readonly Point _value1;
+    private readonly Rectangle _value2;
+
+    public PointOrRectangle(Point value) =>
+        (_kind, _value1, _value2) = (Kind.Point, value, default);
+
+    public PointOrRectangle(Rectangle value) =>
+        (_kind, _value1, _value2) = (Kind.Rectangle, default, value);
+
+    object? IUnion.Value => 
+        _kind switch 
+        {
+            Kind.Point => _value1, // boxes
+            Kind.Rectangle => _value2, // boxes
+            _ => null
+        };
+
+    public bool HasValue => _kind != Null;
+        
+    public bool TryGetValue(out Point value)
+    {
+        if (_kind == Kind.Point)
+        {
+            value = _value1;
+            return true;
+        }
+        else 
+        {
+            value = default;
+            return false;
+        }
+    }
+
+    public bool TryGetValue(out Rectangle value)
+    {
+        if (_kind == Kind.Rectangle)
+        {
+            value = _value2;
+            return true;
+        }
+        else 
+        {
+            value = default;
+            return false;
+        }
+    }
+}
+```


### PR DESCRIPTION
These two proposals outline how union types can be manually declared, in a way that enables them to be consumed as first-class unions.