### PR TITLE
Link to SDK docs for file-based programs

### DIFF
--- a/proposals/csharp-14.0/ignored-directives.md
+++ b/proposals/csharp-14.0/ignored-directives.md
@@ -18,7 +18,7 @@ Add `#:` directive prefix to be used by tooling, but ignored by the language.
 Console.WriteLine("Hello, World!");
 ```
 
-See the [SDK documentation for `dotnet run file.cs`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives#file-based-apps) for more details on directives supported in single-file apps.
+See the [SDK documentation for `dotnet run file.cs`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives#file-based-apps) for more details on directives supported in file-based apps.
 
 ## Motivation
 


### PR DESCRIPTION
I found that GitHub Copilot CLI sometimes has trouble with single-file programs. It's unsure about directives and it sees the programs as C# "scripts". I've given it the csharplang link for the feature, but that wasn't sufficient guidance. I'm hoping that the SDK doc will provide useful context to help its understanding.