### PR TITLE
Fix RefSafetyRulesAttribute spec to match implementation

### DIFF
--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -722,7 +722,7 @@ The expectation is that future versions of the compiler will update the ref safe
 If the compiler loads a module that includes a `[module: RefSafetyRules(version)]` _with a `version` other than `11`_, the compiler will report an error for the unrecognized version if there are any calls to methods declared in that module.
 
 When the C#11 compiler _analyzes a method call_:
-- If the module containing the method declaration includes `[module: RefSafetyRules(version)]`, regardless of `version`, the method call is analyzed with C#11 rules.
+- If the module containing the method declaration includes `[module: RefSafetyRules(version)]`, where `version` is `11`, the method call is analyzed with C#11 rules.
 - If the module containing the method declaration is from source, and compiled with `-langversion:11` or with a corlib containing the feature flag for `ref` fields, the method call is analyzed with C#11 rules.
 - _If the module containing the method declaration references `System.Runtime { ver: 7.0 }`, the method call is analyzed with C#11 rules. This rule is a temporary mitigation for modules compiled with earlier previews of C#11 / .NET 7 and will be removed later._
 - Otherwise, the method call is analyzed with C#7.2 rules.


### PR DESCRIPTION
See `RefFieldTests.RefSafetyRulesAttribute_Version`.