### PR TITLE
Schedule LDM agenda for July 1

### DIFF
--- a/meetings/2026/README.md
+++ b/meetings/2026/README.md
@@ -4,16 +4,12 @@ All schedule items must have a public issue or checked-in proposal that can be l
 
 ## Schedule ASAP
 
-- [Unsafe in `async` methods](https://github.com/dotnet/csharplang/pull/10235) (333fred, jjonescz)
-
 ## Schedule when convenient
 
 - [Labeled `break` and `continue` Statements](https://github.com/dotnet/csharplang/blob/c4ec6fb60c2e174b1abb6c019f22bb15b9b13f6c/proposals/labeled-break-continue.md) (CyrusNajmabadi) Finalize specification.
 - [Final initializers](https://github.com/dotnet/csharplang/blob/5055b97eee8c10d12f822f6d4db9464329615947/proposals/final-initializers.md)
   - [LDM in 2020](https://github.com/dotnet/csharplang/blob/main/meetings/2020/LDM-2020-04-27.md#primary-constructor-bodies-and-validators) approved the syntax. Next is discussing semantics.
 - [Anonymous using declarations](https://github.com/dotnet/csharplang/blob/665a9392e172e6f4f16347c502d9f80220a6e7a4/proposals/anonymous-using-declarations.md) (jnm2, 333fred, CyrusNajmabadi)
-- [Partial extension members](https://github.com/dotnet/csharplang/pull/10126) (Julien)
-- [Extension constants](https://github.com/dotnet/csharplang/blob/main/proposals/extension-constants.md) (Julien)
 - [Extension members on typeless receivers](https://github.com/dotnet/csharplang/blob/main/proposals/extension-members-on-typeless-receivers.md) (CyrusNajmabadi, jnm2)
 - [Collection expression spread optimization question](https://github.com/dotnet/csharplang/issues/10178) (Rikki)
 - [Ref and ref-like parameters of async methods](https://github.com/dotnet/csharplang/blob/c623e9fb9e2c1a61da95cd8d2768117a1c358247/proposals/async-method-ref-parameters.md) (jnm2)
@@ -28,6 +24,10 @@ All schedule items must have a public issue or checked-in proposal that can be l
 ## Schedule
 
 ### Wed Jul 1, 2026
+
+- [Unsafe in `async` methods](https://github.com/dotnet/csharplang/pull/10235) (333fred, jjonescz)
+- [Extension constants](https://github.com/dotnet/csharplang/blob/main/proposals/extension-constants.md) (Julien)
+- [Partial extension members](https://github.com/dotnet/csharplang/pull/10126) (Julien)
 
 ### Wed Jun 10, 2026
 


### PR DESCRIPTION
Schedules the upcoming LDM agenda for July 1, 2026.