### PR TITLE
Simplify null-conditional-await proposal: defer to §12.8.8 / §12.8.10

### DIFF
--- a/proposals/null-conditional-await.md
+++ b/proposals/null-conditional-await.md
@@ -29,14 +29,31 @@ which does nothing if `GetX()` was null, and otherwise awaits the task. This com
 ## Detailed design
 [design]: #detailed-design
 
-### Two independent rules
+### `await? t` builds on `?.` and `await`
 
-The semantics of `await? e` are described by two orthogonal rules that are applied independently. Every case in the worked-examples table at the end of this section is a mechanical cross-product of these two rules; the behaviors of `Task`, `Task<T>`, `ValueTask`, `ValueTask<T>`, and arbitrary user-defined awaitables are all consequences of them, not normative cases of their own.
+The semantics of `await? t` are, both intuitively and literally, the composition of two existing language features:
 
-- **Operand-nullability rule**: what does the static type `S` of `e` tell us about whether `e` can be null at runtime? This drives the compile-time error cases and the shape of the runtime null-test. It is entirely independent of what the awaitable produces.
-- **Result-type rule**: given the awaitable's `GetResult()` return type `R`, what is the type of the whole `await? e` expression? This mirrors the shape of the null-conditional member-access rule in [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access) (lift to `Nullable<T>` for non-nullable value types, keep as-is otherwise), updated for modern C#.
+- the *null_conditional_member_access* `?.` of [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access), gating the rest of the expression on the operand's non-nullness, and
+- the ordinary `await` of [§12.9.8.4](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12984-run-time-evaluation-of-await-expressions), evaluating the awaiter on the non-null branch.
 
-The rest of this section specifies the grammar change, then the operand-nullability rule, then the awaitable-pattern resolution over the underlying type, then the result-type rule, then the run-time semantics that tie the two rules together, then the worked-examples table, and finally a set of notes on interactions with existing features.
+Concretely, `await? t` is the *null_conditional_member_access*
+
+```csharp
+(t)?.GetAwaiter().GetResult()
+```
+
+per §12.8.8, with `await` semantics (§12.9.8.4) applied on the non-null branch. When `GetResult()` returns `void`, the same shape is a *null_conditional_invocation_expression* per [§12.8.10](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12810-null-conditional-invocation-expression) instead.
+
+Equivalently, `await? t` has the meaning of:
+
+- `((object)t == null) ? default(X) : await t`, when `t`'s static type is not `Nullable<V>`, or
+- `(!t.HasValue) ? default(X) : await t.Value`, when `t` has type `Nullable<V>`,
+
+where `X` is the type of `await? t` (computed by §12.9.8.3 below) and `t` is evaluated only once. This is the most direct operational mental model, and it is sufficient to read the rest of the proposal without consulting the formal subsections.
+
+The `Nullable<V>` case above is supplied automatically by §12.8.8's existing nullable-value-type-receiver rule (its `P.Value.A` substitution); `await?` does not introduce a separate "underlying type" concept.
+
+Each subsection below identifies which piece of §12.8.8 / §12.8.10 it inherits, and what `await?` plugs in.
 
 ### Grammar
 
@@ -51,24 +68,19 @@ The rest of this section specifies the grammar change, then the operand-nullabil
 
 The null-conditional form of *await_expression* (`'await' '?' unary_expression`, hereafter written `await? t`) is subject to the same placement restrictions as the existing form. For example, it is only allowed in the body of an async function.
 
-### Applicability: operand-nullability rule
+### Applicability
 
 A new subsection is added to [§12.9.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1298-await-expressions):
 
 > #### 12.9.8.5 Applicability of null-conditional await
 >
-> An *await_expression* of the form `await? t` is well-typed only if the static type `S` of `t` is one of the following:
+> An *await_expression* of the form `await? t` is well-typed when all of:
 >
