### PR TITLE
Clarify collection element grammar and syntax rules

### DIFF
--- a/proposals/csharp-12.0/collection-expressions.md
+++ b/proposals/csharp-12.0/collection-expressions.md
@@ -67,8 +67,6 @@ primary_no_array_creation_expression
   ;
 ```
 
-Collection literals are [target-typed](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-7.1/target-typed-default.md#motivation).
-
 The grammar for `collection_element` is known to introduce a syntax ambiguity.  Specifically `.. expr` is both exactly the production-body for `spread_element`, and is also reachable through `expression_element -> expression -> ... -> range_expression`.  There is a simple overarching
 rule for `collection_elements`.  Specifically, if the element [lexically](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/lexical-structure.md) starts with `..` then it is *always* treated as a `spread_element`.  For example, `..x ? y : z;` is always treated as a `spread_element`
 (so `.. (x ? y : z)`) even though it can be legally parsed as an expression (like `(..x) ? y : z`).
@@ -76,6 +74,8 @@ rule for `collection_elements`.  Specifically, if the element [lexically](https:
 This is beneficial in two ways.  First, a compiler implementation needs only look at the very first token it seems to determine what to parse
 next (a `spread_element` or `expression_element`).  Second, correspondingly, a user can trivially understand what sort of element they have without
 having to mentally try to parse what follows to see if they should think of it as a spread or an expression.
+
+Collection literals are [target-typed](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-7.1/target-typed-default.md#motivation).
 
 ### Spec clarifications
 [spec-clarifications]: #spec-clarifications


### PR DESCRIPTION
Clarified grammar rules for collection elements and resolved syntax ambiguity regarding the `..` operator.

Going to be updating the collection-expression-arguments spec as well.  But wanted to add this here so the rules are very clear and so we can link back to them in that spec.