### PR TITLE
Fix links to other speclets and the speclet disclaimer

### DIFF
--- a/proposals/csharp-14.0/extension-operators.md
+++ b/proposals/csharp-14.0/extension-operators.md
@@ -1,5 +1,7 @@
 # Extension operators
 
+[!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
+
 ***Note:*** *Does not cover user-defined implicit and explicit conversion operators, which are not yet designed or planned.*
 
 ## Declaration

--- a/proposals/csharp-14.0/extensions.md
+++ b/proposals/csharp-14.0/extensions.md
@@ -1,6 +1,6 @@
 # Extension members
 
-[!INCLUDE[Specletdisclaimer](./speclet-disclaimer.md)]
+[!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
 
 Champion issue: https://github.com/dotnet/csharplang/issues/8697
 
@@ -999,7 +999,7 @@ We'd exclude:
 
 ##### Revisit where `Count`/`Length` extension properties come into play  
 
-#### [Collection expressions](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/collection-expressions.md)
+#### [Collection expressions](../csharp-12.0/collection-expressions.md)
 
 - Extension `Add` works
 - Extension `GetEnumerator` works for spread
@@ -1007,7 +1007,7 @@ We'd exclude:
 - Static `Create` extension methods should not count as a blessed **create** method
 - Should extension countable properties affect collection expressions?
 
-#### [`params` collections](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-13.0/params-collections.md)
+#### [`params` collections](..proposals/csharp-13.0/params-collections.md)
 
 - Extensions `Add` does not affect what types are allowed with `params`
 

--- a/proposals/csharp-14.0/field-keyword.md
+++ b/proposals/csharp-14.0/field-keyword.md
@@ -1,6 +1,6 @@
 # `field` keyword in properties
 
-[!INCLUDE[Specletdisclaimer](./speclet-disclaimer.md)]
+[!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
 
 Champion issue: <https://github.com/dotnet/csharplang/issues/8635>
 
@@ -289,9 +289,9 @@ The nullability of the backing field is determined as follows:
 
 #### Constructor analysis
 
-Currently, an auto property is treated very similarly to an ordinary field in [nullable constructor analysis](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-9.0/nullable-constructor-analysis.md). We extend this treatment to *field-backed properties*, by treating every *field-backed property* as a proxy to its backing field.
+Currently, an auto property is treated very similarly to an ordinary field in [nullable constructor analysis](../proposals/csharp-9.0/nullable-constructor-analysis.md). We extend this treatment to *field-backed properties*, by treating every *field-backed property* as a proxy to its backing field.
 
-We update the following spec language from the previous [proposed approach](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-9.0/nullable-constructor-analysis.md#proposed-approach) to accomplish this:
+We update the following spec language from the previous [proposed approach](../proposals/csharp-9.0/nullable-constructor-analysis.md#proposed-approach) to accomplish this:
 
 > At each explicit or implicit 'return' in a constructor, we give a warning for each member whose flow state is incompatible with its annotations and nullability attributes. **If the member is a field-backed property, the nullable annotation of the backing field is used for this check. Otherwise, the nullable annotation of the member itself is used.** A reasonable proxy for this is: if assigning the member to itself at the return point would produce a nullability warning, then a nullability warning will be produced at the return point.
 

--- a/proposals/csharp-14.0/first-class-span-types.md
+++ b/proposals/csharp-14.0/first-class-span-types.md
@@ -1,6 +1,6 @@
 # First-class Span Types
 
-[!INCLUDE[Specletdisclaimer](./speclet-disclaimer.md)]
+[!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
 
 Champion issue: <https://github.com/dotnet/csharplang/issues/8714>
 
@@ -124,7 +124,7 @@ and instead implement changes so the scenario like the one above would end up su
 #### Variance
 
 The goal of the variance section in _implicit span conversion_ is to replicate some amount of covariance for `System.ReadOnlySpan<T>`. Runtime changes would be required to fully
-implement variance through generics here (see https://github.com/dotnet/csharplang/blob/main/proposals/csharp-13.0/ref-struct-interfaces.md for using `ref struct` types in generics), but we can
+implement variance through generics here (see ../csharp-13.0/ref-struct-interfaces.md for using `ref struct` types in generics), but we can
 allow a limited amount of covariance through use of a proposed .NET 9 API: https://github.com/dotnet/runtime/issues/96952. This will allow the language to treat `System.ReadOnlySpan<T>`
 as if the `T` was declared as `out T` in some scenarios. We do not, however, plumb this variant conversion through _all_ variance scenarios, and do not add it to the definition of
 variance-convertible in [§18.2.3.3](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/interfaces.md#18233-variance-conversion). If in the future, we change the runtime
@@ -598,6 +598,6 @@ Keep things as they are.
 [better-conversion-target]: https://github.com/dotnet/csharpstandard/blob/8c5e008e2fd6057e1bbe802a99f6ce93e5c29f64/standard/expressions.md#12647-better-conversion-target
 [is-type-operator]: https://github.com/dotnet/csharpstandard/blob/8c5e008e2fd6057e1bbe802a99f6ce93e5c29f64/standard/expressions.md#1212121-the-is-type-operator
 
-[ce-or]: https://github.com/dotnet/csharplang/blob/566a4812682ccece4ae4483d640a489287fa9c76/proposals/csharp-12.0/collection-expressions.md#overload-resolution
-[overload-resolution-priority]: https://github.com/dotnet/csharplang/blob/566a4812682ccece4ae4483d640a489287fa9c76/proposals/overload-resolution-priority.md
-[better-collection-conversion-from-expression]: https://github.com/dotnet/csharplang/blob/main/proposals/csharp-13.0/collection-expressions-better-conversion.md#detailed-design
+[ce-or]: ../csharp-12.0/collection-expressions.md#overload-resolution
+[overload-resolution-priority]: ../csharp-13.0/proposals/overload-resolution-priority.md
+[better-collection-conversion-from-expression]: ../csharp-13.0/collection-expressions-better-conversion.md#detailed-design

--- a/proposals/csharp-14.0/ignored-directives.md
+++ b/proposals/csharp-14.0/ignored-directives.md
@@ -1,6 +1,6 @@
 # Ignored directives
 
-[!INCLUDE[Specletdisclaimer](./speclet-disclaimer.md)]
+[!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
 
 Champion issue: <https://github.com/dotnet/csharplang/issues/8617>
 

--- a/proposals/csharp-14.0/null-conditional-assignment.md
+++ b/proposals/csharp-14.0/null-conditional-assignment.md
@@ -1,6 +1,6 @@
 # Null-conditional assignment
 
-[!INCLUDE[Specletdisclaimer](./speclet-disclaimer.md)]
+[!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
 
 Champion issue: <https://github.com/dotnet/csharplang/issues/8677>
 

--- a/proposals/csharp-14.0/optional-and-named-parameters-in-expression-trees.md
+++ b/proposals/csharp-14.0/optional-and-named-parameters-in-expression-trees.md
@@ -1,5 +1,7 @@
 # Support optional and named arguments in Expression trees
 
+[!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
+
 Champion issue: https://github.com/dotnet/csharplang/issues/9246
 
 ## Summary

--- a/proposals/csharp-14.0/partial-events-and-constructors.md
+++ b/proposals/csharp-14.0/partial-events-and-constructors.md
@@ -1,6 +1,6 @@
 # Partial Events and Constructors
 
-[!INCLUDE[Specletdisclaimer](./speclet-disclaimer.md)]
+[!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
 
 Champion issue: <https://github.com/dotnet/csharplang/issues/9058>
 
@@ -279,10 +279,10 @@ For more details, see https://github.com/dotnet/roslyn/issues/77254.
 ## Links
 --------->
 
-[partial-methods-ext]: ./csharp-9.0/extending-partial-methods.md
-[partial-props]: ./csharp-13.0/partial-properties.md
-[partial-props-caller-info]: ./csharp-13.0/partial-properties.md#caller-info-attributes
-[partial-props-signatures]: ./csharp-13.0/partial-properties.md#matching-signatures
+[partial-methods-ext]: ../csharp-9.0/extending-partial-methods.md
+[partial-props]: ../csharp-13.0/partial-properties.md
+[partial-props-caller-info]: ../csharp-13.0/partial-properties.md#caller-info-attributes
+[partial-props-signatures]: ../csharp-13.0/partial-properties.md#matching-signatures
 [partial-events-discussion]: https://github.com/dotnet/csharplang/discussions/8064
 [partial-ordering]: https://github.com/dotnet/csharplang/issues/8966
 [xamarin]: https://github.com/xamarin/xamarin-macios/issues/21308#issuecomment-2447535524

--- a/proposals/csharp-14.0/simple-lambda-parameters-with-modifiers.md
+++ b/proposals/csharp-14.0/simple-lambda-parameters-with-modifiers.md
@@ -1,6 +1,6 @@
 # Simple lambda parameters with modifiers
 
-[!INCLUDE[Specletdisclaimer](./speclet-disclaimer.md)]
+[!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
 
 Champion issue: <https://github.com/dotnet/csharplang/issues/8637>
 
@@ -27,7 +27,7 @@ TryParse<int> parse2 = (string text, out int result) => Int32.TryParse(text, out
 
 ### Grammar
 
-No changes.  The [latest lambda grammar](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/lambda-method-group-defaults.md#detailed-design) is:
+No changes.  The [latest lambda grammar](../csharp-12.0/lambda-method-group-defaults.md#detailed-design) is:
 
 ```g4
 lambda_expression
@@ -53,8 +53,8 @@ This grammar already considers `modifiers* identifier` to be syntactically legal
 1. This does not apply to a lambda without a parameter list. `ref x => x.ToString()` would not be legal.
 1. A lambda parameter list still cannot mix `implicit_anonymous_function_parameter` and `explicit_anonymous_function_parameter` parameters.
 1. `(ref readonly p) =>`, `(scoped ref p) =>`, and `(scoped ref readonly p) =>` will be allowed, just as they are with explicit parameters, due to:
-   - [Low-level struct improvements](csharp-11.0/low-level-struct-improvements.md#syntax) in C# 11
-   - [`ref readonly` parameters](csharp-12.0/ref-readonly-parameters.md#parameter-declarations) in C# 12
+   - [Low-level struct improvements](../csharp-11.0/low-level-struct-improvements.md#syntax) in C# 11
+   - [`ref readonly` parameters](../csharp-12.0/ref-readonly-parameters.md#parameter-declarations) in C# 12
 1. The presence/absence of a type has no impact on whether a modifier is required or optional.  In other words, if a modifier was required
    with a type present, it is still required with the type absent.  Similarly, if a modifier was optional with a type present, it is 
    optional with the type absent.
@@ -71,7 +71,7 @@ parameter list".
 Parameters in an implicitly typed parameter list cannot have a `default_argument`.  They
 can have an `attribute_list`.
 
-The following change is required to [anonymous function conversions](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/lambda-method-group-defaults.md#detailed-design):
+The following change is required to [anonymous function conversions](../csharp-12.0/lambda-method-group-defaults.md#detailed-design):
 
 [...]
 > If F has an explicitly **or implicitly typed parameter list**, each parameter in D has the same type and

--- a/proposals/csharp-14.0/unbound-generic-types-in-nameof.md
+++ b/proposals/csharp-14.0/unbound-generic-types-in-nameof.md
@@ -1,6 +1,6 @@
 # Unbound generic types in `nameof`
 
-[!INCLUDE[Specletdisclaimer](./speclet-disclaimer.md)]
+[!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
 
 Champion issue: <https://github.com/dotnet/csharplang/issues/8662>
 

--- a/proposals/csharp-14.0/user-defined-compound-assignment.md
+++ b/proposals/csharp-14.0/user-defined-compound-assignment.md
@@ -1,6 +1,6 @@
 # User Defined Compound Assignment Operators
 
-[!INCLUDE[Specletdisclaimer](./speclet-disclaimer.md)]
+[!INCLUDE[Specletdisclaimer](../speclet-disclaimer.md)]
 
 Champion issue: https://github.com/dotnet/csharplang/issues/9101
 
@@ -206,7 +206,7 @@ has a special name in metadata.
 The signature of an instance increment operator consists of the operator tokens ('checked'? '++' | 'checked'? '--').
 
 A `checked operator` declaration requires a pair-wise declaration of a `regular operator`. A compile-time error occurs otherwise. 
-See also https://github.com/dotnet/csharplang/blob/main/proposals/csharp-11.0/checked-user-defined-operators.md#semantics.
+See also ../csharp-11.0/checked-user-defined-operators.md#semantics.
 
 The purpose of the method is to adjust the value of the instance to result of the requested increment operation,
 whatever that means in context of the declaring type.
@@ -251,7 +251,7 @@ The signature of a compound assignment operator consists of the operator tokens
 the type of the single parameter. The name of the parameter is not part of a compound assignment operator’s signature.
 
 A `checked operator` declaration requires a pair-wise declaration of a `regular operator`. A compile-time error occurs otherwise.
-See also https://github.com/dotnet/csharplang/blob/main/proposals/csharp-11.0/checked-user-defined-operators.md#semantics.
+See also ../csharp-11.0/checked-user-defined-operators.md#semantics.
 
 The purpose of the method is to adjust the value of the instance to result of ```<instance> <binary operator token> parameter```.
 


### PR DESCRIPTION
Follow up to #9573

Fix links that are causing build issues on Learn.

No semantic changes to any of the specs.