### PR TITLE
Add a note about the `RefSafetyRules` ECMA-335 augment in "Low level struct improvements"

### DIFF
--- a/proposals/csharp-11.0/low-level-struct-improvements.md
+++ b/proposals/csharp-11.0/low-level-struct-improvements.md
@@ -745,6 +745,8 @@ namespace System.Runtime.CompilerServices
 }
 ```
 
+Beyond its use by the compiler, `[module: RefSafetyRules(11)]` also carries guarantees about the emitted IL that the runtime is permitted to rely on. For more information see the ECMA-335 augment [III.1.7.7 Opt-in restrictions](https://github.com/dotnet/runtime/blob/main/docs/design/specs/Ecma-335-Augments.md).
+
 ### Safe fixed size buffers
 
 Safe fixed size buffers was not delivered in C# 11. This feature may be implemented in a future version of C#.


### PR DESCRIPTION
We had to remove an optimization from .NET 11 that is illegal according to ECMA 335, but that is legal under C# ref safety rules. 
That optimization turns out to be quite important. For more information see https://github.com/dotnet/runtime/issues/130185.

We are hoping to be able to rely on `RefSafetyRules` to regain this optimization again. The ECMA 335 augment is happening here: https://github.com/dotnet/runtime/pull/130863

Before merging that augment I would like to get an explicit confirmation that the C# team is ok with that. This PR also adds a note to low-level-struct-improvements.md about the cross dependency.