### PR TITLE
Rewrite Detailed design of labeled break/continue proposal

### DIFF
--- a/proposals/labeled-break-continue.md
+++ b/proposals/labeled-break-continue.md
@@ -158,140 +158,94 @@ label, and it is possible to reference that label from their respective `continu
 
 ## Detailed design
 
-### Grammar changes
+The following updates are presented as a diff against the corresponding sections of the C# 6 standard
+([statements.md](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md)).
+Throughout this section, ~~strikethrough~~ indicates text being removed from the existing specification,
+and **bold** indicates text being added. Unchanged prose is quoted verbatim for context.
 
-The grammar for `break` and `continue` statements is extended to allow an optional identifier:
+### [§12.5 Labeled statements](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#125-labeled-statements)
 
-```diff
- break_statement
--    : 'break' ';'
-+    : 'break' identifier? ';'
-     ;
+Insert the following paragraph immediately after the existing paragraph "*A label can be referenced from `goto` statements ([§12.10.4](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12104-the-goto-statement)) within the scope of the label.*":
 
- continue_statement
--    : 'continue' ';'
-+    : 'continue' identifier? ';'
-     ;
-```
+> **If the *statement* immediately nested within a *labeled_statement* is a *switch_statement* ([§12.8.3](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1283-the-switch-statement)) or an *iteration_statement* ([§12.9](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#129-iteration-statements)), the nested statement is said to be *labeled with* the *identifier* of the *labeled_statement*. A *break_statement* ([§12.10.2](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12102-the-break-statement)) or *continue_statement* ([§12.10.3](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12103-the-continue-statement)) can specify such an *identifier* to reference the containing labeled statement.**
+>
+> > ***Note**: Only the *statement* that is **immediately** nested within a *labeled_statement* is labeled with that identifier. For example, given `a: b: while (…) …`, only `b` labels the *iteration_statement*; `a` labels the inner *labeled_statement* `b: while (…) …`, which is not itself a *switch_statement* or *iteration_statement*. Consequently, `break a;` or `continue a;` appearing within the loop body does not target the `while` statement. **end note***
 
-### Semantic rules
+### [§12.10.2 The break statement](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12102-the-break-statement)
 
-#### Label requirements
+> ~~The `break` statement exits the nearest enclosing `switch`, `while`, `do`, `for`, or `foreach` statement.~~ **The `break` statement exits the nearest enclosing *switch_statement* ([§12.8.3](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1283-the-switch-statement)) or *iteration_statement* ([§12.9](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#129-iteration-statements)), or, if an *identifier* is specified, the nearest enclosing *switch_statement* or *iteration_statement* labeled with that *identifier* (see [§12.5](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#125-labeled-statements)).**
+>
+> ```ANTLR
+> break_statement
+>     : 'break' identifier? ';'
+>     ;
+> ```
+>
+> The target of a `break` statement is the end point of the nearest enclosing ~~`switch`, `while`, `do`, `for`, or `foreach` statement~~ **statement determined as above**. ~~If a `break` statement is not enclosed by a `switch`, `while`, `do`, `for`, or `foreach` statement, a compile-time error occurs.~~ **If no such enclosing statement exists, a compile-time error occurs.**
+>
+> ~~When multiple `switch`, `while`, `do`, `for`, or `foreach` statements are nested within each other, a `break` statement applies only to the innermost statement. To transfer control across multiple nesting levels, a `goto` statement ([§12.10.4](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12104-the-goto-statement)) shall be used.~~
+>
+> A `break` statement cannot exit a `finally` block ([§12.11](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1211-the-try-statement)). When a `break` statement occurs within a `finally` block, the target of the `break` statement shall be within the same `finally` block; otherwise a compile-time error occurs.
+>
+> A `break` statement is executed as follows:
+>
+> - If the `break` statement exits one or more `try` blocks with associated `finally` blocks, control is initially transferred to the `finally` block of the innermost `try` statement. When and if control reaches the end point of a `finally` block, control is transferred to the `finally` block of the next enclosing `try` statement. This process is repeated until the `finally` blocks of all intervening `try` statements have been executed.
+> - Control is transferred to the target of the `break` statement.
+>
+> Because a `break` statement unconditionally transfers control elsewhere, the end point of a `break` statement is never reachable.
+>
+> > ***Example**: A labeled `break` resolves to the nearest enclosing *switch_statement* or *iteration_statement* with the matching label:*
+> >
+> > ```csharp
+> > outer: for (int i = 0; i < 10; i++)
+> > {
+> >     for (int j = 0; j < 10; j++)
+> >     {
+> >         if (i * j > 20)
+> >             break outer; // exits the outer for-loop
+> >     }
+> > }
+> > ```
+> >
+> > ***end example***
 
-When a `break` or `continue` statement includes an identifier:
+### [§12.10.3 The continue statement](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12103-the-continue-statement)
 
-1. The identifier must refer to a label on a labeled statement that lexically contains the `break` or `continue` statement.
-
-2. For `break` statements, the labeled statement must be one of:
-   - An iteration statement (`for`, `foreach`, `while`, or `do` statement)
-   - A `switch` statement
-
-3. For `continue` statements, the labeled statement must be an iteration statement (`for`, `foreach`, `while`, or `do` statement).
-
-4. It is a compile-time error if the identifier does not refer to a label in scope.
-
-5. It is a compile-time error if the label refers to a statement that does not meet the requirements above.
-
-#### Updated `break` statement semantics
-
-The existing semantics of the `break` statement are updated as follows:
-
-```diff
- A break statement exits the nearest enclosing switch statement,
--while statement, do statement, for statement, or foreach statement.
-+while statement, do statement, for statement, or foreach statement,
-+or, if an identifier is specified, the labeled statement identified
-+by that label.
-+
-+When an identifier is specified, the labeled statement must be a
-+switch statement or iteration statement that lexically contains the
-+break statement.
-
- The target of a break statement is the end point of the nearest
--enclosing switch statement, while statement, do statement, for statement,
--or foreach statement.
-+enclosing construct (as determined above).
-```
-
-#### Updated `continue` statement semantics
-
-The existing semantics of the `continue` statement are updated as follows:
-
-```diff
- A continue statement starts a new iteration of the nearest enclosing
--while statement, do statement, for statement, or foreach statement.
-+while statement, do statement, for statement, or foreach statement,
-+or, if an identifier is specified, the labeled iteration statement
-+identified by that label.
-+
-+When an identifier is specified, the labeled statement must be an
-+iteration statement that lexically contains the continue statement.
-
- The target of a continue statement is the end point of the embedded
--statement of the nearest enclosing while statement, do statement, for
--statement, or foreach statement.
-+statement of the enclosing construct (as determined above).
-```
-
-### Behavior
-
-A `break` statement with a label behaves exactly as if it were an unlabeled `break` statement directly
-within the labeled construct. Similarly, a `continue` statement with a label behaves as if it were an
-unlabeled `continue` directly within the labeled iteration statement.
-
-For example, these two code fragments are semantically equivalent:
-
-```csharp
-// With labeled break
-outer: for (int i = 0; i < 10; i++)
-{
-    for (int j = 0; j < 10; j++)
-    {
-        if (i * j > 20)
-            break outer;
-    }
-}
-```
-
-```csharp
-// Equivalent using goto
-for (int i = 0; i < 10; i++)
-{
-    for (int j = 0; j < 10; j++)
-    {
-        if (i * j > 20)
-            goto END_OUTER;
-    }
-}
-END_OUTER: ;
-```
-
-And for `continue`:
-
-```csharp
-// With labeled continue  
-outer: for (int i = 0; i < 10; i++)
-{
-    for (int j = 0; j < 10; j++)
-    {
-        if (ShouldSkip(i, j))
-            continue outer;
-    }
-}
-```
-
-```csharp
-// Equivalent using goto
-for (int i = 0; i < 10; i++)
-{
-    for (int j = 0; j < 10; j++)
-    {
-        if (ShouldSkip(i, j))
-            goto CONTINUE_OUTER;
-    }
-    CONTINUE_OUTER: ;
-}
-```
+> ~~The `continue` statement starts a new iteration of the nearest enclosing `while`, `do`, `for`, or `foreach` statement.~~ **The `continue` statement starts a new iteration of the nearest enclosing *iteration_statement* ([§12.9](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#129-iteration-statements)), or, if an *identifier* is specified, the nearest enclosing *iteration_statement* labeled with that *identifier* (see [§12.5](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#125-labeled-statements)).**
+>
+> ```ANTLR
+> continue_statement
+>     : 'continue' identifier? ';'
+>     ;
+> ```
+>
+> The target of a `continue` statement is the end point of the embedded statement of the nearest enclosing ~~`while`, `do`, `for`, or `foreach` statement~~ **_iteration_statement_ determined as above**. ~~If a `continue` statement is not enclosed by a `while`, `do`, `for`, or `foreach` statement, a compile-time error occurs.~~ **If no such enclosing statement exists, a compile-time error occurs.**
+>
+> ~~When multiple `while`, `do`, `for`, or `foreach` statements are nested within each other, a `continue` statement applies only to the innermost statement. To transfer control across multiple nesting levels, a `goto` statement ([§12.10.4](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12104-the-goto-statement)) shall be used.~~
+>
+> A `continue` statement cannot exit a `finally` block ([§12.11](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1211-the-try-statement)). When a `continue` statement occurs within a `finally` block, the target of the `continue` statement shall be within the same `finally` block; otherwise a compile-time error occurs.
+>
+> A `continue` statement is executed as follows:
+>
+> - If the `continue` statement exits one or more `try` blocks with associated `finally` blocks, control is initially transferred to the `finally` block of the innermost `try` statement. When and if control reaches the end point of a `finally` block, control is transferred to the `finally` block of the next enclosing `try` statement. This process is repeated until the `finally` blocks of all intervening `try` statements have been executed.
+> - Control is transferred to the target of the `continue` statement.
+>
+> Because a `continue` statement unconditionally transfers control elsewhere, the end point of a `continue` statement is never reachable.
+>
+> > ***Example**: A labeled `continue` resolves to the nearest enclosing *iteration_statement* with the matching label:*
+> >
+> > ```csharp
+> > outer: for (int i = 0; i < 10; i++)
+> > {
+> >     for (int j = 0; j < 10; j++)
+> >     {
+> >         if (ShouldSkip(i, j))
+> >             continue outer; // continues the outer for-loop
+> >     }
+> > }
+> > ```
+> >
+> > ***end example***
 
 ## Drawbacks/Alternatives
 

--- a/proposals/labeled-break-continue.md
+++ b/proposals/labeled-break-continue.md
@@ -167,85 +167,85 @@ and **bold** indicates text being added. Unchanged prose is quoted verbatim for 
 
 Insert the following paragraph immediately after the existing paragraph "*A label can be referenced from `goto` statements ([§12.10.4](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12104-the-goto-statement)) within the scope of the label.*":
 
-> **If the *statement* immediately nested within a *labeled_statement* is a *switch_statement* ([§12.8.3](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1283-the-switch-statement)) or an *iteration_statement* ([§12.9](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#129-iteration-statements)), the nested statement is said to be *labeled with* the *identifier* of the *labeled_statement*. A *break_statement* ([§12.10.2](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12102-the-break-statement)) or *continue_statement* ([§12.10.3](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12103-the-continue-statement)) can specify such an *identifier* to reference the containing labeled statement.**
->
-> > ***Note**: Only the *statement* that is **immediately** nested within a *labeled_statement* is labeled with that identifier. For example, given `a: b: while (…) …`, only `b` labels the *iteration_statement*; `a` labels the inner *labeled_statement* `b: while (…) …`, which is not itself a *switch_statement* or *iteration_statement*. Consequently, `break a;` or `continue a;` appearing within the loop body does not target the `while` statement. **end note***
+**If the *statement* immediately nested within a *labeled_statement* is a *switch_statement* ([§12.8.3](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1283-the-switch-statement)) or an *iteration_statement* ([§12.9](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#129-iteration-statements)), the nested statement is said to be *labeled with* the *identifier* of the *labeled_statement*. A *break_statement* ([§12.10.2](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12102-the-break-statement)) or *continue_statement* ([§12.10.3](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12103-the-continue-statement)) can specify such an *identifier* to reference the containing labeled statement.**
+
+> ***Note**: Only the *statement* that is **immediately** nested within a *labeled_statement* is labeled with that identifier. For example, given `a: b: while (…) …`, only `b` labels the *iteration_statement*; `a` labels the inner *labeled_statement* `b: while (…) …`, which is not itself a *switch_statement* or *iteration_statement*. Consequently, `break a;` or `continue a;` appearing within the loop body does not target the `while` statement. **end note***
 
 ### [§12.10.2 The break statement](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12102-the-break-statement)
 
-> ~~The `break` statement exits the nearest enclosing `switch`, `while`, `do`, `for`, or `foreach` statement.~~ **The `break` statement exits the nearest enclosing *switch_statement* ([§12.8.3](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1283-the-switch-statement)) or *iteration_statement* ([§12.9](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#129-iteration-statements)), or, if an *identifier* is specified, the nearest enclosing *switch_statement* or *iteration_statement* labeled with that *identifier* (see [§12.5](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#125-labeled-statements)).**
+~~The `break` statement exits the nearest enclosing `switch`, `while`, `do`, `for`, or `foreach` statement.~~ **The `break` statement exits the nearest enclosing *switch_statement* ([§12.8.3](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1283-the-switch-statement)) or *iteration_statement* ([§12.9](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#129-iteration-statements)), or, if an *identifier* is specified, the nearest enclosing *switch_statement* or *iteration_statement* labeled with that *identifier* (see [§12.5](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#125-labeled-statements)).**
+
+```ANTLR
+break_statement
+    : 'break' identifier? ';'
+    ;
+```
+
+The target of a `break` statement is the end point of the nearest enclosing ~~`switch`, `while`, `do`, `for`, or `foreach` statement~~ **statement determined as above**. ~~If a `break` statement is not enclosed by a `switch`, `while`, `do`, `for`, or `foreach` statement, a compile-time error occurs.~~ **If no such enclosing statement exists, a compile-time error occurs.**
+
+~~When multiple `switch`, `while`, `do`, `for`, or `foreach` statements are nested within each other, a `break` statement applies only to the innermost statement. To transfer control across multiple nesting levels, a `goto` statement ([§12.10.4](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12104-the-goto-statement)) shall be used.~~
+
+A `break` statement cannot exit a `finally` block ([§12.11](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1211-the-try-statement)). When a `break` statement occurs within a `finally` block, the target of the `break` statement shall be within the same `finally` block; otherwise a compile-time error occurs.
+
+A `break` statement is executed as follows:
+
+- If the `break` statement exits one or more `try` blocks with associated `finally` blocks, control is initially transferred to the `finally` block of the innermost `try` statement. When and if control reaches the end point of a `finally` block, control is transferred to the `finally` block of the next enclosing `try` statement. This process is repeated until the `finally` blocks of all intervening `try` statements have been executed.
+- Control is transferred to the target of the `break` statement.
+
+Because a `break` statement unconditionally transfers control elsewhere, the end point of a `break` statement is never reachable.
+
+> ***Example**: A labeled `break` resolves to the nearest enclosing *switch_statement* or *iteration_statement* with the matching label:*
 >
-> ```ANTLR
-> break_statement
->     : 'break' identifier? ';'
->     ;
+> ```csharp
+> outer: for (int i = 0; i < 10; i++)
+> {
+>     for (int j = 0; j < 10; j++)
+>     {
+>         if (i * j > 20)
+>             break outer; // exits the outer for-loop
+>     }
+> }
 > ```
 >
