### PR TITLE
Update candidate signatures for collection expressions

### DIFF
--- a/proposals/collection-expression-arguments.md
+++ b/proposals/collection-expression-arguments.md
@@ -312,7 +312,7 @@ The above list is augmented to have the following items:
  If a best method signature is found, the semantics are as followed:
 
 * The candidate signatures for `IReadOnlyDictionary<K, V>` are  `()` (which has the same meaning as not having the `with()` element at all), and `(IEqualityComparer<K>)`.  This comparer will be used to appropriately hash and compare the keys in the destination dictionary the compiler chooses to create (see [Non Mutable Interface Translation](https://github.com/dotnet/csharplang/blob/main/proposals/dictionary-expressions.md#non-mutable-interface-translation)). 
-* The candidate signatures for `IDictionary<T>` are the signatures of `Dictionary<K, V>()`, `Dictionary<K, V>(int)`, `Dictionary<K, V>(IEqualityComparer<K>)`< and `Dictionary<K, V>(int, IEqualityComparer<K>)`constructors.  When constructing the value (see [Mutable Interface Translation](https://github.com/dotnet/csharplang/blob/main/proposals/dictionary-expressions.md#mutable-interface-translation)), the respective `Dictionary<K, V>` constructor will be invoked.
+* The candidate signatures for `IDictionary<T>` are the signatures of `Dictionary<K, V>()`, `Dictionary<K, V>(int)`, `Dictionary<K, V>(IEqualityComparer<K>)` and `Dictionary<K, V>(int, IEqualityComparer<K>)`constructors.  When constructing the value (see [Mutable Interface Translation](https://github.com/dotnet/csharplang/blob/main/proposals/dictionary-expressions.md#mutable-interface-translation)), the respective `Dictionary<K, V>` constructor will be invoked.
 * Otherwise, a binding error is reported.
 
 ```csharp


### PR DESCRIPTION
Clarify candidate signatures for collection expressions and dictionary interfaces.