### PR TITLE
Add 'Extension indexers' to ASAP schedule

### DIFF
--- a/meetings/2026/README.md
+++ b/meetings/2026/README.md
@@ -4,6 +4,8 @@ All schedule items must have a public issue or checked-in proposal that can be l
 
 ## Schedule ASAP
 
+- Extension indexers (Julien)
+
 ## Schedule when convenient
 
 - [Target-typed static member access](https://github.com/dotnet/csharplang/blob/afad49721a7b9923efbbc36ae6c455d85b994543/proposals/target-typed-static-member-access.md) (jnm2, CyrusNajmabadi)


### PR DESCRIPTION
Added 'Extension indexers' to the ASAP schedule.