-> The target of a `break` statement is the end point of the nearest enclosing ~~`switch`, `while`, `do`, `for`, or `foreach` statement~~ **statement determined as above**. ~~If a `break` statement is not enclosed by a `switch`, `while`, `do`, `for`, or `foreach` statement, a compile-time error occurs.~~ **If no such enclosing statement exists, a compile-time error occurs.**
->
-> ~~When multiple `switch`, `while`, `do`, `for`, or `foreach` statements are nested within each other, a `break` statement applies only to the innermost statement. To transfer control across multiple nesting levels, a `goto` statement ([§12.10.4](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12104-the-goto-statement)) shall be used.~~
->
-> A `break` statement cannot exit a `finally` block ([§12.11](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1211-the-try-statement)). When a `break` statement occurs within a `finally` block, the target of the `break` statement shall be within the same `finally` block; otherwise a compile-time error occurs.
->
-> A `break` statement is executed as follows:
->
-> - If the `break` statement exits one or more `try` blocks with associated `finally` blocks, control is initially transferred to the `finally` block of the innermost `try` statement. When and if control reaches the end point of a `finally` block, control is transferred to the `finally` block of the next enclosing `try` statement. This process is repeated until the `finally` blocks of all intervening `try` statements have been executed.
-> - Control is transferred to the target of the `break` statement.
->
-> Because a `break` statement unconditionally transfers control elsewhere, the end point of a `break` statement is never reachable.
->
-> > ***Example**: A labeled `break` resolves to the nearest enclosing *switch_statement* or *iteration_statement* with the matching label:*
-> >
-> > ```csharp
-> > outer: for (int i = 0; i < 10; i++)
-> > {
-> >     for (int j = 0; j < 10; j++)
-> >     {
-> >         if (i * j > 20)
-> >             break outer; // exits the outer for-loop
-> >     }
-> > }
-> > ```
-> >
-> > ***end example***
+> ***end example***
 
 ### [§12.10.3 The continue statement](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12103-the-continue-statement)
 