-> - A reference type (class, interface, delegate, or array type), nullable-annotated or not. The runtime null-test is `(object)t == null`.
-> - A type of the form `Nullable<V>` for some non-nullable value type `V`. The runtime null-test is `!t.HasValue`; where the awaitable pattern of [§12.9.8.2](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12982-awaitable-expressions) is applied, the receiver on the non-null branch is `t.Value`.
-> - A type parameter without a `struct` constraint. The runtime null-test is `(object)t == null`; for runtime instantiations where the type argument happens to be a non-nullable value type, the test is trivially false.
-> - `dynamic`. The null-test is performed on the runtime value of `t`.
+> - The static type `S` of `t` is admissible as the operand `P` of a *null_conditional_member_access* `P?.A` per [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access). The runtime null-test on `t` is the one §12.8.8 defines for that `P` — `!t.HasValue` when `S = Nullable<V>`, `(object)t == null` otherwise; for a type-parameter operand whose runtime instantiation is a non-nullable value type, the test is trivially false, exactly as for `P?.A`.
+> - `S` is not a non-nullable value type, nor a type parameter known to be a non-nullable value type (e.g. `where S : struct`, `where S : unmanaged`); such an operand can never be null at runtime, and the `?` is therefore meaningless.
+> - The awaitable pattern of [§12.9.8.2](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12982-awaitable-expressions) is satisfied for `(t)?.GetAwaiter()`.
 >
-> The third bullet covers every type parameter whose instantiations may include a reference type. That includes a type parameter with a `class` constraint, a base-class constraint, an interface constraint, a `notnull` constraint, or no constraints at all.
->
-> In all other cases, `await? t` is a compile-time error, because `t` can never be null and the `?` is therefore meaningless. For example: `S` is a concrete non-nullable value type (such as `ValueTask` or `ValueTask<int>`); `S` is a type parameter with a `struct` constraint; `S` is a type parameter with an `unmanaged` constraint (which itself implies a value type).
->
-> *Note*: The existing rule in [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access) for *null_conditional_member_access* phrases its type-parameter compile-time error in terms of the **result type** of `P.A`, not the **receiver type** `P`. The rule above follows the same pattern: it places no constraint on type-parameter *operands* of `await?` beyond excluding those known to be non-nullable value types; any constraint on type-parameter *results* is handled in §12.9.8.3 below. *end note*
+> *Note*: As in `P?.A`, the spec's type-parameter restriction falls on the **result** of the access rather than the **operand** receiver. An unconstrained, interface-constrained, or `notnull`-constrained type parameter is therefore permitted as `t`; the corresponding restriction on the awaiter's result type `R` is handled in §12.9.8.3 below. *end note*
 
 ### Awaitable expressions
 
@@ -81,7 +93,7 @@ Additions in **bold**:
 > - `t` is of compile-time type `dynamic`
 > - ...
 >
-> **For an *await_expression* of the form `await? t`, the awaitability check above is performed against the *underlying type* `U` of `t`, where `U = V` when `t`'s static type is `Nullable<V>`, and `U = S` (the static type of `t`) otherwise. The awaitable pattern (including extension-method `GetAwaiter` resolution) is applied to `U` in place of `t`'s static type.**
+> **For an *await_expression* of the form `await? t`, the awaitable pattern (including extension-method `GetAwaiter` resolution) is required to be satisfied at the receiver of the dependent `GetAwaiter()` access in `(t)?.GetAwaiter().GetResult()` per [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access) — that is, on `t.Value` when `t` has type `Nullable<V>`, and on `t` otherwise.**
 
 ### Classification
 
@@ -91,17 +103,11 @@ Additions in **bold**:
 
 > The expression `await t` is classified the same way as the expression `(t).GetAwaiter().GetResult()`. Thus, if the return type of `GetResult` is `void`, the *await_expression* is classified as nothing. If it has a non-`void` return type `T`, the *await_expression* is classified as a value of type `T`.
 >
