### PR TITLE
Specify type inference for constructor calls

### DIFF
--- a/proposals/inference-for-constructor-calls.md
+++ b/proposals/inference-for-constructor-calls.md
@@ -5,43 +5,38 @@ Champion issue: [dotnet/csharplang#9627](https://github.com/dotnet/csharplang/is
 ## Summary
 [summary]: #summary
 
-This proposal allows a generic type's type argument list to be omitted in an object creation expression and inferred from the constructor arguments:
-
-```csharp
-class Pair<TFirst, TSecond>
-{
-    public Pair(TFirst first, TSecond second) { }
-}
-
-var pair = new Pair("answer", 42); // Pair<string, int>
-```
-
-Inference can also use the target type, as defined by [target-typed generic type inference](https://github.com/dotnet/csharplang/blob/main/proposals/target-typed-generic-type-inference.md).
+An object creation can omit the type arguments of a generic type when they can be inferred from the constructor arguments and target type.
 
 ## Motivation
 [motivation]: #motivation
 
-Generic case types in a hierarchy are often constructed through their generic base type:
+Generic types often have factory methods only because method calls can infer type arguments and constructor calls cannot:
 
 ```csharp
-abstract class Option<T> { }
-sealed class Some<T>(T value) : Option<T> { }
+var pair = Pair.Create("answer", 42);
+var pair = new Pair("answer", 42); // Pair<string, int>
+```
 
+This is also needed when a generic case type is constructed through its generic base type:
+
+```csharp
 Option<string> option = new Some("Hello"); // Some<string>
 ```
 
-Today `Some<string>` must be written explicitly or hidden behind a factory method even though the constructor argument and target contain the required type information.
+Today `Some<string>` must be written explicitly or hidden behind a factory method even though the argument and target contain the required type information.
+
+The [type groups proposal](https://github.com/dotnet/csharplang/pull/10310) supplies the same-name types considered by object creation. The [generalized inference proposal](https://github.com/dotnet/csharplang/pull/10311) supplies the shared inference mechanism. The existing [target-typed generic type inference](target-typed-generic-type-inference.md) proposal owns target-derived behavior.
 
 ## Detailed design
 [design]: #detailed-design
 
-The normative design is in [MadsTorgersen/csharpstandard#3](https://github.com/MadsTorgersen/csharpstandard/pull/3), which updates [`standard/expressions.md`](https://github.com/dotnet/csharpstandard/blob/alpha-v12/standard/expressions.md), primarily [§12.6.3 Type inference](https://github.com/dotnet/csharpstandard/blob/alpha-v12/standard/expressions.md#1263-type-inference) and [§12.8.17.2 Object creation expressions](https://github.com/dotnet/csharpstandard/blob/alpha-v12/standard/expressions.md#128172-object-creation-expressions).
+The authoritative specification changes are in [csharpstandard#3](https://github.com/MadsTorgersen/csharpstandard/pull/3). They update [§12.6.3 Type inference](https://github.com/dotnet/csharpstandard/blob/alpha-v12/standard/expressions.md#1263-type-inference) and [§12.8.17.2 Object creation expressions](https://github.com/dotnet/csharpstandard/blob/alpha-v12/standard/expressions.md#128172-object-creation-expressions).
 
 ### Syntax and lookup
 
-Object creation accepts the `type_group` defined by the [type groups proposal](https://github.com/dotnet/csharplang/pull/10310). Lookup may therefore produce accessible same-name types of different arities. An explicitly bound type, including the implied type of `new()`, produces a singleton group.
+Object creation accepts the `type_group` defined by the type groups proposal. Lookup can therefore produce accessible same-name types of different arities. An explicitly bound type, including the implied type of `new()`, produces a singleton group.
 
-Lookup is complete before constructors are considered. Constructor binding operates on the resulting group.
+Lookup completes before constructors are considered. Constructor binding operates on the resulting group.
 
 ### Constructor inference and candidates
 
@@ -49,22 +44,29 @@ For each accessible constructor of each unbound generic type in the group, infer
 
 - the containing type's type parameters;
 - the constructor parameter types and corresponding object-creation arguments;
-- the constructed containing type as the result type; and
-- the target type of the object creation expression, if any.
+- the containing type with its type parameters as the result type; and
+- the target type of the object creation, if any.
 
-The shared inference algorithm is defined by the [generalized generic type inference proposal](https://github.com/dotnet/csharplang/pull/10311). Target-derived behavior comes from [target-typed generic type inference](https://github.com/dotnet/csharplang/blob/main/proposals/target-typed-generic-type-inference.md).
+This supports inference from the target alone or together with arguments:
+
+```csharp
+Box<string> box = new Box();             // Box<string>
+IEnumerable<string> list = new C(5);     // C<string, int>
+```
+
+In the second example, the argument infers `C`'s count type and the target infers its element type. The linked inference proposals define how these inputs produce bounds and type arguments.
 
 Inference is performed separately for each constructor. Failure to match arguments to parameters or infer all containing-type arguments removes that constructor from consideration.
 
-After substitution, the constructed containing type and constructed types in the parameter list must satisfy their constraints, and the substituted parameter list must be applicable to the arguments. Constructors of bound types require no inference and are candidates when accessible and applicable. The default constructor of a struct with no declared parameterless constructor participates on the same basis.
+After substitution, the constructed containing type and constructed types in the parameter list must satisfy their constraints, and the substituted parameter list must be applicable to the arguments. Constructors of bound types require no inference and are candidates when accessible and applicable. A struct's implicit default constructor participates on the same basis.
 
 ### Selection and result
 
-Candidates from every type in the group form one set. A bound non-generic type is not tried before unbound generic types.
+Candidates from every bound and unbound type in the group form one set. A bound non-generic type is not tried before unbound generic types. Type-group lookup deliberately preserves types of different arities for one later binding operation, just as method-group lookup preserves methods for overload resolution.
 
 Normal overload resolution selects the best constructor using substituted parameter types. For better-function-member rules, a constructor of a generic or non-generic type is treated like a generic or non-generic method, respectively; the containing type's parameters and inferred arguments stand in for method type parameters and arguments.
 
-No applicable candidate or no unique best candidate is a binding-time error. The result type is the type containing the selected constructor, with inferred arguments substituted. Selecting the implicit default constructor of a struct produces the default value of that constructed struct type.
+No applicable candidate or no unique best candidate is a binding-time error. The result type is the type containing the selected constructor, with inferred arguments substituted. Selecting a struct's implicit default constructor produces the default value of that constructed struct type.
 
 Object and collection initializer contents are processed after constructor selection and do not contribute inference bounds. Dynamically bound object creation continues to require a singleton group containing a bound class or struct type.
 
@@ -75,12 +77,20 @@ Object and collection initializer contents are processed after constructor selec
 - Target-derived bounds can change an argument-only inference result, allow a new candidate, or conflict with argument-derived bounds.
 - Adding a same-name generic type can make dynamic construction invalid because dynamic construction requires a singleton bound type group.
 
-## Alternative: phased fallback
+## Alternatives
+[alternatives]: #alternatives
+
+### Phased fallback
 
 Constructor binding could try an existing bound type first and consider unbound generic types only if that produces no applicable constructor. This would preserve more existing selections, but it would discard candidates from a lookup result that deliberately groups types across arities. This proposal instead performs one selection over the complete group.
 
 ## Open questions
 [open]: #open-questions
 
-- Should dynamically bound object creation ever support inference for constructors of generic types? The current design does not.
-- Should object or collection initializer contents ever contribute inference bounds? The current design selects a constructor first.
+### Dynamic inference
+
+Should dynamically bound object creation ever support inference for constructors of generic types? The current design does not.
+
+### Initializer bounds
+
+Should object or collection initializer contents ever contribute inference bounds? The current design selects a constructor first.

--- a/proposals/inference-for-constructor-calls.md
+++ b/proposals/inference-for-constructor-calls.md
@@ -18,7 +18,7 @@ var pair = new Pair("answer", 42); // Pair<string, int>
 
 This puts constructors on a more equal footing with generic factory methods. There should be no need to write a factory method just to get the type inference that method calls already enjoy.
 
-This proposal is the object-creation part of a series. It builds on the sibling proposal for [generalized type inference and target-derived bounds](target-typed-generic-type-inference.md), and on a sibling type-groups proposal (link to be added) that looks up accessible types with the same name across arities. The corresponding normative changes are being developed in [csharpstandard#3](https://github.com/MadsTorgersen/csharpstandard/pull/3).
+This proposal is the object-creation part of a series. It builds on the sibling proposal for [generalized type inference and target-derived bounds](https://github.com/dotnet/csharplang/pull/10311), and on the sibling [type-groups proposal](https://github.com/dotnet/csharplang/pull/10310) that looks up accessible types with the same name across arities. The corresponding normative changes are being developed in [csharpstandard#3](https://github.com/MadsTorgersen/csharpstandard/pull/3).
 
 ## Motivation
 [motivation]: #motivation
@@ -69,7 +69,7 @@ That last example is a useful payoff, but not a special case. The feature applie
 
 ### Type groups in object creation
 
-Object creation consumes the shared `type_group` abstraction from the sibling type-groups proposal. An explicitly bound type produces a singleton group. A type-group name such as `Pair` can produce accessible same-name types of different arities, such as `Pair`, `Pair<T>`, and `Pair<TFirst, TSecond>`. A target-typed `new()` expression likewise starts with its single implied type.
+Object creation consumes the shared `type_group` abstraction from the sibling [type-groups proposal](https://github.com/dotnet/csharplang/pull/10310). An explicitly bound type produces a singleton group. A type-group name such as `Pair` can produce accessible same-name types of different arities, such as `Pair`, `Pair<T>`, and `Pair<TFirst, TSecond>`. A target-typed `new()` expression likewise starts with its single implied type.
 
 Lookup determines the group before constructor binding. In other words, lookup exposes the available arities, and then one constructor-binding operation selects from them. This is deliberately similar to method-group lookup followed by overload resolution.
 
@@ -110,7 +110,7 @@ C<TElement, TCount> M<TElement, TCount>(TCount count);
 IEnumerable<string> l = M(5);
 ```
 
-The generalized inference proposal defines how argument inputs and target-derived result bounds interact. This proposal only supplies the constructor-specific inputs.
+The sibling [generalized inference proposal](https://github.com/dotnet/csharplang/pull/10311) defines how argument inputs and target-derived result bounds interact. This proposal only supplies the constructor-specific inputs.
 
 Inference for a constructor fails if the supplied arguments cannot first be matched to its parameters, or if inference cannot determine all required containing-type arguments. Such a failure only removes that constructor from consideration.
 
@@ -122,9 +122,7 @@ Constructors of bound types do not need inference. They contribute candidates un
 
 ### One combined candidate set
 
-**The design uses one candidate set across all bound and unbound types in the type group. It does not first try a non-generic type and fall back to generic types.**
-
-This is the central selection choice in the proposal. Type-group lookup is method-group-like: it intentionally preserves same-name candidates of different arities for a later binding operation. Once lookup has produced that group, constructor binding should choose the best constructor across the whole group rather than let one arity hide the others procedurally.
+This is the central selection choice: object creation uses one candidate set across every bound and unbound type in the group rather than trying a non-generic type first and falling back to generic ones. Type-group lookup is method-group-like: it intentionally preserves same-name candidates of different arities for a later binding operation. Once lookup has produced that group, constructor binding should choose the best constructor across the whole group rather than let one arity hide the others procedurally.
 
 All constructors that survive inference, substitution, constraint checking, and applicability form one candidate set. Normal overload resolution then selects the best constructor using the substituted parameter types. For the better-function-member rules, a constructor of a generic type is treated as the generic counterpart of a constructor of a non-generic type, with the containing type's parameters and inferred arguments standing in for method type parameters and arguments.
 
@@ -152,7 +150,7 @@ The default constructor of a struct with no declared parameterless constructor p
 
 ### Specification impact
 
-The normative draft updates the C# specification's [`expressions.md` type-inference section](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1263-type-inference) and [`expressions.md` object-creation section](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128172-object-creation-expressions). The shared lookup and generalized inference algorithms are owned by the sibling proposals; this proposal specifies how object creation consumes them.
+The normative draft updates the C# specification's [`expressions.md` type-inference section](https://github.com/dotnet/csharpstandard/blob/alpha-v12/standard/expressions.md#1263-type-inference) and [`expressions.md` object-creation section](https://github.com/dotnet/csharpstandard/blob/alpha-v12/standard/expressions.md#128172-object-creation-expressions). The shared lookup and generalized inference algorithms are owned by the sibling proposals; this proposal specifies how object creation consumes them.
 
 ## Compatibility
 

--- a/proposals/inference-for-constructor-calls.md
+++ b/proposals/inference-for-constructor-calls.md
@@ -1,83 +1,207 @@
-# Target-typed inference for constructor calls
+# Type inference for constructor calls
 
-*This proposal builds on the [target-typed generic type inference](https://github.com/dotnet/csharplang/blob/main/proposals/target-typed-generic-type-inference.md) proposal.
+Champion issue: [dotnet/csharplang#9627](https://github.com/dotnet/csharplang/issues/9627)
 
 ## Summary
+[summary]: #summary
 
-Generic type inference is extended to 'new' expressions, which may infer type arguments for the newly created class or struct, including [from a target type](target-typed-generic-type-inference) if present. For instance, given:
+Constructors of generic types can infer the type arguments of their containing type from the constructor arguments and, when present, the target type:
 
 ```csharp
-public class MyCollection<T> : IEnumerable<T>
+class Pair<TFirst, TSecond>
 {
-    public MyCollection() { ... }
-    ...
+    public Pair(TFirst first, TSecond second) { }
 }
+
+var pair = new Pair("answer", 42); // Pair<string, int>
 ```
 
-We would allow the constructor to be called without a type argument when it can be inferred from arguments or (in this case) a target type:
+This puts constructors on a more equal footing with generic factory methods. There should be no need to write a factory method just to get the type inference that method calls already enjoy.
 
-```csharp
-IEnumerable<string> c = new MyCollection(); // 'T' = 'string' inferred from target type
-```
+This proposal is the object-creation part of a series. It builds on the sibling proposal for [generalized type inference and target-derived bounds](target-typed-generic-type-inference.md), and on a sibling type-groups proposal (link to be added) that looks up accessible types with the same name across arities. The corresponding normative changes are being developed in [csharpstandard#3](https://github.com/MadsTorgersen/csharpstandard/pull/3).
 
 ## Motivation
+[motivation]: #motivation
 
-Even without [target-typed generic type inference](https://github.com/dotnet/csharplang/blob/main/proposals/target-typed-generic-type-inference.md) constructors are at a disadvantage to factory methods, because type arguments cannot be inferred on invocation. This frequently leads to trivial factory methods being declared simply for the benefit of type inference. If target-typed inference is added, this convenience gap is only going to grow.
-
-For constructor calls we already have "target type new" for when a target type is exactly the type to be created, but even when that's not the case, arguments or the target type often have sufficient information between them that the type arguments for the constructed type could be inferred.
-
-This is frequently the case for [closed hierarchies](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-15.0/closed-hierarchies.md) and [unions](https://github.com/dotnet/csharplang/blob/main/proposals/nominal-type-unions.md). Most commonly, a target type will be the closed class or union type itself, whereas the constructed type will be one of the case types:
+Constructor arguments often say everything needed to construct the type:
 
 ```csharp
-Option<string> option = new Some<string>("Hello");
+var pair = new Pair("answer", 42); // Pair<string, int>
 ```
 
-With this proposal, it could be written simply as
+Sometimes the target says it all:
 
 ```csharp
-Option<string> option = new Some("Hello"); // Infer 'string' from argument and target type
-```
-
-## Detailed specification
-
-The proposal is specified by treating the constructor "as if" it were a generic method, and the constructor call "as if" it were an invocation of that generic method.
-
-In an *object_creation_expression* of the form `new T(E₁ ...Eₓ)` where `T` has no type argument list, if there is an accessible non-generic type `T` and it has one or more accessible and applicable constructors, then overload resolution proceeds as today.
-
-However, if no such type or constructors are found, then for each generic type `T<X₁...Xᵥ>` with the same type name `T`, and for each constructor of that generic type with the parameter list `(T₁ p₁ ... Tₓ pₓ)`, [generic type inference](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1263-type-inference) is attempted, as if the constructor were a generic method `M` with the same type parameter list as `T<X₁...Xᵥ>`, with the same parameter list `(T₁ p₁ ... Tₓ pₓ)` as the constructor, and with T<X₁...Xᵥ> as its return type:
-
-```csharp
-T<X₁...Xᵥ> M<X₁...Xᵥ>(T₁ p₁ ... Tₓ pₓ)
-```
-
-and as if the object creation expression were an invocation with no type arguments, and with the same argument list and target type `I` (if any) as the creation expression:
-
-```csharp
-M(E₁ ...Eₓ) // without target type
-I i = M(E₁ ...Eₓ) // with target type
-```
-
-(Where the names `i` and `M` are otherwise invisible and not in conflict with any other names in scope.)
-
-For instance, for this type and invocation:
-
-```csharp
-public class C<T1, T2> : IEnumerable<T1>
+class Box<T>
 {
-    public C(T2 t2) { ... }
+    public Box() { }
 }
 
-IEnumerable<string> l = new C(5);
+Box<string> box = new Box();
 ```
 
-Type inference would proceed as if with this method and invocation:
+Arguments and target can also contribute different pieces:
 
 ```csharp
-C<T1, T2> M<T1, T2>(T2 t2);
+class C<TElement, TCount> : IEnumerable<TElement>
+{
+    public C(TCount count) { }
+
+    // IEnumerable<TElement> implementation
+}
+
+IEnumerable<string> l = new C(5); // C<string, int>
+```
+
+This is particularly helpful when constructing one type in a hierarchy through another:
+
+```csharp
+abstract class Option<T> { }
+sealed class Some<T>(T value) : Option<T> { }
+
+Option<string> option = new Some("Hello"); // Some<string>
+```
+
+That last example is a useful payoff, but not a special case. The feature applies the familiar inference and overload-resolution model of methods to object creation generally.
+
+## Detailed design
+[design]: #detailed-design
+
+### Type groups in object creation
+
+Object creation consumes the shared `type_group` abstraction from the sibling type-groups proposal. An explicitly bound type produces a singleton group. A type-group name such as `Pair` can produce accessible same-name types of different arities, such as `Pair`, `Pair<T>`, and `Pair<TFirst, TSecond>`. A target-typed `new()` expression likewise starts with its single implied type.
+
+Lookup determines the group before constructor binding. In other words, lookup exposes the available arities, and then one constructor-binding operation selects from them. This is deliberately similar to method-group lookup followed by overload resolution.
+
+### Inference for each constructor
+
+Inference is attempted separately for every accessible constructor of every unbound generic type in the group. For a type `G<X₁, ..., Xᵥ>` with a constructor
+
+```csharp
+G(T₁ p₁, ..., Tₓ pₓ)
+```
+
+the inference inputs are:
+
+- the type parameters `X₁, ..., Xᵥ` of `G`;
+- the constructor parameter types `T₁, ..., Tₓ`;
+- the corresponding object-creation arguments `E₁, ..., Eₓ`;
+- the result type `G<X₁, ..., Xᵥ>`; and
+- the target type of the object creation, if one exists.
+
+This can be understood as if the constructor were represented by a generic method whose return type is the containing type:
+
+```csharp
+G<X₁, ..., Xᵥ> M<X₁, ..., Xᵥ>(T₁ p₁, ..., Tₓ pₓ)
+```
+
+and as if the object creation supplied the same arguments and target:
+
+```csharp
+M(E₁, ..., Eₓ)
+Target t = M(E₁, ..., Eₓ);
+```
+
+For example, the `C` construction above is inferred as if from:
+
+```csharp
+C<TElement, TCount> M<TElement, TCount>(TCount count);
 
 IEnumerable<string> l = M(5);
 ```
 
-If type inference succeeds, and the inferred type arguments satisfy their constraints, and the constructor is applicable when the type arguments are applied to its containing generic type, then the constructor is a candidate.
+The generalized inference proposal defines how argument inputs and target-derived result bounds interact. This proposal only supplies the constructor-specific inputs.
 
-Overload resolution then proceeds as normal between the resulting candidate constructors.
+Inference for a constructor fails if the supplied arguments cannot first be matched to its parameters, or if inference cannot determine all required containing-type arguments. Such a failure only removes that constructor from consideration.
+
+### Substitution, constraints, and applicability
+
+After inference succeeds, the inferred arguments are substituted for the containing type's parameters. The resulting constructed type and all constructed types in the constructor parameter list must satisfy their constraints, and the substituted parameter list must be applicable to the object-creation arguments. Otherwise that constructor is not a candidate.
+
+Constructors of bound types do not need inference. They contribute candidates under the existing accessibility and applicability rules.
+
+### One combined candidate set
+
+**The design uses one candidate set across all bound and unbound types in the type group. It does not first try a non-generic type and fall back to generic types.**
+
+This is the central selection choice in the proposal. Type-group lookup is method-group-like: it intentionally preserves same-name candidates of different arities for a later binding operation. Once lookup has produced that group, constructor binding should choose the best constructor across the whole group rather than let one arity hide the others procedurally.
+
+All constructors that survive inference, substitution, constraint checking, and applicability form one candidate set. Normal overload resolution then selects the best constructor using the substituted parameter types. For the better-function-member rules, a constructor of a generic type is treated as the generic counterpart of a constructor of a non-generic type, with the containing type's parameters and inferred arguments standing in for method type parameters and arguments.
+
+If there is no applicable candidate, or no unique best candidate, object creation is an error.
+
+### Resulting type
+
+The type of the object creation is the type containing the selected constructor, with inferred type arguments substituted. Thus:
+
+```csharp
+var pair = new Pair("answer", 42);
+```
+
+has type `Pair<string, int>`, because overload resolution selects a constructor of that constructed type.
+
+The default constructor of a struct with no declared parameterless constructor participates in the same way. If selected, the result is the default value of the inferred constructed struct type.
+
+### Specialized object-creation forms
+
+- A target-typed `new()` already has an implied bound type and therefore uses a singleton type group.
+- A constructor initializer already targets a known containing or base type; this feature does not infer a different containing type for it.
+- Object and collection initializer contents are processed after constructor selection and do not currently contribute inference bounds.
+- Attribute creation, nullable wrapping, anonymous object creation, and default construction through a type parameter keep their specialized bound-type behavior.
+- Dynamically bound object creation currently requires the type group to contain exactly one bound class or struct type. Inference for a constructor of a generic type remains a compile-time operation.
+
+### Specification impact
+
+The normative draft updates the C# specification's [`expressions.md` type-inference section](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#1263-type-inference) and [`expressions.md` object-creation section](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/expressions.md#128172-object-creation-expressions). The shared lookup and generalized inference algorithms are owned by the sibling proposals; this proposal specifies how object creation consumes them.
+
+## Compatibility
+
+This feature changes both name binding and candidate selection, so it has real compatibility risks:
+
+- Adding an accessible same-name generic type can add constructors to an existing object creation. A different constructor may win, or the expression may become ambiguous.
+- Type-group lookup can discover two same-name types of the same arity where existing arity-specific lookup found one. The type group is then ambiguous and object creation fails before constructor selection.
+- Target-derived bounds can change an argument-only inference result, make a previously failing candidate succeed, or make inference fail when argument and target bounds conflict.
+- Dynamically bound construction requires a singleton bound type group. A same-name generic type can therefore make a previously valid dynamic construction invalid.
+
+The combined candidate set makes the first risk more visible than phased fallback would. That is the cost of giving type groups method-group-like semantics all the way through binding.
+
+## Drawbacks
+[drawbacks]: #drawbacks
+
+Object creation becomes sensitive to other accessible same-name types, including types of different arities. The result can also depend on target typing, so inference may be less local than argument-only method inference. Finally, applying method-like overload resolution across constructors declared in different types requires a small constructor-specific interpretation of the better-function-member rules.
+
+## Alternatives
+[alternatives]: #alternatives
+
+### Phased fallback
+
+The principal compatibility alternative is to bind an existing non-generic or otherwise bound type first, and consider constructors of unbound generic types only if the first phase has no applicable constructor.
+
+That preserves more existing winners and ambiguities. However, it gives special procedural priority to one member of a type group even though lookup deliberately returned all arities together. It also differs from the method-group intuition that later binding selects the best candidate from the complete lookup result. The current design therefore chooses one combined candidate set.
+
+### Argument-only constructor inference
+
+Inference could use constructor arguments but ignore the target type. That would cover `Pair` but not `Box`, and it would leave useful information on the table for examples such as `C<TElement, TCount>`. This proposal instead uses the common inference mechanism, including target-derived bounds.
+
+### Keep factory methods
+
+The language could continue requiring explicit type arguments on object creation and leave inference to factory methods. That avoids compatibility changes, but perpetuates APIs whose factory methods exist only to recover inference already available to methods.
+
+## Open questions
+[open]: #open-questions
+
+### Dynamic support
+
+Should dynamically bound object creation ever support inference for constructors of generic types? The current design says no and requires a singleton bound type group.
+
+### Initializer bounds
+
+Should object or collection initializer contents eventually contribute inference bounds? The current design selects the constructor first and treats initializer processing as a later step.
+
+### Inherited target-type model
+
+What is the final source and ref-kind model for the target type inherited from generalized inference? Constructor inference should consume that common model rather than define a competing one.
+
+### Selection rules for future type-group consumers
+
+Should every future consumer of a type group use one combined selection step, or can a consumer define different arity preference or fallback rules? Object creation chooses combined selection, but the abstraction may eventually be used elsewhere.

--- a/proposals/inference-for-constructor-calls.md
+++ b/proposals/inference-for-constructor-calls.md
@@ -5,7 +5,7 @@ Champion issue: [dotnet/csharplang#9627](https://github.com/dotnet/csharplang/is
 ## Summary
 [summary]: #summary
 
-Constructors of generic types can infer the type arguments of their containing type from the constructor arguments and, when present, the target type:
+This proposal allows a generic type's type argument list to be omitted in an object creation expression and inferred from the constructor arguments:
 
 ```csharp
 class Pair<TFirst, TSecond>
@@ -16,44 +16,12 @@ class Pair<TFirst, TSecond>
 var pair = new Pair("answer", 42); // Pair<string, int>
 ```
 
-This puts constructors on a more equal footing with generic factory methods. There should be no need to write a factory method just to get the type inference that method calls already enjoy.
-
-This proposal is the object-creation part of a series. It builds on the sibling proposal for [generalized type inference and target-derived bounds](https://github.com/dotnet/csharplang/pull/10311), and on the sibling [type-groups proposal](https://github.com/dotnet/csharplang/pull/10310) that looks up accessible types with the same name across arities. The corresponding normative changes are being developed in [csharpstandard#3](https://github.com/MadsTorgersen/csharpstandard/pull/3).
+Inference can also use the target type, as defined by [target-typed generic type inference](https://github.com/dotnet/csharplang/blob/main/proposals/target-typed-generic-type-inference.md).
 
 ## Motivation
 [motivation]: #motivation
 
-Constructor arguments often say everything needed to construct the type:
-
-```csharp
-var pair = new Pair("answer", 42); // Pair<string, int>
-```
-
-Sometimes the target says it all:
-
-```csharp
-class Box<T>
-{
-    public Box() { }
-}
-
-Box<string> box = new Box();
-```
-
-Arguments and target can also contribute different pieces:
-
-```csharp
-class C<TElement, TCount> : IEnumerable<TElement>
-{
-    public C(TCount count) { }
-
-    // IEnumerable<TElement> implementation
-}
-
-IEnumerable<string> l = new C(5); // C<string, int>
-```
-
-This is particularly helpful when constructing one type in a hierarchy through another:
+Generic case types in a hierarchy are often constructed through their generic base type:
 
 ```csharp
 abstract class Option<T> { }
@@ -62,144 +30,57 @@ sealed class Some<T>(T value) : Option<T> { }
 Option<string> option = new Some("Hello"); // Some<string>
 ```
 
-That last example is a useful payoff, but not a special case. The feature applies the familiar inference and overload-resolution model of methods to object creation generally.
+Today `Some<string>` must be written explicitly or hidden behind a factory method even though the constructor argument and target contain the required type information.
 
 ## Detailed design
 [design]: #detailed-design
 
-### Type groups in object creation
+The normative design is in [MadsTorgersen/csharpstandard#3](https://github.com/MadsTorgersen/csharpstandard/pull/3), which updates [`standard/expressions.md`](https://github.com/dotnet/csharpstandard/blob/alpha-v12/standard/expressions.md), primarily [§12.6.3 Type inference](https://github.com/dotnet/csharpstandard/blob/alpha-v12/standard/expressions.md#1263-type-inference) and [§12.8.17.2 Object creation expressions](https://github.com/dotnet/csharpstandard/blob/alpha-v12/standard/expressions.md#128172-object-creation-expressions).
 
-Object creation consumes the shared `type_group` abstraction from the sibling [type-groups proposal](https://github.com/dotnet/csharplang/pull/10310). An explicitly bound type produces a singleton group. A type-group name such as `Pair` can produce accessible same-name types of different arities, such as `Pair`, `Pair<T>`, and `Pair<TFirst, TSecond>`. A target-typed `new()` expression likewise starts with its single implied type.
+### Syntax and lookup
 
-Lookup determines the group before constructor binding. In other words, lookup exposes the available arities, and then one constructor-binding operation selects from them. This is deliberately similar to method-group lookup followed by overload resolution.
+Object creation accepts the `type_group` defined by the [type groups proposal](https://github.com/dotnet/csharplang/pull/10310). Lookup may therefore produce accessible same-name types of different arities. An explicitly bound type, including the implied type of `new()`, produces a singleton group.
 
-### Inference for each constructor
+Lookup is complete before constructors are considered. Constructor binding operates on the resulting group.
 
-Inference is attempted separately for every accessible constructor of every unbound generic type in the group. For a type `G<X₁, ..., Xᵥ>` with a constructor
+### Constructor inference and candidates
 
-```csharp
-G(T₁ p₁, ..., Tₓ pₓ)
-```
+For each accessible constructor of each unbound generic type in the group, inference uses:
 
-the inference inputs are:
+- the containing type's type parameters;
+- the constructor parameter types and corresponding object-creation arguments;
+- the constructed containing type as the result type; and
+- the target type of the object creation expression, if any.
 
-- the type parameters `X₁, ..., Xᵥ` of `G`;
-- the constructor parameter types `T₁, ..., Tₓ`;
-- the corresponding object-creation arguments `E₁, ..., Eₓ`;
-- the result type `G<X₁, ..., Xᵥ>`; and
-- the target type of the object creation, if one exists.
+The shared inference algorithm is defined by the [generalized generic type inference proposal](https://github.com/dotnet/csharplang/pull/10311). Target-derived behavior comes from [target-typed generic type inference](https://github.com/dotnet/csharplang/blob/main/proposals/target-typed-generic-type-inference.md).
 
-This can be understood as if the constructor were represented by a generic method whose return type is the containing type:
+Inference is performed separately for each constructor. Failure to match arguments to parameters or infer all containing-type arguments removes that constructor from consideration.
 
-```csharp
-G<X₁, ..., Xᵥ> M<X₁, ..., Xᵥ>(T₁ p₁, ..., Tₓ pₓ)
-```
+After substitution, the constructed containing type and constructed types in the parameter list must satisfy their constraints, and the substituted parameter list must be applicable to the arguments. Constructors of bound types require no inference and are candidates when accessible and applicable. The default constructor of a struct with no declared parameterless constructor participates on the same basis.
 
-and as if the object creation supplied the same arguments and target:
+### Selection and result
 
-```csharp
-M(E₁, ..., Eₓ)
-Target t = M(E₁, ..., Eₓ);
-```
+Candidates from every type in the group form one set. A bound non-generic type is not tried before unbound generic types.
 
-For example, the `C` construction above is inferred as if from:
+Normal overload resolution selects the best constructor using substituted parameter types. For better-function-member rules, a constructor of a generic or non-generic type is treated like a generic or non-generic method, respectively; the containing type's parameters and inferred arguments stand in for method type parameters and arguments.
 
-```csharp
-C<TElement, TCount> M<TElement, TCount>(TCount count);
+No applicable candidate or no unique best candidate is a binding-time error. The result type is the type containing the selected constructor, with inferred arguments substituted. Selecting the implicit default constructor of a struct produces the default value of that constructed struct type.
 
-IEnumerable<string> l = M(5);
-```
-
-The sibling [generalized inference proposal](https://github.com/dotnet/csharplang/pull/10311) defines how argument inputs and target-derived result bounds interact. This proposal only supplies the constructor-specific inputs.
-
-Inference for a constructor fails if the supplied arguments cannot first be matched to its parameters, or if inference cannot determine all required containing-type arguments. Such a failure only removes that constructor from consideration.
-
-### Substitution, constraints, and applicability
-
-After inference succeeds, the inferred arguments are substituted for the containing type's parameters. The resulting constructed type and all constructed types in the constructor parameter list must satisfy their constraints, and the substituted parameter list must be applicable to the object-creation arguments. Otherwise that constructor is not a candidate.
-
-Constructors of bound types do not need inference. They contribute candidates under the existing accessibility and applicability rules.
-
-### One combined candidate set
-
-This is the central selection choice: object creation uses one candidate set across every bound and unbound type in the group rather than trying a non-generic type first and falling back to generic ones. Type-group lookup is method-group-like: it intentionally preserves same-name candidates of different arities for a later binding operation. Once lookup has produced that group, constructor binding should choose the best constructor across the whole group rather than let one arity hide the others procedurally.
-
-All constructors that survive inference, substitution, constraint checking, and applicability form one candidate set. Normal overload resolution then selects the best constructor using the substituted parameter types. For the better-function-member rules, a constructor of a generic type is treated as the generic counterpart of a constructor of a non-generic type, with the containing type's parameters and inferred arguments standing in for method type parameters and arguments.
-
-If there is no applicable candidate, or no unique best candidate, object creation is an error.
-
-### Resulting type
-
-The type of the object creation is the type containing the selected constructor, with inferred type arguments substituted. Thus:
-
-```csharp
-var pair = new Pair("answer", 42);
-```
-
-has type `Pair<string, int>`, because overload resolution selects a constructor of that constructed type.
-
-The default constructor of a struct with no declared parameterless constructor participates in the same way. If selected, the result is the default value of the inferred constructed struct type.
-
-### Specialized object-creation forms
-
-- A target-typed `new()` already has an implied bound type and therefore uses a singleton type group.
-- A constructor initializer already targets a known containing or base type; this feature does not infer a different containing type for it.
-- Object and collection initializer contents are processed after constructor selection and do not currently contribute inference bounds.
-- Attribute creation, nullable wrapping, anonymous object creation, and default construction through a type parameter keep their specialized bound-type behavior.
-- Dynamically bound object creation currently requires the type group to contain exactly one bound class or struct type. Inference for a constructor of a generic type remains a compile-time operation.
-
-### Specification impact
-
-The normative draft updates the C# specification's [`expressions.md` type-inference section](https://github.com/dotnet/csharpstandard/blob/alpha-v12/standard/expressions.md#1263-type-inference) and [`expressions.md` object-creation section](https://github.com/dotnet/csharpstandard/blob/alpha-v12/standard/expressions.md#128172-object-creation-expressions). The shared lookup and generalized inference algorithms are owned by the sibling proposals; this proposal specifies how object creation consumes them.
+Object and collection initializer contents are processed after constructor selection and do not contribute inference bounds. Dynamically bound object creation continues to require a singleton group containing a bound class or struct type.
 
 ## Compatibility
 
-This feature changes both name binding and candidate selection, so it has real compatibility risks:
+- An accessible same-name generic type can add candidates to an existing object creation, changing the selected constructor or making the expression ambiguous.
+- Type-group lookup can find same-arity types that previous arity-specific lookup did not consider together, making lookup ambiguous before constructor selection.
+- Target-derived bounds can change an argument-only inference result, allow a new candidate, or conflict with argument-derived bounds.
+- Adding a same-name generic type can make dynamic construction invalid because dynamic construction requires a singleton bound type group.
 
-- Adding an accessible same-name generic type can add constructors to an existing object creation. A different constructor may win, or the expression may become ambiguous.
-- Type-group lookup can discover two same-name types of the same arity where existing arity-specific lookup found one. The type group is then ambiguous and object creation fails before constructor selection.
-- Target-derived bounds can change an argument-only inference result, make a previously failing candidate succeed, or make inference fail when argument and target bounds conflict.
-- Dynamically bound construction requires a singleton bound type group. A same-name generic type can therefore make a previously valid dynamic construction invalid.
+## Alternative: phased fallback
 
-The combined candidate set makes the first risk more visible than phased fallback would. That is the cost of giving type groups method-group-like semantics all the way through binding.
-
-## Drawbacks
-[drawbacks]: #drawbacks
-
-Object creation becomes sensitive to other accessible same-name types, including types of different arities. The result can also depend on target typing, so inference may be less local than argument-only method inference. Finally, applying method-like overload resolution across constructors declared in different types requires a small constructor-specific interpretation of the better-function-member rules.
-
-## Alternatives
-[alternatives]: #alternatives
-
-### Phased fallback
-
-The principal compatibility alternative is to bind an existing non-generic or otherwise bound type first, and consider constructors of unbound generic types only if the first phase has no applicable constructor.
-
-That preserves more existing winners and ambiguities. However, it gives special procedural priority to one member of a type group even though lookup deliberately returned all arities together. It also differs from the method-group intuition that later binding selects the best candidate from the complete lookup result. The current design therefore chooses one combined candidate set.
-
-### Argument-only constructor inference
-
-Inference could use constructor arguments but ignore the target type. That would cover `Pair` but not `Box`, and it would leave useful information on the table for examples such as `C<TElement, TCount>`. This proposal instead uses the common inference mechanism, including target-derived bounds.
-
-### Keep factory methods
-
-The language could continue requiring explicit type arguments on object creation and leave inference to factory methods. That avoids compatibility changes, but perpetuates APIs whose factory methods exist only to recover inference already available to methods.
+Constructor binding could try an existing bound type first and consider unbound generic types only if that produces no applicable constructor. This would preserve more existing selections, but it would discard candidates from a lookup result that deliberately groups types across arities. This proposal instead performs one selection over the complete group.
 
 ## Open questions
 [open]: #open-questions
 
-### Dynamic support
-
-Should dynamically bound object creation ever support inference for constructors of generic types? The current design says no and requires a singleton bound type group.
-
-### Initializer bounds
-
-Should object or collection initializer contents eventually contribute inference bounds? The current design selects the constructor first and treats initializer processing as a later step.
-
-### Inherited target-type model
-
-What is the final source and ref-kind model for the target type inherited from generalized inference? Constructor inference should consume that common model rather than define a competing one.
-
-### Selection rules for future type-group consumers
-
-Should every future consumer of a type group use one combined selection step, or can a consumer define different arity preference or fallback rules? Object creation chooses combined selection, but the abstraction may eventually be used elsewhere.
+- Should dynamically bound object creation ever support inference for constructors of generic types? The current design does not.
+- Should object or collection initializer contents ever contribute inference bounds? The current design selects a constructor first.


### PR DESCRIPTION
## Summary

- allow a generic type's type argument list to be omitted in an object creation expression and inferred from constructor arguments
- consume [type-group lookup](https://github.com/dotnet/csharplang/pull/10310) and [generalized generic type inference](https://github.com/dotnet/csharplang/pull/10311), linking the existing [target-typed inference proposal](https://github.com/dotnet/csharplang/blob/main/proposals/target-typed-generic-type-inference.md) for target-derived behavior
- construct one candidate set from bound and inferred types across all arities, then apply overload resolution once
- specify the resulting type, implicit struct default constructors, initializer staging, and the compile-time boundary for dynamic construction

Champion issue: https://github.com/dotnet/csharplang/issues/9627

## Specification

The authoritative draft is [MadsTorgersen/csharpstandard#3](https://github.com/MadsTorgersen/csharpstandard/pull/3). It updates `standard/expressions.md`, primarily §12.6.3 type inference and §12.8.17.2 object creation expressions.

## Compatibility and open design

Same-name types can add candidates or introduce lookup and overload-resolution ambiguities. Target-derived bounds can alter inference, and dynamic construction still requires a singleton bound type group. The proposal retains phased fallback as the principal alternative and leaves dynamic inference and initializer-derived bounds open.