### PR TITLE
Link champion issue and discussion from typeless-receivers spec

### DIFF
--- a/proposals/extension-members-on-typeless-receivers.md
+++ b/proposals/extension-members-on-typeless-receivers.md
@@ -1,5 +1,8 @@
 # Extension members on typeless receivers
 
+Champion issue: <https://github.com/dotnet/csharplang/issues/10146>
+Discussion: <https://github.com/dotnet/csharplang/discussions/10145>
+
 ## Summary
 
 Allow extension members to be invoked on a receiver expression that has no type:


### PR DESCRIPTION
The [extension members on typeless receivers](https://github.com/dotnet/csharplang/blob/main/proposals/extension-members-on-typeless-receivers.md) speclet was merged in #10142. Adding the standard cross-links so each artifact references the others:

- Champion issue: #10146
- Discussion: https://github.com/dotnet/csharplang/discussions/10145

Both the issue and the discussion already link to the spec; this PR closes the loop on the spec side.