-> **For an *await_expression* of the form `await? t`, let `R` be the return type of `(u).GetAwaiter().GetResult()`, where `u` has the underlying type `U` determined per §12.9.8.2. The classification of `await? t` is determined from `R` as follows:**
->
-> - **If `R` is `void`, `await? t` is classified as *nothing*, and may appear only where a *null_conditional_invocation_expression* ([§12.8.10](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12810-null-conditional-invocation-expression)) is permitted: as a *statement_expression*, *anonymous_function_body*, or *method_body*.**
-> - **Otherwise, if `R` is a type parameter that is not known to be a reference type or a non-nullable value type, a compile-time error occurs. This mirrors the type-parameter restriction on the result type in §12.8.8.**
-> - **Otherwise, if `R` is a non-nullable value type (either a concrete struct type, or a type parameter with a `struct` constraint), `await? t` is classified as a value of type `Nullable<R>`.**
-> - **Otherwise, if `R` is already a nullable value type (i.e. `R = Nullable<V>` for some non-nullable value type `V`), `await? t` is classified as a value of type `R` (unchanged).**
-> - **Otherwise, `R` is a reference type, or a type parameter known to be a reference type, and `await? t` is classified as a value of type `R` with nullable-reference-type annotation `R?`.**
+> **The classification of `await? t` is the classification — and the type, in the non-`void` case — of the *null_conditional_member_access* `(t)?.GetAwaiter().GetResult()` per [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access), or the *null_conditional_invocation_expression* of the same shape per [§12.8.10](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12810-null-conditional-invocation-expression) when `GetResult()` returns `void`. Inheriting §12.8.8 / §12.8.10 here gives `await?` the lift to `Nullable<R>` for non-nullable value-type results, the unchanged classification of an already-`Nullable<V>` result, the reference-type result with its nullable-reference-type annotation, the pointer-type result case, the compile-time error when `R` is a type parameter not known to be a reference type or non-nullable value type, and the *nothing* / statement-position rule for `void` — all without restatement.**
 >
 > **Regardless of branch, `t` is evaluated only once.**
 
-> *Note*: This classification rule is concerned solely with computing the *result type* from the awaiter's `R`. Constraints on the *operand* type `S` of `t` are handled by §12.9.8.5 above. In particular, `await?` is asymmetric in the same way that `P?.A` is: an unconstrained, interface-constrained, or `notnull`-constrained type parameter is permitted as an *operand* (with a runtime null-test), but the same type parameter appearing as the awaiter's *result type* `R` is a compile-time error. *end note*
+> *Note*: `await?` inherits the asymmetry of `P?.A`: an unconstrained, interface-constrained, or `notnull`-constrained type parameter is permitted as the *operand* `t` (with the runtime null-test from §12.9.8.5), but the same type parameter appearing as the awaiter's *result type* `R` is a compile-time error per §12.8.8. *end note*
 
 ### Run-time evaluation
 
@@ -114,38 +120,33 @@ Additions in **bold**:
 > - An awaiter `a` is obtained by evaluating the expression `(t).GetAwaiter()`.
 > - ...
 >
-> **At run-time, the expression `await? t` is evaluated as follows:**
+> **At run-time, `await? t` is evaluated as the *null_conditional_member_access* `(t)?.GetAwaiter().GetResult()` per [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access), or the *null_conditional_invocation_expression* of the same shape per [§12.8.10](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12810-null-conditional-invocation-expression) when `GetResult()` returns `void`, with `await` semantics (§12.9.8.4) applied on the non-null branch. The null-test on `t`, the short-circuit (with `t` evaluated only once), §12.8.8's handling of `t : Nullable<V>` (where the dependent access runs against `t.Value`), and the implicit conversion of the non-null branch's value to the static type of `await? t` are all inherited from §12.8.8 / §12.8.10. In particular, when `t` is null no awaiter is obtained, `IsCompleted`/`OnCompleted`/`UnsafeOnCompleted`/`GetResult` are not invoked, and the enclosing async function is not suspended at this expression — directly because §12.8.8's short-circuit does not evaluate the dependent accesses.**
 >
