### PR TITLE
unions.md: Expand usage of `TryGetValue(Nullable<T>)` methods for a pattern that implies checking for a specific type `T`

### DIFF
--- a/proposals/unions.md
+++ b/proposals/unions.md
@@ -350,7 +350,7 @@ if (result is 1) { ... } // if (result.HasValue && result.GetValueOrDefault().Va
 
 The compiler will prefer implementing pattern behavior by means of members prescribed by the non-boxing access pattern. While it is free to do any optimization within the bounds of the well-formedness rules, the following are the minimum set guaranteed to be applied:
 
-* For a pattern that implies checking for a specific type `T`, if a `TryGetValue(S value)` method is available, and there is an identity, or implicit reference/boxing conversion from `T` to `S`, then that method is used to obtain the value. The pattern is then applied to that value. If there is more than one such method, then any where the conversion from `T` to `S` is not a boxing conversion is preferred if available. If there is still more than one method, one is chosen in an implementation-defined manner.
+* For a pattern that implies checking for a specific type `T`, if a `TryGetValue(S value)` method is available, and there is an identity, or implicit reference/boxing conversion from `T` to `S`, or `S` is a `Nullable<T>`, then that method is used to obtain the value. The pattern is then applied to that value. If there is more than one such method, then any where the conversion from `T` to `S` is not a boxing conversion is preferred if available. If there is still more than one method, one is chosen in an implementation-defined manner.
 * Otherwise, for a pattern that implies checking for `null`, if a `HasValue` property is available, that property is used to check if the union value is null.
 * Otherwise, the pattern is applied to the result of accessing the `IUnion.Value` property on the incoming union.
 


### PR DESCRIPTION
Otherwise the following scenario doesn't use `TryGetValue`:
```
[System.Runtime.CompilerServices.Union]
struct S1
{
    private readonly object _value;
    public S1(int? x) { _value = x; }
    public S1(string x) { _value = x; }
    public object Value => _value;
    public bool TryGetValue(out int? x) { if (_value is int v) { x = v; return true; } x = null; return false; }

    static bool Test1(S1 u)
    {
        return u is int;
    }   
}
```