### PR TITLE
Extension indexers: disallow on strings and arrays

### DIFF
--- a/proposals/extension-indexers.md
+++ b/proposals/extension-indexers.md
@@ -469,11 +469,13 @@ int[] i = [0, .. c]; // Uses Length, if available, to allocate the right size
 
 Decision (LDM 2026-03-09): no, it's unlikely that an extension would be able to implement this in a performant way, so it would not help for optimization.
 
-### Should implicit indexers come into play for array or string types?
+### ~~Should implicit indexers come into play for array or string types?~~
 
 I propose that implicit indexers not contribute to those scenarios, because they are only possible with a malformed corlib (missing instance `Length`, `GetSubArray` or `GetSubstring`).
 
-### Should extension indexers come into play for array or string types?
+Decision (LDM/Mads by email 2026-04-07): no extension indexers on strings or arrays.
+
+### ~~Should extension indexers come into play for array or string types?~~
 
 The current spec and baseline rules for [array access](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128122-array-access) and [string access](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128123-string-access) mean that extension indexers don't work on arrays or strings.  
 Yet the declaration of such extension indexers is permitted.  
@@ -505,3 +507,4 @@ public static class E
 ```
 Note: there is no question for [pointer element access](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#2464-pointer-element-access) since an extension parameter may not be a pointer type. 
 
+Decision (LDM/Mads by email 2026-04-07): no extension indexers on strings or arrays.

--- a/proposals/extension-indexers.md
+++ b/proposals/extension-indexers.md
@@ -475,6 +475,9 @@ I propose that implicit indexers not contribute to those scenarios, because they
 
 ### Should extension indexers come into play for array types?
 
+The current spec and baseline rules for [array access](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128122-array-access) mean that extension indexers don't work on arrays.  
+Yet the declaration of such extension indexers is permitted.  
+
 ```cs
 C c = ...;
 int[] i = ...;
@@ -488,3 +491,6 @@ public static class E
     }
 }
 ```
+
+Note: there is no question for [pointer element access](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#2464-pointer-element-access) since an extension parameter may not be a pointer type. 
+

--- a/proposals/extension-indexers.md
+++ b/proposals/extension-indexers.md
@@ -468,3 +468,23 @@ int[] i = [0, .. c]; // Uses Length, if available, to allocate the right size
 ```
 
 Decision (LDM 2026-03-09): no, it's unlikely that an extension would be able to implement this in a performant way, so it would not help for optimization.
+
+### Should implicit indexers come into play for array or string types?
+
+This is only possible with a malformed corlib (missing instance `Length`, `GetSubArray` or `GetSubstring`).
+
+### Should extension indexers come into play for array types?
+
+```cs
+C c = ...;
+int[] i = ...;
+_ = i[c];
+
+public static class E
+{
+    extension(int[] i)
+    {
+        public int this[C c] => throw null;
+    }
+}
+```

--- a/proposals/extension-indexers.md
+++ b/proposals/extension-indexers.md
@@ -473,15 +473,14 @@ Decision (LDM 2026-03-09): no, it's unlikely that an extension would be able to 
 
 I propose that implicit indexers not contribute to those scenarios, because they are only possible with a malformed corlib (missing instance `Length`, `GetSubArray` or `GetSubstring`).
 
-### Should extension indexers come into play for array types?
+### Should extension indexers come into play for array or string types?
 
-The current spec and baseline rules for [array access](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128122-array-access) mean that extension indexers don't work on arrays.  
+The current spec and baseline rules for [array access](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128122-array-access) and [string access](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128123-string-access) mean that extension indexers don't work on arrays or strings.  
 Yet the declaration of such extension indexers is permitted.  
 
 ```cs
-C c = ...;
 int[] i = ...;
-_ = i[c];
+_ = i[new C()];
 
 public static class E
 {
@@ -492,5 +491,17 @@ public static class E
 }
 ```
 
+```cs
+string s = "...;
+_ = s[new C()];
+
+public static class E
+{
+    extension(int[] i)
+    {
+        public int this[C c] => throw null;
+    }
+}
+```
 Note: there is no question for [pointer element access](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/unsafe-code.md#2464-pointer-element-access) since an extension parameter may not be a pointer type. 
 

--- a/proposals/extension-indexers.md
+++ b/proposals/extension-indexers.md
@@ -471,7 +471,7 @@ Decision (LDM 2026-03-09): no, it's unlikely that an extension would be able to 
 
 ### Should implicit indexers come into play for array or string types?
 
-This is only possible with a malformed corlib (missing instance `Length`, `GetSubArray` or `GetSubstring`).
+I propose that implicit indexers not contribute to those scenarios, because they are only possible with a malformed corlib (missing instance `Length`, `GetSubArray` or `GetSubstring`).
 
 ### Should extension indexers come into play for array types?
 


### PR DESCRIPTION
Relates to championed proposal: https://github.com/dotnet/csharplang/issues/9856