-> - **`t` is evaluated.**
-> - **The null-test appropriate to `t`'s static type is applied: `!t.HasValue` when `t` has type `Nullable<V>`; otherwise `(object)t == null` (reference types, type parameters, and `dynamic`). For a type-parameter operand whose runtime instantiation is a non-nullable value type, the test is trivially false.**
-> - **If the test indicates that `t` is null, the result of `await? t` is `default(X)`, where `X` is the result type of `await? t` determined by §12.9.8.3. That is, a null reference when `X` is a nullable-annotated reference type, a `Nullable<R>` with `HasValue == false` when `X = Nullable<R>`, or *nothing* when `X` is *nothing* (the `void` case). No awaiter is obtained; `IsCompleted`, `OnCompleted`/`UnsafeOnCompleted`, and `GetResult` are not invoked; and the enclosing async function is not suspended at this expression.**
-> - **Otherwise, run-time evaluation proceeds as for the ordinary `await` expression above, applied to the non-null value of `t` (when `t` has type `Nullable<V>`, the awaitable pattern is applied to `t.Value`), producing a value of type `R`, which is then implicitly converted to the result type `X`.**
+> **Equivalently, `await? t` has the meaning of:**
 >
-> **Equivalently, `await? t` is semantically equivalent to:**
->
-> - **`((object)t == null) ? default(X) : await t`, when `t`'s static type is not `Nullable<V>` (i.e., a reference type, a type parameter, or `dynamic`), or**
+> - **`((object)t == null) ? default(X) : await t`, when `t`'s static type is not `Nullable<V>`, or**
 > - **`(!t.HasValue) ? default(X) : await t.Value`, when `t` has type `Nullable<V>`,**
 >
-> **with `t` evaluated only once and with `X` the result type determined by §12.9.8.3. The conversion from `R` (the type of `await t` / `await t.Value`) to `X` follows the ordinary conditional-expression type rules: when `R` is a non-nullable value type, `X = Nullable<R>` and the non-null branch is implicitly converted via the standard `R`-to-`Nullable<R>` conversion; when `R` is already a nullable value type, a reference type, or a type parameter, `X` and `R` agree (up to nullable-reference-type annotation) and no conversion is needed; when `R` is `void` the whole expression is classified as *nothing* and the equivalence is phrased at statement level rather than expression level.**
+> **where `X` is the type of `await? t` per §12.9.8.3, with `t` evaluated only once and the implicit conversion from the non-null branch's value to `X` following the standard conditional-expression rules.**
 
 ### Worked examples
 
-The following tables are non-normative. They illustrate how the two rules above combine.
+The following tables are non-normative. They illustrate how §12.8.8 / §12.8.10 inheritance plays out for `await? t`.
 
 `await?` is defined in terms of the awaitable pattern ([§12.9.8.2](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12982-awaitable-expressions)) and not in terms of any specific BCL types. The framework types `Task`, `Task<T>`, `ValueTask`, and `ValueTask<T>` appear below purely as illustrative examples of, respectively, reference-type and value-type awaitables; an arbitrary user-defined `class RefAwaitable` or `struct StructAwaitable<T>` that satisfies §12.9.8.2 behaves identically to `Task` or `ValueTask<T>` with the same `GetResult()` return type. The rules apply uniformly.
 
-**Table A. How the operand is null-tested and how the awaitable pattern is resolved (operand-nullability rule, §12.9.8.5 + §12.9.8.2):**
+**Table A. How the operand is null-tested and where the awaitable pattern is resolved (§12.9.8.5 + §12.9.8.2, both inheriting §12.8.8):**
 
 | Static type of `t` | Null test | Awaitable pattern applied to |
 |---|---|---|
 | Reference-type awaitable (e.g. `Task`, `Task<X>`, user `class RefAwaitable`) | `(object)t == null` | `t` |
 | `Nullable<V>` where `V` is a value-type awaitable (e.g. `Nullable<ValueTask>`, `Nullable<ValueTask<X>>`, `Nullable<StructAwaitable<X>>`) | `!t.HasValue` | `t.Value` |
