### PR TITLE
Revise 'with()' usage in collection expressions

### DIFF
--- a/proposals/collection-expression-arguments.md
+++ b/proposals/collection-expression-arguments.md
@@ -368,7 +368,7 @@ Span<int> a = [with(), 1, 2, 3]; // error: arguments not supported
 Span<int> b = [with([1, 2]), 3]; // error: arguments not supported
 
 int[] a = [with(), 1, 2, 3]; // error: arguments not supported
-int[] b = [with(length: 1]), 3]; // error: arguments not supported
+int[] b = [with(length: 1), 3]; // error: arguments not supported
 ```
 
 ### Create methods

--- a/proposals/collection-expression-arguments.md
+++ b/proposals/collection-expression-arguments.md
@@ -337,7 +337,7 @@ If the target type is an *interface type*, then:
 
   |Interfaces|Candidate signatures|
   |:---:|:---:|
-  |`IEnumerable<E>`<br>`IReadOnlyCollection<E>`<br>`IReadOnlyList<E>` `()` (no parameters)|
+  |`IEnumerable<E>`<br>`IReadOnlyCollection<E>`<br>`IReadOnlyList<E>`|`()` (no parameters)|
   |`ICollection<E>`<br>`IList<E>`|`()` (no parameters)<br>`(int capacity)`|
   |`IReadOnlyDictionary<K, V>`|`()` (no parameters)<br>`(IEqualityComparer<K>? comparer)`|
   |`IDictionary<K, V>`|`()` (no parameters)<br>`(int capacity)`<br>`(IEqualityComparer<K>? comparer)`<br>`(int capacity, IEqualityComparer<K>? comparer)`|

--- a/proposals/collection-expression-arguments.md
+++ b/proposals/collection-expression-arguments.md
@@ -356,7 +356,7 @@ r = [with(StringComparer.Ordinal)]; // new $PrivateImpl<string, int>(StringCompa
 
 d = [with(capacity: 2)]; // new Dictionary<string, int>(capacity: 2)
 r = [with(capacity: 2)]; // error: 'capacity' parameter not recognized
-d = [with()];            // Legal: empty arguments supported fro interfaces
+d = [with()];            // Legal: empty arguments supported for interfaces
 ```
 
 #### Other target types


### PR DESCRIPTION
Updating the collection-expression-arguments spec with the final conclusions of the LDM.

Chuck had incorporated all feedback up through LDM https://github.com/dotnet/csharplang/blob/main/meetings/2025/LDM-2025-05-12.md#constructor-binding-behavior in PR https://github.com/dotnet/csharplang/pull/9381.

However, the conclusions in that same LDM (https://github.com/dotnet/csharplang/blob/main/meetings/2025/LDM-2025-05-12.md#empty-argument-lists) about `with()` expressions were not incorporated into the spec yet. 

Updating accordingly.