-> ~~The `continue` statement starts a new iteration of the nearest enclosing `while`, `do`, `for`, or `foreach` statement.~~ **The `continue` statement starts a new iteration of the nearest enclosing *iteration_statement* ([§12.9](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#129-iteration-statements)), or, if an *identifier* is specified, the nearest enclosing *iteration_statement* labeled with that *identifier* (see [§12.5](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#125-labeled-statements)).**
+~~The `continue` statement starts a new iteration of the nearest enclosing `while`, `do`, `for`, or `foreach` statement.~~ **The `continue` statement starts a new iteration of the nearest enclosing *iteration_statement* ([§12.9](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#129-iteration-statements)), or, if an *identifier* is specified, the nearest enclosing *iteration_statement* labeled with that *identifier* (see [§12.5](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#125-labeled-statements)).**
+
+```ANTLR
+continue_statement
+    : 'continue' identifier? ';'
+    ;
+```
+
+The target of a `continue` statement is the end point of the embedded statement of the nearest enclosing ~~`while`, `do`, `for`, or `foreach` statement~~ **_iteration_statement_ determined as above**. ~~If a `continue` statement is not enclosed by a `while`, `do`, `for`, or `foreach` statement, a compile-time error occurs.~~ **If no such enclosing statement exists, a compile-time error occurs.**
+
+~~When multiple `while`, `do`, `for`, or `foreach` statements are nested within each other, a `continue` statement applies only to the innermost statement. To transfer control across multiple nesting levels, a `goto` statement ([§12.10.4](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12104-the-goto-statement)) shall be used.~~
+
+A `continue` statement cannot exit a `finally` block ([§12.11](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1211-the-try-statement)). When a `continue` statement occurs within a `finally` block, the target of the `continue` statement shall be within the same `finally` block; otherwise a compile-time error occurs.
+
+A `continue` statement is executed as follows:
+
+- If the `continue` statement exits one or more `try` blocks with associated `finally` blocks, control is initially transferred to the `finally` block of the innermost `try` statement. When and if control reaches the end point of a `finally` block, control is transferred to the `finally` block of the next enclosing `try` statement. This process is repeated until the `finally` blocks of all intervening `try` statements have been executed.
+- Control is transferred to the target of the `continue` statement.
+
+Because a `continue` statement unconditionally transfers control elsewhere, the end point of a `continue` statement is never reachable.
+
+> ***Example**: A labeled `continue` resolves to the nearest enclosing *iteration_statement* with the matching label:*
 >
-> ```ANTLR
-> continue_statement
->     : 'continue' identifier? ';'
->     ;
+> ```csharp
+> outer: for (int i = 0; i < 10; i++)
+> {
+>     for (int j = 0; j < 10; j++)
+>     {
+>         if (ShouldSkip(i, j))
+>             continue outer; // continues the outer for-loop
+>     }
+> }
 > ```
 >
-> The target of a `continue` statement is the end point of the embedded statement of the nearest enclosing ~~`while`, `do`, `for`, or `foreach` statement~~ **_iteration_statement_ determined as above**. ~~If a `continue` statement is not enclosed by a `while`, `do`, `for`, or `foreach` statement, a compile-time error occurs.~~ **If no such enclosing statement exists, a compile-time error occurs.**
->
-> ~~When multiple `while`, `do`, `for`, or `foreach` statements are nested within each other, a `continue` statement applies only to the innermost statement. To transfer control across multiple nesting levels, a `goto` statement ([§12.10.4](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12104-the-goto-statement)) shall be used.~~
->
-> A `continue` statement cannot exit a `finally` block ([§12.11](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1211-the-try-statement)). When a `continue` statement occurs within a `finally` block, the target of the `continue` statement shall be within the same `finally` block; otherwise a compile-time error occurs.
->
-> A `continue` statement is executed as follows:
->
-> - If the `continue` statement exits one or more `try` blocks with associated `finally` blocks, control is initially transferred to the `finally` block of the innermost `try` statement. When and if control reaches the end point of a `finally` block, control is transferred to the `finally` block of the next enclosing `try` statement. This process is repeated until the `finally` blocks of all intervening `try` statements have been executed.
-> - Control is transferred to the target of the `continue` statement.
->
-> Because a `continue` statement unconditionally transfers control elsewhere, the end point of a `continue` statement is never reachable.
->
-> > ***Example**: A labeled `continue` resolves to the nearest enclosing *iteration_statement* with the matching label:*
-> >
-> > ```csharp
-> > outer: for (int i = 0; i < 10; i++)
-> > {
-> >     for (int j = 0; j < 10; j++)
-> >     {
-> >         if (ShouldSkip(i, j))
-> >             continue outer; // continues the outer for-loop
-> >     }
-> > }
-> > ```
-> >
-> > ***end example***
+> ***end example***
 
 ## Drawbacks/Alternatives
 

--- a/proposals/labeled-break-continue.md
+++ b/proposals/labeled-break-continue.md
@@ -169,17 +169,19 @@ Insert the following paragraph immediately after the existing paragraph "*A labe
 
 **If the *statement* immediately nested within a *labeled_statement* is a *switch_statement* ([§12.8.3](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1283-the-switch-statement)) or an *iteration_statement* ([§12.9](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#129-iteration-statements)), the nested statement is said to be *labeled with* the *identifier* of the *labeled_statement*. A *break_statement* ([§12.10.2](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12102-the-break-statement)) or *continue_statement* ([§12.10.3](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12103-the-continue-statement)) can specify such an *identifier* to reference the containing labeled statement.**
 
-> ***Note**: Only the *statement* that is **immediately** nested within a *labeled_statement* is labeled with that identifier. For example, given `a: b: while (…) …`, only `b` labels the *iteration_statement*; `a` labels the inner *labeled_statement* `b: while (…) …`, which is not itself a *switch_statement* or *iteration_statement*. Consequently, `break a;` or `continue a;` appearing within the loop body does not target the `while` statement. **end note***
+***Note**: Only the *statement* that is **immediately** nested within a *labeled_statement* is labeled with that identifier. For example, given `a: b: while (…) …`, only `b` labels the *iteration_statement*; `a` labels the inner *labeled_statement* `b: while (…) …`, which is not itself a *switch_statement* or *iteration_statement*. Consequently, `break a;` or `continue a;` appearing within the loop body does not target the `while` statement. **end note***
 
 ### [§12.10.2 The break statement](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12102-the-break-statement)
-
-~~The `break` statement exits the nearest enclosing `switch`, `while`, `do`, `for`, or `foreach` statement.~~ **The `break` statement exits the nearest enclosing *switch_statement* ([§12.8.3](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1283-the-switch-statement)) or *iteration_statement* ([§12.9](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#129-iteration-statements)), or, if an *identifier* is specified, the nearest enclosing *switch_statement* or *iteration_statement* labeled with that *identifier* (see [§12.5](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#125-labeled-statements)).**
 
 ```ANTLR
 break_statement
     : 'break' identifier? ';'
     ;
 ```
+
+~~The `break` statement exits the nearest enclosing `switch`, `while`, `do`, `for`, or `foreach` statement.~~
+
+**The `break` statement exits the nearest enclosing *switch_statement* ([§12.8.3](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#1283-the-switch-statement)) or *iteration_statement* ([§12.9](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#129-iteration-statements)), or, if an *identifier* is specified, the nearest enclosing *switch_statement* or *iteration_statement* labeled with that *identifier* (see [§12.5](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#125-labeled-statements)).**
 
 The target of a `break` statement is the end point of the nearest enclosing ~~`switch`, `while`, `do`, `for`, or `foreach` statement~~ **statement determined as above**. ~~If a `break` statement is not enclosed by a `switch`, `while`, `do`, `for`, or `foreach` statement, a compile-time error occurs.~~ **If no such enclosing statement exists, a compile-time error occurs.**
 
@@ -211,13 +213,15 @@ Because a `break` statement unconditionally transfers control elsewhere, the end
 
 ### [§12.10.3 The continue statement](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#12103-the-continue-statement)
 
-~~The `continue` statement starts a new iteration of the nearest enclosing `while`, `do`, `for`, or `foreach` statement.~~ **The `continue` statement starts a new iteration of the nearest enclosing *iteration_statement* ([§12.9](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#129-iteration-statements)), or, if an *identifier* is specified, the nearest enclosing *iteration_statement* labeled with that *identifier* (see [§12.5](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#125-labeled-statements)).**
-
 ```ANTLR
 continue_statement
     : 'continue' identifier? ';'
     ;
 ```
+
+~~The `continue` statement starts a new iteration of the nearest enclosing `while`, `do`, `for`, or `foreach` statement.~~ 
+
+**The `continue` statement starts a new iteration of the nearest enclosing *iteration_statement* ([§12.9](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#129-iteration-statements)), or, if an *identifier* is specified, the nearest enclosing *iteration_statement* labeled with that *identifier* (see [§12.5](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/statements.md#125-labeled-statements)).**
 
 The target of a `continue` statement is the end point of the embedded statement of the nearest enclosing ~~`while`, `do`, `for`, or `foreach` statement~~ **_iteration_statement_ determined as above**. ~~If a `continue` statement is not enclosed by a `while`, `do`, `for`, or `foreach` statement, a compile-time error occurs.~~ **If no such enclosing statement exists, a compile-time error occurs.**
 


### PR DESCRIPTION
Rewrites the **Detailed design** section of `proposals/labeled-break-continue.md` to match the implementation and to align with standard C# specification terminology.

## What changes

The proposed spec edits are now expressed as an explicit diff against the C# 6 standard (strikethrough for removals, bold for additions), touching three sections:

- **§12.5 Labeled statements** — add a paragraph defining that a *switch_statement* or *iteration_statement* immediately nested in a *labeled_statement* is *labeled with* the *identifier* of the *labeled_statement*, and that a *break_statement* / *continue_statement* may reference that *identifier*. A `*Note*` clarifies that only the immediately nested statement is labeled — e.g. in `a: b: while (…) …`, only `b` labels the loop; `a` labels the inner *labeled_statement*.
- **§12.10.2 The break statement** — rewritten to exit the nearest enclosing *switch_statement* or *iteration_statement*, or the nearest enclosing one *labeled with* a specified *identifier*. Grammar updated inline to `'break' identifier? ';'`. The out-of-scope rule is collapsed into a single "**If no such enclosing statement exists, a compile-time error occurs.**" sentence. The paragraph directing users to `goto` for multi-level transfers is removed.
- **§12.10.3 The continue statement** — parallel treatment, restricted to *iteration_statement*.

Short `*Example*` blocks are added to §12.10.2 / §12.10.3 illustrating labeled `break outer;` and `continue outer;`.

## What is removed

- The **Label requirements** subsection: redundant once the "nearest enclosing … labeled with" wording is in place; the "nearest enclosing" rule inherently excludes out-of-scope labels.
- The **Behavior** subsection and its `goto`-based "equivalent" examples: no longer accurate or useful now that the feature is defined directly in terms of *iteration_statement* / *switch_statement* semantics, and the normative sections + examples above carry the explanatory load.

## What is unchanged

Summary, Motivation, Drawbacks/Alternatives, Related discussions, and Design meetings sections are untouched.