-| Type parameter `S` without a `struct` constraint whose underlying type is awaitable (includes `where S : class`, `where S : SomeBaseClass`, `where S : ISomething`, `where S : notnull`, unconstrained, …) | `(object)t == null` (trivially false at runtime for non-nullable value-type instantiations; the JIT is expected to elide it) | `t` |
+| Type parameter `S` without a `struct` constraint (includes `where S : class`, `where S : SomeBaseClass`, `where S : ISomething`, `where S : notnull`, unconstrained, …) | `(object)t == null` (trivially false at runtime for non-nullable value-type instantiations; the JIT is expected to elide it) | `t` |
 | `dynamic` | Runtime null-test on `t` | `t` |
 | Non-nullable value-type awaitable (e.g. `ValueTask`, `ValueTask<X>`, user `struct StructAwaitable<X>`) | compile-time error | |
 | Type parameter `S` known to be a non-nullable value type (e.g. `where S : struct`, `where S : unmanaged`) | compile-time error | |
 
-**Table B. How the result type of `await? t` is computed from `R = GetResult()`'s return type (result-type rule, §12.9.8.3):**
+**Table B. How the result type of `await? t` is computed from `R = GetResult()`'s return type (§12.9.8.3 inheriting §12.8.8 / §12.8.10):**
 
 | `R` | Classification of `await? t` |
 |---|---|
@@ -170,7 +171,7 @@ The Task/ValueTask behaviors readers typically think about are all mechanical cr
 
 ### Interaction and edge cases
 
-- **Extension `GetAwaiter`** is supported; the awaitable-pattern resolution in §12.9.8.2 runs against the underlying type `U` exactly as for ordinary `await`, including the existing rules for extension-method `GetAwaiter` resolution.
+- **Extension `GetAwaiter`** is supported. §12.9.8.2's awaitable-pattern check (which includes extension-method `GetAwaiter` resolution) runs against the receiver of `(t)?.GetAwaiter()` per §12.8.8 — `t.Value` for `t : Nullable<V>`, `t` otherwise — exactly as for ordinary `await` on those receivers.
 - **`ConfigureAwait(false)`** returns a struct awaitable type (e.g. `ConfiguredTaskAwaitable`). Consequently, `await? task.ConfigureAwait(false)` is a compile-time error per §12.9.8.5 (non-nullable value-type operand). The intended spelling when `task` itself is nullable is `await? task?.ConfigureAwait(false)`: the inner `?.` produces a `Nullable<ConfiguredTaskAwaitable>`, which is a valid `await?` operand.
 - **`await? t` is a *unary_expression***, not a *null_conditional_member_access*. It does not continue a `?.` chain from its left: to apply `await?` to the result of `x?.GetTaskAsync()` the spelling is `await? x?.GetTaskAsync()` (`await?` consumes the result of the entire `?.` chain), not a continuation of that chain.
 - **Statement position** is permitted regardless of whether `GetResult()` returns `void` or a value: `await? task;` where `task` has type `Task<int>?` is a valid statement (the `Nullable<int>` result is discarded), exactly as `x?.IntReturningMethod()` is a valid statement today.

--- a/proposals/null-conditional-await.md
+++ b/proposals/null-conditional-await.md
@@ -31,29 +31,16 @@ which does nothing if `GetX()` was null, and otherwise awaits the task. This com
 
 ### `await? t` builds on `?.` and `await`
 
-The semantics of `await? t` are, both intuitively and literally, the composition of two existing language features:
-
-- the *null_conditional_member_access* `?.` of [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access), gating the rest of the expression on the operand's non-nullness, and
-- the ordinary `await` of [§12.9.8.4](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12984-run-time-evaluation-of-await-expressions), evaluating the awaiter on the non-null branch.
-
-Concretely, `await? t` is the *null_conditional_member_access*
+`await? t` is the composition of two existing features: the *null_conditional_member_access* `?.` of [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access) on the operand, and the ordinary `await` of [§12.9.8.4](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12984-run-time-evaluation-of-await-expressions) on the non-null branch. Concretely, `await? t` has the meaning of:
 
 ```csharp
-(t)?.GetAwaiter().GetResult()
+((object)t == null) ? default(X) : await t        // when t is not Nullable<V>
+(!t.HasValue)       ? default(X) : await t.Value  // when t has type Nullable<V>
 ```
 
