### PR TITLE
Document 'using static' directive for extension members

### DIFF
--- a/proposals/csharp-14.0/extensions.md
+++ b/proposals/csharp-14.0/extensions.md
@@ -440,7 +440,7 @@ static class E
 }
 ```
 
-A **using_static_directive** still does not import extension methods directly as static methods, so the implementation method for non-static extension methods cannot be invoked as a static method.  
+A **using_static_directive** still does not import extension methods directly as static methods, so the implementation method for non-static extension methods cannot be invoked directly as a static method.  
 ```cs
 using static E;
 


### PR DESCRIPTION
Relates to https://github.com/dotnet/roslyn/pull/79890

Standard as FYI: https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/namespaces.md#1454-using-static-directives