### PR TITLE
Revisions to immediately-enumerated-collection-expressions.md

### DIFF
--- a/proposals/immediately-enumerated-collection-expressions.md
+++ b/proposals/immediately-enumerated-collection-expressions.md
@@ -104,7 +104,7 @@ This proposal doesn't get us 100% of the way there to "conditional element inclu
 string[] items2 = ["a", "b", .. includeRest ? ["c", "d"] : []];
 ```
 
-We are interested in pursuing type inference improvements which we expect to improve things across the board--for calls, foreach, and spreads--all in a similar way.
+We are interested in pursuing type inference improvements which we expect to improve things across the board—for calls, foreach, and spreads—all in a similar way.
 ```cs
 // Make all of the following work using a future type inference improvement:
 M1(cond ? [1] : [2]);


### PR DESCRIPTION
#9754

Have addressed notes from LDM on Monday 13th October.
Adjusted the definition of *best common element type* to be more clear.
Adjusted the spec so that spread cases like `string?[] arr = [.. [null]];` can work, using the element type from the conversion of the containing collection expression.