-per §12.8.8, with `await` semantics (§12.9.8.4) applied on the non-null branch. When `GetResult()` returns `void`, the same shape is a *null_conditional_invocation_expression* per [§12.8.10](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12810-null-conditional-invocation-expression) instead.
+where `X` is the static type of `await? t` and `t` is evaluated only once. Formally, this is the *null_conditional_member_access* `(t)?.GetAwaiter().GetResult()` per §12.8.8 — or the *null_conditional_invocation_expression* per [§12.8.10](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12810-null-conditional-invocation-expression) when `GetResult()` returns `void` — with `await` substituted on the non-null branch. The `Nullable<V>` operand case follows from §12.8.8's existing `P.Value.A` rule.
 
-Equivalently, `await? t` has the meaning of:
-
-- `((object)t == null) ? default(X) : await t`, when `t`'s static type is not `Nullable<V>`, or
-- `(!t.HasValue) ? default(X) : await t.Value`, when `t` has type `Nullable<V>`,
-
-where `X` is the type of `await? t` (computed by §12.9.8.3 below) and `t` is evaluated only once. This is the most direct operational mental model, and it is sufficient to read the rest of the proposal without consulting the formal subsections.
-
-The `Nullable<V>` case above is supplied automatically by §12.8.8's existing nullable-value-type-receiver rule (its `P.Value.A` substitution); `await?` does not introduce a separate "underlying type" concept.
-
-Each subsection below identifies which piece of §12.8.8 / §12.8.10 it inherits, and what `await?` plugs in.
+Operand applicability, the runtime null-test shape, result-type classification (lift to `Nullable<R>`, NRT annotation, pointer-type result, the type-parameter restriction on the result, and *void* → §12.8.10), and the single-evaluation guarantee are inherited from §12.8.8 / §12.8.10. The only normative content unique to `await?` is the await-semantics substitution on the non-null branch.
 
 ### Grammar
 
@@ -74,13 +61,10 @@ A new subsection is added to [§12.9.8](https://github.com/dotnet/csharpstandard
 
 > #### 12.9.8.5 Applicability of null-conditional await
 >
-> An *await_expression* of the form `await? t` is well-typed when all of:
+> `await? t` is well-typed iff:
 >
-> - The static type `S` of `t` is admissible as the operand `P` of a *null_conditional_member_access* `P?.A` per [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access). The runtime null-test on `t` is the one §12.8.8 defines for that `P` — `!t.HasValue` when `S = Nullable<V>`, `(object)t == null` otherwise; for a type-parameter operand whose runtime instantiation is a non-nullable value type, the test is trivially false, exactly as for `P?.A`.
-> - `S` is not a non-nullable value type, nor a type parameter known to be a non-nullable value type (e.g. `where S : struct`, `where S : unmanaged`); such an operand can never be null at runtime, and the `?` is therefore meaningless.
-> - The awaitable pattern of [§12.9.8.2](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12982-awaitable-expressions) is satisfied for `(t)?.GetAwaiter()`.
->
-> *Note*: As in `P?.A`, the spec's type-parameter restriction falls on the **result** of the access rather than the **operand** receiver. An unconstrained, interface-constrained, or `notnull`-constrained type parameter is therefore permitted as `t`; the corresponding restriction on the awaiter's result type `R` is handled in §12.9.8.3 below. *end note*
+> - The static type `S` of `t` is admissible as the operand `P` of a *null_conditional_member_access* `P?.A` per [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access). The runtime null-test on `t` is the one §12.8.8 specifies for that `P`.
+> - `t` (or `t.Value`, when `t : Nullable<V>`) satisfies the awaitable pattern of [§12.9.8.2](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12982-awaitable-expressions).
 
 ### Awaitable expressions
 
@@ -93,7 +77,7 @@ Additions in **bold**:
 > - `t` is of compile-time type `dynamic`
 > - ...
 >
-> **For an *await_expression* of the form `await? t`, the awaitable pattern (including extension-method `GetAwaiter` resolution) is required to be satisfied at the receiver of the dependent `GetAwaiter()` access in `(t)?.GetAwaiter().GetResult()` per [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access) — that is, on `t.Value` when `t` has type `Nullable<V>`, and on `t` otherwise.**
+> **For `await? t`, the awaitable pattern (including extension-method `GetAwaiter` resolution) is checked on `t.Value` when `t` has type `Nullable<V>`, and on `t` otherwise.**
 
 ### Classification
 
@@ -103,11 +87,9 @@ Additions in **bold**:
 
 > The expression `await t` is classified the same way as the expression `(t).GetAwaiter().GetResult()`. Thus, if the return type of `GetResult` is `void`, the *await_expression* is classified as nothing. If it has a non-`void` return type `T`, the *await_expression* is classified as a value of type `T`.
 >
-> **The classification of `await? t` is the classification — and the type, in the non-`void` case — of the *null_conditional_member_access* `(t)?.GetAwaiter().GetResult()` per [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access), or the *null_conditional_invocation_expression* of the same shape per [§12.8.10](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12810-null-conditional-invocation-expression) when `GetResult()` returns `void`. Inheriting §12.8.8 / §12.8.10 here gives `await?` the lift to `Nullable<R>` for non-nullable value-type results, the unchanged classification of an already-`Nullable<V>` result, the reference-type result with its nullable-reference-type annotation, the pointer-type result case, the compile-time error when `R` is a type parameter not known to be a reference type or non-nullable value type, and the *nothing* / statement-position rule for `void` — all without restatement.**
->
-> **Regardless of branch, `t` is evaluated only once.**
+> **The classification of `await? t` is that of the *null_conditional_member_access* `(t)?.GetAwaiter().GetResult()` per [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access), or the *null_conditional_invocation_expression* of the same shape per [§12.8.10](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12810-null-conditional-invocation-expression) when `GetResult()` returns `void`.**
 
-> *Note*: `await?` inherits the asymmetry of `P?.A`: an unconstrained, interface-constrained, or `notnull`-constrained type parameter is permitted as the *operand* `t` (with the runtime null-test from §12.9.8.5), but the same type parameter appearing as the awaiter's *result type* `R` is a compile-time error per §12.8.8. *end note*
+> *Note*: §12.8.8's type-parameter restriction applies to the result type, not the operand. An unconstrained, interface-constrained, or `notnull`-constrained type parameter is permitted as the operand `t` (per §12.9.8.5) but is a compile-time error as the awaiter's result type `R`. *end note*
 
 ### Run-time evaluation
 
@@ -120,14 +102,12 @@ Additions in **bold**:
 > - An awaiter `a` is obtained by evaluating the expression `(t).GetAwaiter()`.
 > - ...
 >
-> **At run-time, `await? t` is evaluated as the *null_conditional_member_access* `(t)?.GetAwaiter().GetResult()` per [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access), or the *null_conditional_invocation_expression* of the same shape per [§12.8.10](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12810-null-conditional-invocation-expression) when `GetResult()` returns `void`, with `await` semantics (§12.9.8.4) applied on the non-null branch. The null-test on `t`, the short-circuit (with `t` evaluated only once), §12.8.8's handling of `t : Nullable<V>` (where the dependent access runs against `t.Value`), and the implicit conversion of the non-null branch's value to the static type of `await? t` are all inherited from §12.8.8 / §12.8.10. In particular, when `t` is null no awaiter is obtained, `IsCompleted`/`OnCompleted`/`UnsafeOnCompleted`/`GetResult` are not invoked, and the enclosing async function is not suspended at this expression — directly because §12.8.8's short-circuit does not evaluate the dependent accesses.**
->
-> **Equivalently, `await? t` has the meaning of:**
+> **At run-time, `await? t` is evaluated as the *null_conditional_member_access* `(t)?.GetAwaiter().GetResult()` per [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access), or the *null_conditional_invocation_expression* per [§12.8.10](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12810-null-conditional-invocation-expression) when `GetResult()` returns `void`, with `await` on the non-null branch. Equivalently:**
 >
 > - **`((object)t == null) ? default(X) : await t`, when `t`'s static type is not `Nullable<V>`, or**
 > - **`(!t.HasValue) ? default(X) : await t.Value`, when `t` has type `Nullable<V>`,**
 >
-> **where `X` is the type of `await? t` per §12.9.8.3, with `t` evaluated only once and the implicit conversion from the non-null branch's value to `X` following the standard conditional-expression rules.**
+> **with `t` evaluated only once and `X` the type of `await? t` per §12.9.8.3.**
 
 ### Worked examples
 

--- a/proposals/null-conditional-await.md
+++ b/proposals/null-conditional-await.md
@@ -64,6 +64,7 @@ A new subsection is added to [§12.9.8](https://github.com/dotnet/csharpstandard
 > `await? t` is well-typed iff:
 >
 > - The static type `S` of `t` is admissible as the operand `P` of a *null_conditional_member_access* `P?.A` per [§12.8.8](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#1288-null-conditional-member-access). The runtime null-test on `t` is the one §12.8.8 specifies for that `P`.
+> - When `GetResult()` returns non-void, its return type is admissible as the result type of `A` in `P?.A` per §12.8.8 (so, for example, an unconstrained type parameter result is a compile-time error here, just as `P?.A` would be).
 > - `t` (or `t.Value`, when `t : Nullable<V>`) satisfies the awaitable pattern of [§12.9.8.2](https://github.com/dotnet/csharpstandard/blob/standard-v7/standard/expressions.md#12982-awaitable-expressions).
 
 ### Awaitable expressions


### PR DESCRIPTION
## Summary

The detailed-design section of the `null-conditional-await` proposal previously enumerated five classification cases, four operand-applicability cases, and four runtime-evaluation steps in parallel to the existing rules for *null-conditional member access* (§12.8.8) and *null-conditional invocation expression* (§12.8.10). Every one of those cases was a mechanical cross-product of `?.` and `await`.

Recast around a single intuition: **`await? t` is the *null_conditional_member_access* `(t)?.GetAwaiter().GetResult()` per §12.8.8, with `await` semantics applied on the non-null branch.** The classification (lifting to `Nullable<R>`, the type-parameter result restriction, the pointer-type result case, the already-`Nullable<V>` case, NRT annotation), the *void* → §12.8.10 routing, the null-test shape, the `Nullable<V>` operand handling (§12.8.8's `P.Value.A` rule), and the single-evaluation guarantee all fall out of §12.8.8 / §12.8.10 without restatement. Future evolution of those sections (e.g. recent LDM clarifications around pointer results) is automatically inherited.

The only carve-out kept normatively is the operand-side compile-time error on a known non-nullable value-type operand (concrete struct, `where T : struct`, `where T : unmanaged`): `await?` rejects these even though §12.8.8 would admit them with a trivially-false null-test.

## What changed

- **New** *"`await? t` builds on `?.` and `await`"* intuition section. States the equivalence both as `(t)?.GetAwaiter().GetResult()` and as the operational form `((object)t == null) ? default(X) : await t` / `(!t.HasValue) ? default(X) : await t.Value`. A reader who stops at the end of this section has a complete operational mental model.
- **§12.9.8.5 Applicability** collapses to: (a) `S` admissible as `P` in `P?.A` per §12.8.8, (b) value-type-operand carve-out, (c) awaitable pattern on `(t)?.GetAwaiter()`.
- **§12.9.8.2 / §12.9.8.3 / §12.9.8.4** each become a single short paragraph cross-referencing §12.8.8 / §12.8.10 and naming what `await?` plugs in.
- **"Underlying type `U`" auxiliary concept dropped** throughout. §12.8.8's existing nullable-value-type-receiver rule supplies the same behavior.
- **Worked-examples Tables A and B** retained verbatim as non-normative; their headers updated to point at the inheriting subsections.

## Net effect

- No observable behavior change.
- The detailed-design body is shorter and easier to skim.
- Future spec changes to §12.8.8 / §12.8.10 (the LDM has been clarifying these recently around pointer results, type-parameter receivers, etc.) propagate automatically into `await?`.